### PR TITLE
feat(config, tests): Implement configuration-driven UI and testing

### DIFF
--- a/experiments/veo-app/components/imagen/advanced_controls.py
+++ b/experiments/veo-app/components/imagen/advanced_controls.py
@@ -15,12 +15,18 @@
 import mesop as me
 
 from state.imagen_state import PageState
+from config.imagen_models import get_imagen_model_config
 
 
 @me.component
 def advanced_controls():
-    """Advanced image generation controls"""
+    """Advanced image generation controls, driven by the selected model's configuration."""
     state = me.state(PageState)
+    selected_config = get_imagen_model_config(state.image_model_name)
+
+    if not selected_config:
+        return
+
     with me.box(style=_BOX_STYLE):
         with me.box(
             style=me.Style(
@@ -63,10 +69,8 @@ def advanced_controls():
                     label="Number of images",
                     value=str(state.imagen_image_count),
                     options=[
-                        me.SelectOption(label="1", value="1"),
-                        me.SelectOption(label="2", value="2"),
-                        me.SelectOption(label="3", value="3"),
-                        me.SelectOption(label="4", value="4"),
+                        me.SelectOption(label=str(i), value=str(i))
+                        for i in range(1, selected_config.max_samples + 1)
                     ],
                     on_selection_change=on_select_image_count,
                     style=me.Style(min_width="155px", flex_grow=1),

--- a/experiments/veo-app/components/veo/file_uploader.py
+++ b/experiments/veo-app/components/veo/file_uploader.py
@@ -17,31 +17,25 @@ import mesop as me
 from state.veo_state import PageState
 from common.storage import store_to_gcs
 from config.default import Default
+from config.veo_models import get_veo_model_config
 
 config = Default()
 
 
 @me.component
 def file_uploader():
-    """File uploader for I2V and interpolation"""
+    """File uploader for I2V and interpolation, driven by model configuration."""
     state = me.state(PageState)
+    selected_config = get_veo_model_config(state.veo_model)
 
-    # Define buttons based on the selected model
-    if state.veo_model.startswith("3.0"):
-        veo_mode_buttons = [
-            me.ButtonToggleButton(label="t2v", value="t2v"),
-            me.ButtonToggleButton(label="i2v", value="i2v"),
-        ]
-        # If interpolation was selected, default to t2v for Veo 3.0
-        # as it's not a supported mode.
-        if state.veo_mode == "interpolation":
-            state.veo_mode = "t2v"
-    else:
-        veo_mode_buttons = [
-            me.ButtonToggleButton(label="t2v", value="t2v"),
-            me.ButtonToggleButton(label="i2v", value="i2v"),
-            me.ButtonToggleButton(label="interpolation", value="interpolation"),
-        ]
+    if not selected_config:
+        return
+
+    # Dynamically create the buttons based on the supported modes for the selected model.
+    veo_mode_buttons = [
+        me.ButtonToggleButton(label=mode, value=mode)
+        for mode in selected_config.supported_modes
+    ]
 
     me.button_toggle(
         value=state.veo_mode,

--- a/experiments/veo-app/components/veo/generation_controls.py
+++ b/experiments/veo-app/components/veo/generation_controls.py
@@ -15,54 +15,61 @@
 import mesop as me
 
 from state.veo_state import PageState
+from config.veo_models import VEO_MODELS, get_veo_model_config
 
 
 @me.component
 def generation_controls():
-    """Video generation controls"""
+    """Video generation controls, driven by the selected model's configuration."""
     state = me.state(PageState)
+    selected_config = get_veo_model_config(state.veo_model)
+
+    if not selected_config:
+        me.text("Error: No model configuration found.")
+        return
+
     with me.box(style=me.Style(display="flex", flex_basis="row", gap=5)):
+        # Aspect Ratio Selector
         me.select(
             label="aspect",
             appearance="outline",
             options=[
-                me.SelectOption(label="16:9 widescreen", value="16:9"),
-                me.SelectOption(label="9:16 portrait", value="9:16"),
+                me.SelectOption(label=f"{ratio} {'widescreen' if ratio == '16:9' else 'portrait'}", value=ratio)
+                for ratio in selected_config.supported_aspect_ratios
             ],
             value=state.aspect_ratio,
             on_selection_change=on_selection_change_aspect,
-            disabled=True if state.veo_model.startswith("3.0") else False,
+            disabled=len(selected_config.supported_aspect_ratios) <= 1,
         )
+
+        # Video Length Selector
         me.select(
             label="length",
             options=[
-                me.SelectOption(label="5 seconds", value="5"),
-                me.SelectOption(label="6 seconds", value="6"),
-                me.SelectOption(label="7 seconds", value="7"),
-                me.SelectOption(label="8 seconds", value="8"),
+                me.SelectOption(label=f"{i} seconds", value=str(i))
+                for i in range(selected_config.min_duration, selected_config.max_duration + 1)
             ],
             appearance="outline",
             style=me.Style(),
-            value=f"{state.video_length}",
+            value=str(state.video_length),
             on_selection_change=on_selection_change_length,
-            disabled=True
-            if state.veo_model.startswith("3.0")
-            else False,  # 3.0 only does 8 seconds
+            disabled=selected_config.min_duration == selected_config.max_duration,
         )
+
+        # Prompt Enhancement Checkbox
         me.checkbox(
             label="auto-enhance prompt",
             checked=state.auto_enhance_prompt,
             on_change=on_change_auto_enhance_prompt,
-            disabled=True
-            if state.veo_model.startswith("3.0")
-            else False,  # 3.0 no enhance prompt
+            disabled=not selected_config.supports_prompt_enhancement,
         )
+
+        # Model Selector
         me.select(
             label="model",
             options=[
-                me.SelectOption(label="Veo 2.0", value="2.0"),
-                me.SelectOption(label="Veo 3.0", value="3.0"),
-                me.SelectOption(label="Veo 3.0 Fast", value="3.0-fast"),
+                me.SelectOption(label=model.display_name, value=model.version_id)
+                for model in VEO_MODELS
             ],
             appearance="outline",
             style=me.Style(),
@@ -84,19 +91,20 @@ def on_selection_change_aspect(e: me.SelectSelectionChangeEvent):
 
 
 def on_selection_change_model(e: me.SelectSelectionChangeEvent):
-    """Adjust model based on user event."""
+    """Adjust model based on user event and apply its constraints."""
     state = me.state(PageState)
     state.veo_model = e.value
-    # reset to veo 3 settings
-    if state.veo_model.startswith("3.0"):
-        # aspect = 16x9 only
-        # length = 8 seconds
-        # no auto enhance
-        state.aspect_ratio = "16:9"
-        state.video_length = 8
-        state.auto_enhance_prompt = False
-        if state.veo_mode == "interpolation":
-            state.veo_mode = "t2v"
+    
+    new_config = get_veo_model_config(e.value)
+    if new_config:
+        # Apply the default settings and constraints from the new model's config
+        state.aspect_ratio = new_config.supported_aspect_ratios[0]
+        state.video_length = new_config.default_duration
+        state.auto_enhance_prompt = new_config.supports_prompt_enhancement
+        
+        # If the current mode is no longer supported, default to the first supported mode.
+        if state.veo_mode not in new_config.supported_modes:
+            state.veo_mode = new_config.supported_modes[0]
 
 
 def on_change_auto_enhance_prompt(e: me.CheckboxChangeEvent):

--- a/experiments/veo-app/config/default.py
+++ b/experiments/veo-app/config/default.py
@@ -95,49 +95,7 @@ class Default:
         ]
     )
     
-    display_image_models: list[ImageModel] = field(
-        default_factory=lambda: Default._get_display_image_models()
-    )
-
-    @staticmethod
-    def _get_display_image_models() -> list[ImageModel]:
-        imagen_models_override_str = os.environ.get("IMAGEN_MODELS")
-        if imagen_models_override_str:
-            try:
-                parsed_models = json.loads(imagen_models_override_str)
-                if isinstance(parsed_models, list) and all(
-                    isinstance(item, dict) and "display" in item and "model_name" in item
-                    for item in parsed_models
-                ):
-                    print(f"Using IMAGEN_MODELS override from environment: {parsed_models}")
-                    return parsed_models # type: ignore
-                else:
-                    print(
-                        "Warning: IMAGEN_MODELS environment variable has invalid format. "
-                        "Expected a JSON list of {'display': str, 'model_name': str}. "
-                        "Falling back to default models."
-                    )
-            except json.JSONDecodeError:
-                print(
-                    "Warning: IMAGEN_MODELS environment variable is not valid JSON. "
-                    "Falling back to default models."
-                )
-            except Exception as e:
-                print(
-                    f"Warning: Error processing IMAGEN_MODELS environment variable: {e}. "
-                    "Falling back to default models."
-                )
-        
-        # Default models if override is not present or invalid
-        return [
-            {"display": "Imagen 3 Fast", "model_name": Default.MODEL_IMAGEN_FAST},
-            {"display": "Imagen 3", "model_name": Default.MODEL_IMAGEN},
-            {"display": "Imagen 4 Fast (preview)", "model_name": Default.MODEL_IMAGEN4_FAST},
-            {"display": "Imagen 4 (preview)", "model_name": Default.MODEL_IMAGEN4},
-            {"display": "Imagen 4 Ultra (preview)", "model_name": Default.MODEL_IMAGEN4_ULTRA},
-            # Example: to include Nano by default if not overridden:
-            # {"display": "Imagen Nano", "model_name": Default.MODEL_IMAGEN_NANO},
-        ]
+    
 
 
 def load_welcome_page_config():

--- a/experiments/veo-app/config/imagen_models.py
+++ b/experiments/veo-app/config/imagen_models.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+@dataclass
+class ImagenModelConfig:
+    """Configuration for a specific Imagen model version."""
+    model_name: str
+    display_name: str
+    supported_aspect_ratios: List[str]
+    max_samples: int
+    default_samples: int
+
+# This list is the single source of truth for all Imagen model configurations.
+IMAGEN_MODELS: List[ImagenModelConfig] = [
+    ImagenModelConfig(
+        model_name="imagen-3.0-fast-generate-001",
+        display_name="Imagen 3 Fast",
+        supported_aspect_ratios=["1:1", "3:4", "4:3", "9:16", "16:9"],
+        max_samples=4,
+        default_samples=1,
+    ),
+    ImagenModelConfig(
+        model_name="imagen-3.0-generate-002",
+        display_name="Imagen 3",
+        supported_aspect_ratios=["1:1", "3:4", "4:3", "9:16", "16:9"],
+        max_samples=4,
+        default_samples=1,
+    ),
+    ImagenModelConfig(
+        model_name="imagen-4.0-generate-preview-06-06",
+        display_name="Imagen 4 (preview)",
+        supported_aspect_ratios=["1:1", "3:4", "4:3", "9:16", "16:9"],
+        max_samples=4,
+        default_samples=1,
+    ),
+    ImagenModelConfig(
+        model_name="imagen-4.0-fast-generate-preview-06-06",
+        display_name="Imagen 4 Fast (preview)",
+        supported_aspect_ratios=["1:1", "3:4", "4:3", "9:16", "16:9"],
+        max_samples=4,
+        default_samples=1,
+    ),
+    ImagenModelConfig(
+        model_name="imagen-4.0-ultra-generate-preview-06-06",
+        display_name="Imagen 4 Ultra (preview)",
+        supported_aspect_ratios=["1:1", "3:4", "4:3", "9:16", "16:9"],
+        max_samples=1,
+        default_samples=1,
+    ),
+]
+
+# Helper function to easily find a model's config by its model_name.
+def get_imagen_model_config(model_name: str) -> Optional[ImagenModelConfig]:
+    """Finds and returns the configuration for a given Imagen model name."""
+    for model in IMAGEN_MODELS:
+        if model.model_name == model_name:
+            return model
+    return None

--- a/experiments/veo-app/config/veo_models.py
+++ b/experiments/veo-app/config/veo_models.py
@@ -1,0 +1,82 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class VeoModelConfig:
+    """Configuration for a specific VEO model version."""
+    version_id: str
+    model_name: str
+    display_name: str
+    supported_modes: List[str]
+    supported_aspect_ratios: List[str]
+    min_duration: int
+    max_duration: int
+    default_duration: int
+    max_samples: int
+    default_samples: int
+    supports_prompt_enhancement: bool
+
+# This list is the single source of truth for all VEO model configurations.
+VEO_MODELS: List[VeoModelConfig] = [
+    VeoModelConfig(
+        version_id="2.0",
+        model_name="veo-2.0-generate-001",
+        display_name="Veo 2.0",
+        supported_modes=["t2v", "i2v", "interpolation"],
+        supported_aspect_ratios=["16:9", "9:16"],
+        min_duration=5,
+        max_duration=8,
+        default_duration=5,
+        max_samples=4,
+        default_samples=1,
+        supports_prompt_enhancement=True,
+    ),
+    VeoModelConfig(
+        version_id="3.0",
+        model_name="veo-3.0-generate-preview",
+        display_name="Veo 3.0",
+        supported_modes=["t2v", "i2v"],
+        supported_aspect_ratios=["16:9"],
+        min_duration=8,
+        max_duration=8,
+        default_duration=8,
+        max_samples=2,
+        default_samples=1,
+        supports_prompt_enhancement=False,
+    ),
+    VeoModelConfig(
+        version_id="3.0-fast",
+        model_name="veo-3.0-fast-generate-preview",
+        display_name="Veo 3.0 Fast",
+        supported_modes=["t2v", "i2v"],
+        supported_aspect_ratios=["16:9"],
+        min_duration=8,
+        max_duration=8,
+        default_duration=8,
+        max_samples=2,
+        default_samples=1,
+        supports_prompt_enhancement=False,
+    ),
+]
+
+# Helper function to easily find a model's config by its version_id.
+def get_veo_model_config(version_id: str) -> Optional[VeoModelConfig]:
+    """Finds and returns the configuration for a given VEO model version_id."""
+    for model in VEO_MODELS:
+        if model.version_id == version_id:
+            return model
+    return None

--- a/experiments/veo-app/developers_guide.md
+++ b/experiments/veo-app/developers_guide.md
@@ -56,6 +56,52 @@ service cloud.firestore {
 }
 ```
 
+## Configuration-Driven Architecture
+
+A key architectural principle in this project is the use of centralized, type-safe configuration to drive the behavior of the UI and backend logic. This approach makes the application more robust, easier to maintain, and less prone to bugs.
+
+A prime example of this is the handling of the VEO and Imagen models. Instead of hardcoding model names, capabilities, and constraints throughout the application, we define them in a single location:
+
+-   **`config/veo_models.py`**
+-   **`config/imagen_models.py`**
+
+These files contain `dataclass` definitions that serve as a **single source of truth** for each model's properties, such as:
+
+-   Supported aspect ratios
+-   Valid video durations (min, max, and default)
+-   Maximum number of samples
+-   Supported generation modes (e.g., `t2v`, `i2v`, `interpolation`)
+
+The UI components then read from these configuration objects to dynamically build the user interface. For example, the model selection dropdowns, sliders, and feature toggles are all populated and configured based on the capabilities of the currently selected model. This means that to add a new model or update an existing one, you only need to modify the relevant configuration file, and the entire application will adapt automatically.
+
+This pattern is the preferred way to manage model capabilities and other complex configurations in this project.
+
+## Testing Strategy
+
+This project uses a combination of unit tests and integration tests to ensure code quality and reliability. The tests are located in the `test/` directory and are built using the `pytest` framework.
+
+### Unit Tests
+
+Unit tests are used to verify the internal logic of individual functions and components in isolation. They are fast, reliable, and do not depend on external services. We use mocking to simulate the behavior of external APIs, allowing us to test our code's logic without making real network calls.
+
+### Integration Tests
+
+Integration tests are used to verify the interaction between our application and live Google Cloud services. These tests make real API calls and are essential for confirming that our code can successfully communicate with the VEO and Imagen APIs.
+
+-   **Marker:** Integration tests are marked with the `@pytest.mark.integration` decorator.
+-   **Execution:** These tests are skipped by default. To run them, use the `-m` flag:
+    ```bash
+    pytest -m integration -v -s
+    ```
+
+### Component-Level Tests
+
+For testing the data flow within our components (e.g., from a successful API call to the Firestore logging), we use component-level integration tests. These tests mock the external API calls but let the internal data handling and state management logic run as it normally would. This is a powerful way to catch bugs in our data mapping and event handling logic.
+
+### Test Configuration
+
+Tests that require access to Google Cloud Storage can be configured to use a custom GCS bucket via the `--gcs-bucket` command-line option. See the `test/README.md` file for more details.
+
 ## How to Add a New Page
 
 Adding a new page to the application is a straightforward process. Here are the steps:

--- a/experiments/veo-app/requirements.txt
+++ b/experiments/veo-app/requirements.txt
@@ -52,7 +52,7 @@ docstring-parser==0.16
     # via google-cloud-aiplatform
 executing==2.2.0
     # via stack-data
-fastapi==0.116.0
+fastapi==0.116.1
     # via veo-app
 firebase-admin==6.9.0
     # via veo-app
@@ -107,7 +107,7 @@ google-crc32c==1.7.1
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-genai==1.25.0
+google-genai==1.20.0
     # via
     #   google-cloud-aiplatform
     #   veo-app
@@ -306,7 +306,7 @@ sniffio==1.3.1
     # via anyio
 stack-data==0.6.3
     # via ipython
-starlette==0.46.2
+starlette==0.47.1
     # via fastapi
 tenacity==9.1.2
     # via veo-app

--- a/experiments/veo-app/state/imagen_state.py
+++ b/experiments/veo-app/state/imagen_state.py
@@ -2,17 +2,7 @@ from dataclasses import dataclass, field
 
 import mesop as me
 
-from config.default import (
-    Default,
-    ImageModel,
-)
-
-app_config_instance = Default()
-
-def _get_default_image_models() -> list[ImageModel]:
-    """Helper function for PageState default_factory."""
-    # Ensure app_config_instance.display_image_models provides a list of ImageModel compatible dicts or objects
-    return app_config_instance.display_image_models.copy()
+from config.imagen_models import IMAGEN_MODELS
 
 
 @dataclass
@@ -21,10 +11,9 @@ class PageState:
     """Local Page State"""
 
     # Image generation model selection and output
-    image_models: list[ImageModel] = field(default_factory=_get_default_image_models)
     image_output: list[str] = field(default_factory=list)
     image_commentary: str = ""
-    image_model_name: str = app_config_instance.MODEL_IMAGEN4_FAST
+    image_model_name: str = "imagen-4.0-generate-preview-06-06"
 
     # General UI state
     is_loading: bool = False

--- a/experiments/veo-app/test/test_imagen_api_integration.py
+++ b/experiments/veo-app/test/test_imagen_api_integration.py
@@ -1,0 +1,47 @@
+
+
+import pytest
+from models.image_models import generate_images
+from config.imagen_models import IMAGEN_MODELS
+
+# Parametrize the test to run for each model defined in the configuration.
+@pytest.mark.integration
+@pytest.mark.parametrize("model_config", IMAGEN_MODELS)
+def test_imagen_api_call(gcs_bucket_for_tests, model_config):
+    """An integration test that calls the real Imagen API for text-to-image.
+    
+    This test is marked as 'integration' and will be skipped unless explicitly
+    run with 'pytest -m integration'. It verifies that the application can
+    successfully communicate with the live Imagen API and receive a valid response
+    for every supported model.
+    """
+    # --- Arrange ---
+    # Use a simple, reliable prompt that is unlikely to trigger content filters.
+    prompt = "a happy dog running on a sunny beach"
+    output_gcs = f"{gcs_bucket_for_tests}/integration_tests"
+
+    # --- Act ---
+    # Call the actual generate_images function, which will make a real API call.
+    response = generate_images(
+        model=model_config.model_name,
+        prompt=prompt,
+        number_of_images=model_config.default_samples,
+        aspect_ratio=model_config.supported_aspect_ratios[0], # Use the first supported aspect ratio
+        negative_prompt="",
+    )
+
+    # --- Assert ---
+    # Verify that the operation completed successfully and returned a valid response.
+    assert response is not None, "The API response should not be None."
+    assert hasattr(response, 'generated_images'), "The response should have a 'generated_images' attribute."
+    
+    generated_images = response.generated_images
+    assert len(generated_images) > 0, "The 'generated_images' list should not be empty."
+    
+    image = generated_images[0].image
+    assert image is not None, "The generated image should not be None."
+    assert hasattr(image, 'gcs_uri'), "The image should have a 'gcs_uri' attribute."
+    assert image.gcs_uri.startswith("gs://"), f"The returned URI should be a GCS URI. Got {image.gcs_uri}"
+
+    print(f"\nIntegration test for model {model_config.model_name} PASSED. Image generated successfully at: {image.gcs_uri}")
+

--- a/experiments/veo-app/test/test_imagen_generation_flow.py
+++ b/experiments/veo-app/test/test_imagen_generation_flow.py
@@ -1,0 +1,66 @@
+
+
+import pytest
+from unittest.mock import patch, MagicMock
+import datetime
+
+# Setup sys.path to allow imports from the parent directory.
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from components.imagen.generation_controls import on_click_generate_images
+from state.imagen_state import PageState
+from state.state import AppState
+from common.metadata import MediaItem
+
+@patch('components.imagen.generation_controls.add_media_item_to_firestore')
+@patch('components.imagen.generation_controls.generate_compliment', return_value="A stunning image!")
+@patch('components.imagen.generation_controls.generate_images_from_prompt', return_value=["gs://fake-bucket/fake_image.png"])
+@patch('mesop.state')
+def test_imagen_generation_flow_and_metadata(mock_state, mock_generate_images, mock_generate_compliment, mock_add_media_item):
+    """    
+    Tests the Imagen generation flow, focusing on the data handling and metadata
+    creation after a successful API call.
+    """
+    # --- Arrange ---
+    # Setup the mocked state that the on_click_generate_images function will use.
+    mock_app_state = AppState(user_email="test_user@example.com")
+    mock_page_state = PageState(
+        image_prompt_input="a test prompt for imagen",
+        image_model_name="imagen-4.0-generate-preview-06-06",
+        imagen_image_count=1,
+        image_negative_prompt_input="",
+        image_aspect_ratio="1:1",
+        imagen_seed=123
+    )
+
+    # Configure the mesop.state mock to return the correct state object when called.
+    mock_state.side_effect = [mock_app_state, mock_page_state]
+
+    # --- Act ---
+    # Call the event handler function. This is a generator function, so we need to exhaust it.
+    for _ in on_click_generate_images(MagicMock()):
+        pass
+
+    # --- Assert ---
+    # 1. Verify that our main image generation function was called.
+    mock_generate_images.assert_called_once()
+
+    # 2. Verify that the Firestore logging function was called.
+    mock_add_media_item.assert_called_once()
+
+    # 3. Inspect the data that was passed to the Firestore function.
+    # This is the crucial part that catches the `NameError` or `AttributeError`.
+    call_args, _ = mock_add_media_item.call_args
+    media_item_logged = call_args[0]
+
+    assert isinstance(media_item_logged, MediaItem)
+    assert media_item_logged.user_email == "test_user@example.com"
+    assert media_item_logged.prompt == "a test prompt for imagen"
+    assert media_item_logged.gcs_uris == ["gs://fake-bucket/fake_image.png"]
+    assert media_item_logged.model == "imagen-4.0-generate-preview-06-06"
+    assert media_item_logged.critique == "A stunning image!"
+
+    print("\nComponent-level integration test for Imagen passed successfully.")
+

--- a/experiments/veo-app/test/test_veo_api_integration.py
+++ b/experiments/veo-app/test/test_veo_api_integration.py
@@ -2,49 +2,61 @@
 
 import pytest
 from models.veo import text_to_video
+from config.veo_models import VEO_MODELS
 
+# Parametrize the test to run for each model defined in the configuration.
 @pytest.mark.integration
-def test_veo_t2v_api_call(gcs_bucket_for_tests):
+@pytest.mark.parametrize("model_config", VEO_MODELS)
+def test_veo_t2v_api_call(gcs_bucket_for_tests, model_config):
     """An integration test that calls the real VEO API for text-to-video.
     
     This test is marked as 'integration' and will be skipped unless explicitly
     run with 'pytest -m integration'. It verifies that the application can
-    successfully communicate with the live VEO API and receive a valid response.
+    successfully communicate with the live VEO API and receive a valid response
+    for every supported model.
     """
     # --- Arrange ---
     # Use a simple, reliable prompt that is unlikely to trigger content filters.
     prompt = "a happy dog running on a sunny beach"
-    model = "2.0"  # Use the stable Veo 2.0 model for this test
     output_gcs = f"{gcs_bucket_for_tests}/integration_tests"
 
     # --- Act ---
     # Call the actual text_to_video function, which will make a real API call.
-    # This will take some time.
+    # The duration and other parameters are now pulled from the model's config.
     operation_result = text_to_video(
-        model=model,
+        model=model_config.version_id,
         prompt=prompt,
         seed=42,
-        aspect_ratio="16:9",
-        sample_count=1,
+        aspect_ratio=model_config.supported_aspect_ratios[0], # Use the first supported aspect ratio
+        sample_count=model_config.default_samples,
         output_gcs=output_gcs,
-        enable_pr=False,
-        duration_seconds=5,
+        enable_pr=model_config.supports_prompt_enhancement,
+        duration_seconds=model_config.default_duration,
     )
 
     # --- Assert ---
+    # Print the full response object for debugging purposes.
+    print(f"\n--- Full API Response for model {model_version} ---")
+    print(operation_result)
+    print("----------------------------------------------------")
+
     # Verify that the operation completed successfully and returned a valid response.
     assert operation_result is not None, "The API operation result should not be None."
-    assert operation_result.get("done"), "The 'done' flag in the operation should be True."
-    
+    assert operation_result.get("done"), f"The 'done' flag in the operation should be True. Full response: {operation_result}"
+
+    # Explicitly check for a top-level error in the operation result.
+    if 'error' in operation_result:
+        pytest.fail(f"API returned a top-level error: {operation_result['error']}")
+
     response_data = operation_result.get("response", {})
-    assert "videos" in response_data, "The response should contain a 'videos' key."
-    
+    assert "videos" in response_data, f"The response should contain a 'videos' key. Full response: {operation_result}"
+
     videos = response_data["videos"]
     assert len(videos) > 0, "The 'videos' list should not be empty."
-    
+
     video_uri = videos[0].get("gcsUri")
     assert video_uri is not None, "The video should have a 'gcsUri'."
     assert video_uri.startswith(output_gcs), f"The video URI should be in the specified output bucket. Got {video_uri}"
 
-    print(f"\nIntegration test PASSED. Video generated successfully at: {video_uri}")
+    print(f"\nIntegration test for model {model_version} PASSED. Video generated successfully at: {video_uri}")
 

--- a/experiments/veo-app/test/test_veo_generation_flow.py
+++ b/experiments/veo-app/test/test_veo_generation_flow.py
@@ -1,0 +1,65 @@
+
+
+import pytest
+from unittest.mock import patch, MagicMock
+import datetime
+
+# Setup sys.path to allow imports from the parent directory.
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pages.veo import on_click_veo
+from state.veo_state import PageState
+from state.state import AppState
+from common.metadata import MediaItem
+
+@patch('pages.veo.add_media_item_to_firestore')
+@patch('pages.veo.generate_video', return_value="gs://fake-bucket/fake_video.mp4")
+@patch('mesop.state')
+def test_veo_generation_flow_and_metadata(mock_state, mock_generate_video, mock_add_media_item):
+    """
+    Tests the VEO generation flow, focusing on the data handling and metadata
+    creation after a successful API call.
+    """
+    # --- Arrange ---
+    # Setup the mocked state that the on_click_veo function will use.
+    mock_app_state = AppState(user_email="test_user@example.com")
+    mock_page_state = PageState(
+        veo_prompt_input="a test prompt for veo",
+        veo_model="2.0",
+        aspect_ratio="16:9",
+        video_length=5,
+        reference_image_gcs=None,
+        last_reference_image_gcs=None,
+        auto_enhance_prompt=False
+    )
+
+    # Configure the mesop.state mock to return the correct state object when called.
+    mock_state.side_effect = [mock_app_state, mock_page_state]
+
+    # --- Act ---
+    # Call the event handler function. This is a generator function, so we need to exhaust it.
+    for _ in on_click_veo(MagicMock()):
+        pass
+
+    # --- Assert ---
+    # 1. Verify that our main video generation function was called.
+    mock_generate_video.assert_called_once()
+
+    # 2. Verify that the Firestore logging function was called.
+    mock_add_media_item.assert_called_once()
+
+    # 3. Inspect the data that was passed to the Firestore function.
+    # This is the crucial part that catches the `NameError` or `AttributeError`.
+    call_args, _ = mock_add_media_item.call_args
+    media_item_logged = call_args[0]
+
+    assert isinstance(media_item_logged, MediaItem)
+    assert media_item_logged.user_email == "test_user@example.com"
+    assert media_item_logged.prompt == "a test prompt for veo"
+    assert media_item_logged.gcsuri == "gs://fake-bucket/fake_video.mp4"
+    assert media_item_logged.model == "veo-2.0-generate-001" # This comes from config
+
+    print("\nComponent-level integration test for VEO passed successfully.")
+

--- a/experiments/veo-app/uv.lock
+++ b/experiments/veo-app/uv.lock
@@ -283,16 +283,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.116.0"
+version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/38/e1da78736143fd885c36213a3ccc493c384ae8fea6a0f0bc272ef42ebea8/fastapi-0.116.0.tar.gz", hash = "sha256:80dc0794627af0390353a6d1171618276616310d37d24faba6648398e57d687a", size = 296518, upload-time = "2025-07-07T15:09:27.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/d7/6c8b3bfe33eeffa208183ec037fee0cce9f7f024089ab1c5d12ef04bd27c/fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143", size = 296485, upload-time = "2025-07-11T16:22:32.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/68/d80347fe2360445b5f58cf290e588a4729746e7501080947e6cdae114b1f/fastapi-0.116.0-py3-none-any.whl", hash = "sha256:fdcc9ed272eaef038952923bef2b735c02372402d1203ee1210af4eea7a78d2b", size = 95625, upload-time = "2025-07-07T15:09:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565", size = 95631, upload-time = "2025-07-11T16:22:30.485Z" },
 ]
 
 [[package]]
@@ -1387,27 +1387,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.12.2"
+version = "0.12.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/3d/d9a195676f25d00dbfcf3cf95fdd4c685c497fcfa7e862a44ac5e4e96480/ruff-0.12.2.tar.gz", hash = "sha256:d7b4f55cd6f325cb7621244f19c873c565a08aff5a4ba9c69aa7355f3f7afd3e", size = 4432239, upload-time = "2025-07-03T16:40:19.566Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/2a/43955b530c49684d3c38fcda18c43caf91e99204c2a065552528e0552d4f/ruff-0.12.3.tar.gz", hash = "sha256:f1b5a4b6668fd7b7ea3697d8d98857390b40c1320a63a178eee6be0899ea2d77", size = 4459341, upload-time = "2025-07-11T13:21:16.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/b6/2098d0126d2d3318fd5bec3ad40d06c25d377d95749f7a0c5af17129b3b1/ruff-0.12.2-py3-none-linux_armv6l.whl", hash = "sha256:093ea2b221df1d2b8e7ad92fc6ffdca40a2cb10d8564477a987b44fd4008a7be", size = 10369761, upload-time = "2025-07-03T16:39:38.847Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/4b/5da0142033dbe155dc598cfb99262d8ee2449d76920ea92c4eeb9547c208/ruff-0.12.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:09e4cf27cc10f96b1708100fa851e0daf21767e9709e1649175355280e0d950e", size = 11155659, upload-time = "2025-07-03T16:39:42.294Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/21/967b82550a503d7c5c5c127d11c935344b35e8c521f52915fc858fb3e473/ruff-0.12.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ae64755b22f4ff85e9c52d1f82644abd0b6b6b6deedceb74bd71f35c24044cc", size = 10537769, upload-time = "2025-07-03T16:39:44.75Z" },
-    { url = "https://files.pythonhosted.org/packages/33/91/00cff7102e2ec71a4890fb7ba1803f2cdb122d82787c7d7cf8041fe8cbc1/ruff-0.12.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3eb3a6b2db4d6e2c77e682f0b988d4d61aff06860158fdb413118ca133d57922", size = 10717602, upload-time = "2025-07-03T16:39:47.652Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/eb/928814daec4e1ba9115858adcda44a637fb9010618721937491e4e2283b8/ruff-0.12.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:73448de992d05517170fc37169cbca857dfeaeaa8c2b9be494d7bcb0d36c8f4b", size = 10198772, upload-time = "2025-07-03T16:39:49.641Z" },
-    { url = "https://files.pythonhosted.org/packages/50/fa/f15089bc20c40f4f72334f9145dde55ab2b680e51afb3b55422effbf2fb6/ruff-0.12.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b8b94317cbc2ae4a2771af641739f933934b03555e51515e6e021c64441532d", size = 11845173, upload-time = "2025-07-03T16:39:52.069Z" },
-    { url = "https://files.pythonhosted.org/packages/43/9f/1f6f98f39f2b9302acc161a4a2187b1e3a97634fe918a8e731e591841cf4/ruff-0.12.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:45fc42c3bf1d30d2008023a0a9a0cfb06bf9835b147f11fe0679f21ae86d34b1", size = 12553002, upload-time = "2025-07-03T16:39:54.551Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/70/08991ac46e38ddd231c8f4fd05ef189b1b94be8883e8c0c146a025c20a19/ruff-0.12.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce48f675c394c37e958bf229fb5c1e843e20945a6d962cf3ea20b7a107dcd9f4", size = 12171330, upload-time = "2025-07-03T16:39:57.55Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a9/5a55266fec474acfd0a1c73285f19dd22461d95a538f29bba02edd07a5d9/ruff-0.12.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:793d8859445ea47591272021a81391350205a4af65a9392401f418a95dfb75c9", size = 11774717, upload-time = "2025-07-03T16:39:59.78Z" },
-    { url = "https://files.pythonhosted.org/packages/87/e5/0c270e458fc73c46c0d0f7cf970bb14786e5fdb88c87b5e423a4bd65232b/ruff-0.12.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6932323db80484dda89153da3d8e58164d01d6da86857c79f1961934354992da", size = 11646659, upload-time = "2025-07-03T16:40:01.934Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/b6/45ab96070c9752af37f0be364d849ed70e9ccede07675b0ec4e3ef76b63b/ruff-0.12.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6aa7e623a3a11538108f61e859ebf016c4f14a7e6e4eba1980190cacb57714ce", size = 10604012, upload-time = "2025-07-03T16:40:04.363Z" },
-    { url = "https://files.pythonhosted.org/packages/86/91/26a6e6a424eb147cc7627eebae095cfa0b4b337a7c1c413c447c9ebb72fd/ruff-0.12.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2a4a20aeed74671b2def096bdf2eac610c7d8ffcbf4fb0e627c06947a1d7078d", size = 10176799, upload-time = "2025-07-03T16:40:06.514Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/0c/9f344583465a61c8918a7cda604226e77b2c548daf8ef7c2bfccf2b37200/ruff-0.12.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:71a4c550195612f486c9d1f2b045a600aeba851b298c667807ae933478fcef04", size = 11241507, upload-time = "2025-07-03T16:40:08.708Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/b7/99c34ded8fb5f86c0280278fa89a0066c3760edc326e935ce0b1550d315d/ruff-0.12.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:4987b8f4ceadf597c927beee65a5eaf994c6e2b631df963f86d8ad1bdea99342", size = 11717609, upload-time = "2025-07-03T16:40:10.836Z" },
-    { url = "https://files.pythonhosted.org/packages/51/de/8589fa724590faa057e5a6d171e7f2f6cffe3287406ef40e49c682c07d89/ruff-0.12.2-py3-none-win32.whl", hash = "sha256:369ffb69b70cd55b6c3fc453b9492d98aed98062db9fec828cdfd069555f5f1a", size = 10523823, upload-time = "2025-07-03T16:40:13.203Z" },
-    { url = "https://files.pythonhosted.org/packages/94/47/8abf129102ae4c90cba0c2199a1a9b0fa896f6f806238d6f8c14448cc748/ruff-0.12.2-py3-none-win_amd64.whl", hash = "sha256:dca8a3b6d6dc9810ed8f328d406516bf4d660c00caeaef36eb831cf4871b0639", size = 11629831, upload-time = "2025-07-03T16:40:15.478Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/1f/72d2946e3cc7456bb837e88000eb3437e55f80db339c840c04015a11115d/ruff-0.12.2-py3-none-win_arm64.whl", hash = "sha256:48d6c6bfb4761df68bc05ae630e24f506755e702d4fb08f08460be778c7ccb12", size = 10735334, upload-time = "2025-07-03T16:40:17.677Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fd/b44c5115539de0d598d75232a1cc7201430b6891808df111b8b0506aae43/ruff-0.12.3-py3-none-linux_armv6l.whl", hash = "sha256:47552138f7206454eaf0c4fe827e546e9ddac62c2a3d2585ca54d29a890137a2", size = 10430499, upload-time = "2025-07-11T13:20:26.321Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c5/9eba4f337970d7f639a37077be067e4ec80a2ad359e4cc6c5b56805cbc66/ruff-0.12.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0a9153b000c6fe169bb307f5bd1b691221c4286c133407b8827c406a55282041", size = 11213413, upload-time = "2025-07-11T13:20:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/2c/fac3016236cf1fe0bdc8e5de4f24c76ce53c6dd9b5f350d902549b7719b2/ruff-0.12.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fa6b24600cf3b750e48ddb6057e901dd5b9aa426e316addb2a1af185a7509882", size = 10586941, upload-time = "2025-07-11T13:20:33.046Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0f/41fec224e9dfa49a139f0b402ad6f5d53696ba1800e0f77b279d55210ca9/ruff-0.12.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2506961bf6ead54887ba3562604d69cb430f59b42133d36976421bc8bd45901", size = 10783001, upload-time = "2025-07-11T13:20:35.534Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/dd64a9ce56d9ed6cad109606ac014860b1c217c883e93bf61536400ba107/ruff-0.12.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4faaff1f90cea9d3033cbbcdf1acf5d7fb11d8180758feb31337391691f3df0", size = 10269641, upload-time = "2025-07-11T13:20:38.459Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5c/2be545034c6bd5ce5bb740ced3e7014d7916f4c445974be11d2a406d5088/ruff-0.12.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40dced4a79d7c264389de1c59467d5d5cefd79e7e06d1dfa2c75497b5269a5a6", size = 11875059, upload-time = "2025-07-11T13:20:41.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d4/a74ef1e801ceb5855e9527dae105eaff136afcb9cc4d2056d44feb0e4792/ruff-0.12.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0262d50ba2767ed0fe212aa7e62112a1dcbfd46b858c5bf7bbd11f326998bafc", size = 12658890, upload-time = "2025-07-11T13:20:44.442Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c8/1057916416de02e6d7c9bcd550868a49b72df94e3cca0aeb77457dcd9644/ruff-0.12.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12371aec33e1a3758597c5c631bae9a5286f3c963bdfb4d17acdd2d395406687", size = 12232008, upload-time = "2025-07-11T13:20:47.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/59/4f7c130cc25220392051fadfe15f63ed70001487eca21d1796db46cbcc04/ruff-0.12.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:560f13b6baa49785665276c963edc363f8ad4b4fc910a883e2625bdb14a83a9e", size = 11499096, upload-time = "2025-07-11T13:20:50.348Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/01/a0ad24a5d2ed6be03a312e30d32d4e3904bfdbc1cdbe63c47be9d0e82c79/ruff-0.12.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023040a3499f6f974ae9091bcdd0385dd9e9eb4942f231c23c57708147b06311", size = 11688307, upload-time = "2025-07-11T13:20:52.945Z" },
+    { url = "https://files.pythonhosted.org/packages/93/72/08f9e826085b1f57c9a0226e48acb27643ff19b61516a34c6cab9d6ff3fa/ruff-0.12.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:883d844967bffff5ab28bba1a4d246c1a1b2933f48cb9840f3fdc5111c603b07", size = 10661020, upload-time = "2025-07-11T13:20:55.799Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a0/68da1250d12893466c78e54b4a0ff381370a33d848804bb51279367fc688/ruff-0.12.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2120d3aa855ff385e0e562fdee14d564c9675edbe41625c87eeab744a7830d12", size = 10246300, upload-time = "2025-07-11T13:20:58.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/22/5f0093d556403e04b6fd0984fc0fb32fbb6f6ce116828fd54306a946f444/ruff-0.12.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6b16647cbb470eaf4750d27dddc6ebf7758b918887b56d39e9c22cce2049082b", size = 11263119, upload-time = "2025-07-11T13:21:01.503Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/f4c0b69bdaffb9968ba40dd5fa7df354ae0c73d01f988601d8fac0c639b1/ruff-0.12.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e1417051edb436230023575b149e8ff843a324557fe0a265863b7602df86722f", size = 11746990, upload-time = "2025-07-11T13:21:04.524Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/84/7cc7bd73924ee6be4724be0db5414a4a2ed82d06b30827342315a1be9e9c/ruff-0.12.3-py3-none-win32.whl", hash = "sha256:dfd45e6e926deb6409d0616078a666ebce93e55e07f0fb0228d4b2608b2c248d", size = 10589263, upload-time = "2025-07-11T13:21:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/07/87/c070f5f027bd81f3efee7d14cb4d84067ecf67a3a8efb43aadfc72aa79a6/ruff-0.12.3-py3-none-win_amd64.whl", hash = "sha256:a946cf1e7ba3209bdef039eb97647f1c77f6f540e5845ec9c114d3af8df873e7", size = 11695072, upload-time = "2025-07-11T13:21:11.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/30/f3eaf6563c637b6e66238ed6535f6775480db973c836336e4122161986fc/ruff-0.12.3-py3-none-win_arm64.whl", hash = "sha256:5f9c7c9c8f84c2d7f27e93674d27136fbf489720251544c4da7fb3d742e011b1", size = 10805855, upload-time = "2025-07-11T13:21:13.547Z" },
 ]
 
 [[package]]
@@ -1480,14 +1480,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.46.2"
+version = "0.47.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/69/662169fdb92fb96ec3eaee218cf540a629d629c86d7993d9651226a6789b/starlette-0.47.1.tar.gz", hash = "sha256:aef012dd2b6be325ffa16698f9dc533614fb1cebd593a906b90dc1025529a79b", size = 2583072, upload-time = "2025-06-21T04:03:17.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/82/95/38ef0cd7fa11eaba6a99b3c4f5ac948d8bc6ff199aabd327a29cc000840c/starlette-0.47.1-py3-none-any.whl", hash = "sha256:5e11c9f5c7c3f24959edbf2dffdc01bba860228acf657129467d8a7468591527", size = 72747, upload-time = "2025-06-21T04:03:15.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit introduces a major architectural improvement by refactoring the VEO and Imagen pages to be driven by centralized configuration files. This eliminates hardcoded values, reduces bugs, and makes the application significantly easier to maintain and extend.

Key Changes:

**1. Centralized Model Configuration:**
- Created `config/veo_models.py` and `config/imagen_models.py` to serve as the single source of truth for all model-specific constraints.
- These configurations define supported modes, aspect ratios, durations, sample counts, and other features for each model in a structured `dataclass`.

**2. Configuration-Driven UI:**
- Refactored the VEO and Imagen UI components (`generation_controls`, `file_uploader`, `advanced_controls`) to be dynamically generated based on the new configuration files.
- The UI now automatically adapts to the constraints of the selected model, such as disabling unsupported options or populating dropdowns with valid values.

**3. Enhanced Testing Strategy:**
- Introduced a formal distinction between unit and integration tests using a custom `integration` marker in `pytest`.
- Created new integration tests (`test_veo_api_integration.py`, `test_imagen_api_integration.py`) that make real API calls to all configured models, verifying live functionality.
- Added new component-level integration tests (`test_veo_generation_flow.py`, `test_imagen_generation_flow.py`) to validate the data handling and Firestore logging logic after a successful (mocked) API call, preventing data-related `NameError` and `AttributeError` bugs.
- Implemented a configurable test setup (`test/conftest.py`) allowing developers to specify a custom GCS bucket via the `--gcs-bucket` command-line flag.
- Updated `test/README.md` to document the new testing procedures.

**4. Bug Fixes:**
- Resolved a `NameError` in the Imagen "Random" button by restoring necessary imports and configuration instances.
- Fixed a `NameError` in the Firestore metadata logging for Imagen by removing a reference to an obsolete `modifiers` variable.
- Corrected an `AttributeError` to allow anonymous (local) users without a logged-in email to generate images without causing an error.
- Set the default Imagen model to "Imagen 4 (preview)" as requested.