### PR TITLE
feat(library): display VTO input images in details view

### DIFF
--- a/experiments/veo-app/GEMINI.md
+++ b/experiments/veo-app/GEMINI.md
@@ -250,12 +250,16 @@ When refactoring code, follow these steps to avoid common errors:
 2.  **Pay close attention to data models.** When changing a data model, make sure to update all code that uses that data model. This includes code that reads from and writes to the data model.
 3.  **Run tests after making changes.** This will help you to catch any errors that you may have introduced.
 
+## Code Quality and Style
+After any code modification, ensure the changes adhere to the project's established style guide (e.g., Google Python Style Guide for this project). Proactively run any configured linters or formatters to verify compliance before considering a task complete. This ensures consistency and maintainability.
+
 # Data Consistency
 
 When working with Firestore, it is important to keep the data in Firestore consistent with the data models in the code. This can be done by:
 
 *   **Using a single source of truth for your data models.** This will help to ensure that all code is using the same data models.
 *   **Using a data migration tool to update your data in Firestore when you change your data models.** This will help to ensure that your data in Firestore is always consistent with your data models.
+*   **When checking field values from external data sources like Firestore, prefer containment checks (e.g., `if 'substring' in value:`) over exact equality checks (`if value == 'exact_string'`) for identifiers that might have variations. This makes the code more robust. Also, always use the `.get('key', default_value)` method to access dictionary keys safely.**
 
 # Working with GCS URIs
 
@@ -266,6 +270,9 @@ gs://<bucket-name>/<object-name>
 ```
 
 When constructing a GCS URI, make sure to not include the `gs://` prefix more than once.
+
+## VTO Page Lessons Learned: Creating the Virtual Try-On (VTO) Page
+VTO-generated items stored in Firestore can be identified by checking if the `model` field in their `raw_data` contains the string `'virtual-try-on'`. The original input images are available in the `raw_data` under the keys `person_image_gcs` and `product_image_gcs`.
 
 
 # More Lessons Learned

--- a/experiments/veo-app/components/library/image_details.py
+++ b/experiments/veo-app/components/library/image_details.py
@@ -1,3 +1,21 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyright: basic
+
+"""A component for displaying media item details, including a carousel."""
+
 import mesop as me
 
 from common.metadata import MediaItem
@@ -6,23 +24,32 @@ from common.metadata import MediaItem
 @me.stateclass
 class CarouselState:
     """State for the image carousel."""
+
     current_index: int = 0
 
 
-def on_next(e: me.ClickEvent):
-    """Event handler for the 'Next' button in the image carousel."""
+def on_next(e: me.ClickEvent) -> None:
+    """Event handler for the 'Next' button in the image carousel.
+
+    Args:
+        e: The Mesop click event.
+    """
     state = me.state(CarouselState)
     state.current_index += 1
 
 
-def on_prev(e: me.ClickEvent):
-    """Event handler for the 'Previous' button in the image carousel."""
+def on_prev(e: me.ClickEvent) -> None:
+    """Event handler for the 'Previous' button in the image carousel.
+
+    Args:
+        e: The Mesop click event.
+    """
     state = me.state(CarouselState)
     state.current_index -= 1
 
 
 @me.component
-def image_details(item: MediaItem):
+def image_details(item: MediaItem) -> None:
     """A component that displays image details in a carousel.
 
     Args:
@@ -31,12 +58,17 @@ def image_details(item: MediaItem):
     state = me.state(CarouselState)
     num_images = len(item.gcs_uris)
 
-    with me.box(style=me.Style(display="flex", flex_direction="column", align_items="center", gap=16)):
+    with me.box(
+        style=me.Style(
+            display="flex", flex_direction="column", align_items="center", gap=16
+        )
+    ):
         # Image display
+        image_url = item.gcs_uris[state.current_index].replace(
+            "gs://", "https://storage.mtls.cloud.google.com/"
+        )
         me.image(
-            src=item.gcs_uris[state.current_index].replace(
-                "gs://", "https://storage.mtls.cloud.google.com/"
-            ),
+            src=image_url,
             style=me.Style(
                 width="100%",
                 height="auto",
@@ -45,7 +77,14 @@ def image_details(item: MediaItem):
         )
 
         # Carousel controls
-        with me.box(style=me.Style(display="flex", align_items="center", justify_content="center", gap=16)):
+        with me.box(
+            style=me.Style(
+                display="flex",
+                align_items="center",
+                justify_content="center",
+                gap=16,
+            )
+        ):
             me.button(
                 "Back",
                 on_click=on_prev,
@@ -57,10 +96,69 @@ def image_details(item: MediaItem):
                 on_click=on_next,
                 disabled=state.current_index >= num_images - 1,
             )
-    
+
     if item.rewritten_prompt:
         me.text(f'Rewritten Prompt: "{item.rewritten_prompt}"')
     else:
         me.text(f"Prompt: \"{item.prompt or 'N/A'}\"")
     if item.critique:
         me.text(f"Critique: {item.critique}")
+
+    # Conditionally display VTO input images
+    if item.raw_data and "virtual-try-on" in item.raw_data.get("model", ""):
+        with me.box(style=me.Style(margin=me.Margin(top=16))):
+            me.text(
+                "Input Images",
+                style=me.Style(font_weight="bold", margin=me.Margin(bottom=8)),
+            )
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    gap=16,
+                    justify_content="center",
+                )
+            ):
+                # Person Image
+                person_gcs_uri = item.raw_data.get("person_image_gcs")
+                if person_gcs_uri:
+                    with me.box(
+                        style=me.Style(
+                            display="flex",
+                            flex_direction="column",
+                            align_items="center",
+                            gap=4,
+                        )
+                    ):
+                        me.text("Person Image")
+                        person_url = person_gcs_uri.replace(
+                            "gs://", "https://storage.mtls.cloud.google.com/"
+                        )
+                        me.image(
+                            src=person_url,
+                            style=me.Style(
+                                width="200px", height="auto", border_radius="8px"
+                            ),
+                        )
+
+                # Product Image
+                product_gcs_uri = item.raw_data.get("product_image_gcs")
+                if product_gcs_uri:
+                    with me.box(
+                        style=me.Style(
+                            display="flex",
+                            flex_direction="column",
+                            align_items="center",
+                            gap=4,
+                        )
+                    ):
+                        me.text("Product Image")
+                        product_url = product_gcs_uri.replace(
+                            "gs://", "https://storage.mtls.cloud.google.com/"
+                        )
+                        me.image(
+                            src=product_url,
+                            style=me.Style(
+                                width="200px", height="auto", border_radius="8px"
+                            ),
+                        )

--- a/experiments/veo-app/pages/library.py
+++ b/experiments/veo-app/pages/library.py
@@ -16,20 +16,19 @@
 import json
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 import mesop as me
+from google.cloud import firestore  # Explicitly import for firestore.Query
 
 # Imports from your project structure
 from common.metadata import (
-    get_total_media_count, # This might need adjustment if we want truly accurate filtered counts server-side
-    db,
-    config,
-    get_media_item_by_id,
     MediaItem,
+    config,
+    db,
+    get_media_item_by_id,
+    get_total_media_count,  # This might need adjustment if we want truly accurate filtered counts server-side
 )
-from google.cloud import firestore  # Explicitly import for firestore.Query
-
 from components.dialog import (
     dialog,
     dialog_actions,
@@ -53,14 +52,16 @@ class PageState:
     media_per_page: int = 9
     total_media: int = 0
     media_items: List[MediaItem] = field(default_factory=list)
-    key: int = 0 # Used to force re-render of the media grid
+    key: int = 0  # Used to force re-render of the media grid
     show_details_dialog: bool = False
     selected_media_item_id: Optional[str] = None
     dialog_instance_key: int = 0
     selected_values: list[str] = field(
         default_factory=lambda: ["all"]
     )  # Default to "all" media types
-    error_filter_value: str = "all"  # New state for error filter: "all", "no_errors", "only_errors"
+    error_filter_value: str = (
+        "all"  # New state for error filter: "all", "no_errors", "only_errors"
+    )
     initial_url_param_processed: bool = False
     url_item_not_found_message: Optional[str] = None
 
@@ -69,10 +70,9 @@ def get_media_for_page(
     page: int,
     media_per_page: int,
     type_filters: Optional[List[str]] = None,
-    error_filter: str = "all", # "all", "no_errors", "only_errors"
+    error_filter: str = "all",  # "all", "no_errors", "only_errors"
 ) -> List[MediaItem]:
-    """
-    Fetches a paginated and filtered list of media items from Firestore.
+    """ Fetches a paginated and filtered list of media items from Firestore.
 
     NOTE: This implementation currently fetches a larger batch of items (up to 'fetch_limit')
     and then performs filtering and pagination client-side (in Python). For very large datasets
@@ -90,9 +90,7 @@ def get_media_for_page(
     Returns:
         A list of MediaItem objects.
     """
-    fetch_limit = (
-        1000  # Max items to fetch for client-side filtering/pagination
-    )
+    fetch_limit = 1000  # Max items to fetch for client-side filtering/pagination
 
     try:
         query = db.collection(config.GENMEDIA_COLLECTION_NAME).order_by(
@@ -120,7 +118,7 @@ def get_media_for_page(
                     passes_type_filter = True
                 elif "music" in type_filters and mime_type.startswith("audio/"):
                     passes_type_filter = True
-            
+
             if not passes_type_filter:
                 continue
 
@@ -132,20 +130,19 @@ def get_media_for_page(
                 passes_error_filter = True
             elif error_filter == "only_errors" and error_message_present:
                 passes_error_filter = True
-            
+
             if not passes_error_filter:
                 continue
-            
+
             # Construct MediaItem if all filters pass
             timestamp_iso_str: Optional[str] = None
             raw_timestamp = raw_item_data.get("timestamp")
             if isinstance(raw_timestamp, datetime):
                 timestamp_iso_str = raw_timestamp.isoformat()
             elif isinstance(raw_timestamp, str):
-                timestamp_iso_str = raw_timestamp # Assuming it's already ISO format
-            elif hasattr(raw_timestamp, "isoformat"): # For Firestore Timestamp objects
+                timestamp_iso_str = raw_timestamp  # Assuming it's already ISO format
+            elif hasattr(raw_timestamp, "isoformat"):  # For Firestore Timestamp objects
                 timestamp_iso_str = raw_timestamp.isoformat()
-
 
             try:
                 gen_time = (
@@ -216,16 +213,16 @@ def _load_media_and_update_state(pagestate: PageState, is_filter_change: bool = 
         is_filter_change: Whether the media is being loaded due to a filter change.
     """
     if is_filter_change:
-        pagestate.current_page = 1 # Reset to first page on any filter change
+        pagestate.current_page = 1  # Reset to first page on any filter change
 
     # Fetch all items matching current filters to correctly determine total_media for pagination
     # This fetches up to 'fetch_limit' defined in get_media_for_page.
     # For very large datasets, a server-side count with filters would be more performant.
     all_matching_items = get_media_for_page(
-        page=1, # Fetch from page 1
-        media_per_page=1000, # Effectively fetch all matching items up to the internal limit
+        page=1,  # Fetch from page 1
+        media_per_page=1000,  # Effectively fetch all matching items up to the internal limit
         type_filters=pagestate.selected_values,
-        error_filter=pagestate.error_filter_value
+        error_filter=pagestate.error_filter_value,
     )
     pagestate.total_media = len(all_matching_items)
 
@@ -234,9 +231,9 @@ def _load_media_and_update_state(pagestate: PageState, is_filter_change: bool = 
         pagestate.current_page,
         pagestate.media_per_page,
         pagestate.selected_values,
-        pagestate.error_filter_value
+        pagestate.error_filter_value,
     )
-    pagestate.key += 1 # Force re-render of the grid
+    pagestate.key += 1  # Force re-render of the grid
 
 
 def library_content(app_state: me.state):
@@ -249,7 +246,9 @@ def library_content(app_state: me.state):
 
     if not pagestate.initial_url_param_processed:
         # Load initial data respecting all filters
-        _load_media_and_update_state(pagestate, is_filter_change=True) # Treat initial load as a filter change for count
+        _load_media_and_update_state(
+            pagestate, is_filter_change=True
+        )  # Treat initial load as a filter change for count
 
         query_params = me.query_params
         media_id_from_url = query_params.get("media_id")
@@ -270,8 +269,10 @@ def library_content(app_state: me.state):
                     # or we re-evaluate if it should be shown.
                     # For now, we add it if found, but it might not match current filters.
                     if not any(v.id == fetched_item.id for v in pagestate.media_items):
-                         pagestate.media_items.insert(0, fetched_item) # Prepend for visibility
-                         # pagestate.total_media +=1 # Adjust if needed, though complex with filters
+                        pagestate.media_items.insert(
+                            0, fetched_item
+                        )  # Prepend for visibility
+                        # pagestate.total_media +=1 # Adjust if needed, though complex with filters
 
                     pagestate.selected_media_item_id = fetched_item.id
                     pagestate.show_details_dialog = True
@@ -286,10 +287,10 @@ def library_content(app_state: me.state):
         (pagestate.total_media + pagestate.media_per_page - 1)
         // pagestate.media_per_page
         if pagestate.media_per_page > 0 and pagestate.total_media > 0
-        else 1 # Ensure at least 1 page if total_media is 0 to avoid division by zero or 0 pages
+        else 1  # Ensure at least 1 page if total_media is 0 to avoid division by zero or 0 pages
     )
-    if pagestate.total_media == 0: total_pages = 0 # Show 0 pages if no items
-
+    if pagestate.total_media == 0:
+        total_pages = 0  # Show 0 pages if no items
 
     with page_scaffold():  # pylint: disable=not-context-manager
         with page_frame():  # pylint: disable=not-context-manager
@@ -306,24 +307,31 @@ def library_content(app_state: me.state):
                     )
                 ):
                     me.text(pagestate.url_item_not_found_message)
-            
+
             # Filter Toggles Container
-            with me.box(style=me.Style(display="flex", flex_direction="row", gap=10, margin=me.Margin(bottom=20))):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    gap=10,
+                    margin=me.Margin(bottom=20),
+                )
+            ):
                 # Media Type Filter
                 me.button_toggle(
-                    value=pagestate.selected_values, # This is a list
+                    value=pagestate.selected_values,  # This is a list
                     buttons=[
                         me.ButtonToggleButton(label="All Types", value="all"),
                         me.ButtonToggleButton(label="Images", value="images"),
                         me.ButtonToggleButton(label="Videos", value="videos"),
                         me.ButtonToggleButton(label="Music", value="music"),
                     ],
-                    multiple=True, 
+                    multiple=True,
                     on_change=on_change_selected_type_filters,
                 )
                 # Error Message Filter
                 me.button_toggle(
-                    value=pagestate.error_filter_value, # This is a string
+                    value=pagestate.error_filter_value,  # This is a string
                     buttons=[
                         me.ButtonToggleButton(label="Show All", value="all"),
                         me.ButtonToggleButton(label="No Errors", value="no_errors"),
@@ -334,7 +342,7 @@ def library_content(app_state: me.state):
                 )
 
             with me.box(
-                key=str(pagestate.key), # Refreshes the grid when key changes
+                key=str(pagestate.key),  # Refreshes the grid when key changes
                 style=me.Style(
                     display="grid",
                     grid_template_columns="repeat(auto-fill, minmax(300px, 1fr))",
@@ -343,10 +351,18 @@ def library_content(app_state: me.state):
                 ),
             ):
                 if pagestate.is_loading and not pagestate.show_details_dialog:
-                    with me.box(style=me.Style(display="flex", justify_content="center", padding=me.Padding.all(20))):
+                    with me.box(
+                        style=me.Style(
+                            display="flex",
+                            justify_content="center",
+                            padding=me.Padding.all(20),
+                        )
+                    ):
                         me.progress_spinner()
                 elif not pagestate.media_items:
-                    with me.box(style=me.Style(padding=me.Padding.all(20), text_align="center")):
+                    with me.box(
+                        style=me.Style(padding=me.Padding.all(20), text_align="center")
+                    ):
                         me.text("No media items found for the selected filters.")
                 else:
                     for i, m_item in enumerate(pagestate.media_items):
@@ -392,15 +408,19 @@ def library_content(app_state: me.state):
                             try:
                                 # Ensure timestamp is a string before parsing
                                 ts_str = m_item.timestamp
-                                if isinstance(m_item.timestamp, datetime): # Should not happen if MediaItem.timestamp is str
-                                     ts_str = m_item.timestamp.isoformat()
+                                if isinstance(
+                                    m_item.timestamp, datetime
+                                ):  # Should not happen if MediaItem.timestamp is str
+                                    ts_str = m_item.timestamp.isoformat()
 
                                 timestamp_display_str = datetime.fromisoformat(
-                                    ts_str.replace("Z", "+00:00") # Handle Z for UTC
+                                    ts_str.replace("Z", "+00:00")  # Handle Z for UTC
                                 ).strftime("%Y-%m-%d %H:%M")
                             except (ValueError, TypeError) as e_ts:
                                 # print(f"Timestamp parsing error for '{m_item.timestamp}': {e_ts}")
-                                timestamp_display_str = str(m_item.timestamp) # Fallback to string if parsing fails
+                                timestamp_display_str = str(
+                                    m_item.timestamp
+                                )  # Fallback to string if parsing fails
 
                         item_duration_str = (
                             f"{m_item.duration} sec"
@@ -409,7 +429,9 @@ def library_content(app_state: me.state):
                         )
 
                         with me.box(
-                            key=str(i), # Use item ID if available and unique, otherwise index is fine for local list
+                            key=str(
+                                i
+                            ),  # Use item ID if available and unique, otherwise index is fine for local list
                             # key=m_item.id or str(i), # Prefer item ID for key if stable
                             on_click=on_media_item_click,
                             style=me.Style(
@@ -459,27 +481,34 @@ def library_content(app_state: me.state):
                                     if m_item.duration is not None:
                                         pill(item_duration_str, "duration")
                                     pill("24 fps", "fps")
-                                    if m_item.enhanced_prompt_used and media_type_group == "video":
-                                        with me.tooltip(message="Prompt was auto-enhanced"):
+                                    if (
+                                        m_item.enhanced_prompt_used
+                                        and media_type_group == "video"
+                                    ):
+                                        with me.tooltip(
+                                            message="Prompt was auto-enhanced"
+                                        ):
                                             me.icon(
                                                 "auto_fix_normal",
                                                 style=me.Style(
                                                     color=me.theme_var("primary")
                                                 ),
                                             )
-                                    
+
                                 elif media_type_group == "image":
                                     pill("Image", "media_type_image")
                                     if m_item.aspect:
                                         pill(m_item.aspect, "aspect")
-                                        
+
                                 elif media_type_group == "audio":
                                     pill("Audio", "media_type_audio")
                                     if m_item.duration is not None:
                                         pill(item_duration_str, "duration")
 
                                     if m_item.rewritten_prompt is not None:
-                                        with me.tooltip(message="Custom prompt rewriter"):
+                                        with me.tooltip(
+                                            message="Custom prompt rewriter"
+                                        ):
                                             me.icon(
                                                 "auto_fix_normal",
                                                 style=me.Style(
@@ -489,8 +518,10 @@ def library_content(app_state: me.state):
 
                                 # Pill for error message
                                 if m_item.error_message:
-                                    pill("Error", "error_present",)
-
+                                    pill(
+                                        "Error",
+                                        "error_present",
+                                    )
 
                             me.text(
                                 f'"{prompt_display_grid}"'
@@ -501,7 +532,7 @@ def library_content(app_state: me.state):
                                     font_style="italic"
                                     if prompt_display_grid
                                     else "normal",
-                                    min_height="40px", # Ensure consistent height
+                                    min_height="40px",  # Ensure consistent height
                                 ),
                             )
 
@@ -509,12 +540,12 @@ def library_content(app_state: me.state):
                             with me.box(
                                 style=me.Style(
                                     display="flex",
-                                    flex_direction="row", # Changed to row for side-by-side potential
+                                    flex_direction="row",  # Changed to row for side-by-side potential
                                     gap=8,
-                                    align_items="center", # Align items vertically in center
-                                    justify_content="center", # Center content horizontally
+                                    align_items="center",  # Align items vertically in center
+                                    justify_content="center",  # Center content horizontally
                                     margin=me.Margin(top=8, bottom=8),
-                                    min_height="150px", # Ensure consistent height for preview area
+                                    min_height="150px",  # Ensure consistent height for preview area
                                 )
                             ):
                                 if m_item.error_message:
@@ -522,7 +553,7 @@ def library_content(app_state: me.state):
                                     me.text(
                                         f"Error: {m_item.error_message}",
                                         style=me.Style(
-                                            width="100%", # Take full width of the preview area
+                                            width="100%",  # Take full width of the preview area
                                             font_style="italic",
                                             font_size="10pt",
                                             margin=me.Margin.all(3),
@@ -535,17 +566,21 @@ def library_content(app_state: me.state):
                                                 )
                                             ),
                                             border_radius=5,
-                                            background=me.theme_var("error-container"), # Corrected theme var
-                                            color=me.theme_var("on-error-container"), # Corrected theme var
+                                            background=me.theme_var(
+                                                "error-container"
+                                            ),  # Corrected theme var
+                                            color=me.theme_var(
+                                                "on-error-container"
+                                            ),  # Corrected theme var
                                         ),
                                     )
-                                else: # Only show media preview if no error
+                                else:  # Only show media preview if no error
                                     if media_type_group == "video" and item_url:
                                         me.video(
                                             src=item_url,
                                             style=me.Style(
-                                                width="100%", # Take full width
-                                                height="150px", # Fixed height for consistency
+                                                width="100%",  # Take full width
+                                                height="150px",  # Fixed height for consistency
                                                 border_radius=6,
                                                 object_fit="cover",
                                             ),
@@ -553,13 +588,13 @@ def library_content(app_state: me.state):
                                     elif media_type_group == "image" and item_url:
                                         me.image(
                                             src=item_url,
-                                            #alt_text=m_item.prompt or "Generated Image",
+                                            # alt_text=m_item.prompt or "Generated Image",
                                             style=me.Style(
-                                                max_width="100%", # Ensure it doesn't overflow
-                                                max_height="150px", # Max height for consistency
-                                                height="auto", # Maintain aspect ratio
+                                                max_width="100%",  # Ensure it doesn't overflow
+                                                max_height="150px",  # Max height for consistency
+                                                height="auto",  # Maintain aspect ratio
                                                 border_radius=6,
-                                                object_fit="contain", # Use contain to see whole image
+                                                object_fit="contain",  # Use contain to see whole image
                                             ),
                                         )
                                     elif media_type_group == "audio" and item_url:
@@ -567,7 +602,7 @@ def library_content(app_state: me.state):
                                             src=item_url,
                                             # style=me.Style(width="100%"), # Audio player width
                                         )
-                                    else: # Fallback if no URL or unknown type (and no error)
+                                    else:  # Fallback if no URL or unknown type (and no error)
                                         me.text(
                                             f"{media_type_group.capitalize() if media_type_group else 'Media'} not available.",
                                             style=me.Style(
@@ -580,11 +615,14 @@ def library_content(app_state: me.state):
                                         )
 
                                 # Reference images for video (only if no error)
-                                if media_type_group == "video" and not m_item.error_message:
+                                if (
+                                    media_type_group == "video"
+                                    and not m_item.error_message
+                                ):
                                     with me.box(
                                         style=me.Style(
                                             display="flex",
-                                            flex_direction="column", # Stack reference images
+                                            flex_direction="column",  # Stack reference images
                                             gap=5,
                                             # margin=me.Margin(left=8) # Add some space if side-by-side with video
                                         )
@@ -597,7 +635,7 @@ def library_content(app_state: me.state):
                                             me.image(
                                                 src=ref_img_url,
                                                 style=me.Style(
-                                                    height="70px", # Smaller reference images
+                                                    height="70px",  # Smaller reference images
                                                     width="auto",
                                                     border_radius=4,
                                                     object_fit="contain",
@@ -628,9 +666,11 @@ def library_content(app_state: me.state):
                                 )
             # Dialog for Media Details
             library_dialog_style = me.Style(
-                max_width="80vw", width="80vw", min_width="600px" # Responsive width
+                max_width="80vw",
+                width="80vw",
+                min_width="600px",  # Responsive width
             )
-            with dialog( # pylint: disable=not-context-manager
+            with dialog(  # pylint: disable=not-context-manager
                 key=str(pagestate.dialog_instance_key),
                 is_open=pagestate.show_details_dialog,
                 dialog_style=library_dialog_style,
@@ -671,8 +711,8 @@ def library_content(app_state: me.state):
                             flex_direction="column",
                             gap=12,
                             width="100%",
-                            max_height="80vh", # Max viewport height
-                            overflow_y="auto", # Scroll if content exceeds max height
+                            max_height="80vh",  # Max viewport height
+                            overflow_y="auto",  # Scroll if content exceeds max height
                             padding=me.Padding.all(24),
                         )
                     ):
@@ -683,7 +723,7 @@ def library_content(app_state: me.state):
                                 font_weight="bold",
                                 margin=me.Margin(bottom=16),
                                 color=me.theme_var("on-surface-variant"),
-                                flex_shrink=0, # Prevent title from shrinking
+                                flex_shrink=0,  # Prevent title from shrinking
                             ),
                         )
 
@@ -702,62 +742,74 @@ def library_content(app_state: me.state):
                         )
                         if dialog_media_type_group == "image":
                             image_details(item)
-                        elif dialog_media_type_group == "video" and item_display_url and not item.error_message:
+                        elif (
+                            dialog_media_type_group == "video"
+                            and item_display_url
+                            and not item.error_message
+                        ):
                             me.video(
                                 src=item_display_url,
                                 style=me.Style(
                                     width="100%",
                                     max_height="40vh",
                                     border_radius=8,
-                                    background="#000", # Background for video player
-                                    display="block", # Ensure it takes block space
+                                    background="#000",  # Background for video player
+                                    display="block",  # Ensure it takes block space
                                     margin=me.Margin(bottom=16),
                                 ),
                             )
-                        elif dialog_media_type_group == "audio" and item_display_url and not item.error_message:
+                        elif (
+                            dialog_media_type_group == "audio"
+                            and item_display_url
+                            and not item.error_message
+                        ):
                             me.audio(
                                 src=item_display_url,
                                 # style=me.Style(width="100%", margin=me.Margin(top=8, bottom=16))
                             )
-                        
+
                         if item.error_message:
                             me.text(
                                 f"Error: {item.error_message}",
                                 style=me.Style(
-                                    color=me.theme_var("error"), font_style="italic",
+                                    color=me.theme_var("error"),
+                                    font_style="italic",
                                     padding=me.Padding.all(8),
                                     background=me.theme_var("error-container"),
                                     border_radius=4,
-                                    margin=me.Margin(bottom=10)
+                                    margin=me.Margin(bottom=10),
                                 ),
                             )
 
                         me.text(f"Model: {item.raw_data['model']}")
-                        
+
                         if dialog_media_type_group != "image":
-                            me.text(f"Prompt: \"{item.prompt or 'N/A'}\"")
+                            me.text(f'Prompt: "{item.prompt or "N/A"}"')
                             if item.enhanced_prompt_used:
-                                me.text(f'Enhanced Prompt: "{item.enhanced_prompt_used}"')
-                        
+                                me.text(
+                                    f'Enhanced Prompt: "{item.enhanced_prompt_used}"'
+                                )
+
                         dialog_timestamp_str_detail = "N/A"
                         if item.timestamp:
                             try:
                                 ts_str_detail = item.timestamp
                                 if isinstance(item.timestamp, datetime):
-                                     ts_str_detail = item.timestamp.isoformat()
+                                    ts_str_detail = item.timestamp.isoformat()
                                 dialog_timestamp_str_detail = datetime.fromisoformat(
-                                    ts_str_detail.replace("Z", "+00:00") 
-                                ).strftime("%Y-%m-%d %H:%M:%S %Z") # More detailed timestamp
+                                    ts_str_detail.replace("Z", "+00:00")
+                                ).strftime(
+                                    "%Y-%m-%d %H:%M:%S %Z"
+                                )  # More detailed timestamp
                             except Exception:
                                 dialog_timestamp_str_detail = str(item.timestamp)
                         me.text(f"Generated: {dialog_timestamp_str_detail}")
-
 
                         if item.generation_time is not None:
                             me.text(
                                 f"Generation Time: {round(item.generation_time, 2)} seconds"
                             )
-                        
+
                         if item.model is not None:
                             me.text(f"Model: {item.model}")
 
@@ -782,7 +834,10 @@ def library_content(app_state: me.state):
                                 me.text(
                                     "Reference Image:",
                                     style=me.Style(
-                                        font_weight="500", margin=me.Margin(top=8) # medium is not a valid value
+                                        font_weight="500",
+                                        margin=me.Margin(
+                                            top=8
+                                        ),  # medium is not a valid value
                                     ),
                                 )
                                 me.image(
@@ -813,10 +868,10 @@ def library_content(app_state: me.state):
                                         margin=me.Margin(top=4),
                                     ),
                                 )
-                        
+
                         with me.content_button(
                             on_click=on_click_set_permalink,
-                            key=item.id or "", # Ensure key is not None
+                            key=item.id or "",  # Ensure key is not None
                         ):
                             with me.box(
                                 style=me.Style(
@@ -831,14 +886,16 @@ def library_content(app_state: me.state):
 
                         if item.raw_data:
                             with me.expansion_panel(
-                                key="raw_metadata_panel_dialog", # Unique key for dialog panel
+                                key="raw_metadata_panel_dialog",  # Unique key for dialog panel
                                 title="Firestore Metadata",
                                 description=item.id or "N/A",
                                 icon="dataset",
                             ):
                                 try:
                                     json_string = json.dumps(
-                                        item.raw_data, indent=2, default=str # Use default=str for non-serializable
+                                        item.raw_data,
+                                        indent=2,
+                                        default=str,  # Use default=str for non-serializable
                                     )
                                     me.markdown(f"```json\n{json_string}\n```")
                                 except Exception as e_json:
@@ -853,8 +910,13 @@ def library_content(app_state: me.state):
                 else:
                     with me.box(style=me.Style(padding=me.Padding.all(16))):
                         me.text("No media item selected or found for the given ID.")
-                
-                me.button("Close", on_click=on_close_details_dialog, type="flat", style=me.Style(margin=me.Margin(top=24)))
+
+                me.button(
+                    "Close",
+                    on_click=on_close_details_dialog,
+                    type="flat",
+                    style=me.Style(margin=me.Margin(top=24)),
+                )
 
             # Pagination controls
             if total_pages > 1:
@@ -869,7 +931,7 @@ def library_content(app_state: me.state):
                 ):
                     me.button(
                         "Previous",
-                        key="-1", # Key for direction
+                        key="-1",  # Key for direction
                         on_click=handle_page_change,
                         disabled=pagestate.current_page == 1 or pagestate.is_loading,
                         type="stroked",
@@ -877,7 +939,7 @@ def library_content(app_state: me.state):
                     me.text(f"Page {pagestate.current_page} of {total_pages}")
                     me.button(
                         "Next",
-                        key="1", # Key for direction
+                        key="1",  # Key for direction
                         on_click=handle_page_change,
                         disabled=pagestate.current_page == total_pages
                         or pagestate.is_loading,
@@ -887,21 +949,23 @@ def library_content(app_state: me.state):
 
 def on_click_set_permalink(e: me.ClickEvent):
     """set the permalink from dialog"""
-    if e.key: # Ensure key is not None or empty
-      me.query_params["media_id"] = e.key
+    if e.key:  # Ensure key is not None or empty
+        me.query_params["media_id"] = e.key
 
 
 def on_media_item_click(e: me.ClickEvent):
     pagestate = me.state(PageState)
     try:
         # Assuming e.key is the index of the item in the currently displayed pagestate.media_items
-        selected_index = int(e.key) # The key for the media item box is its index 'i'
+        selected_index = int(e.key)  # The key for the media item box is its index 'i'
         if 0 <= selected_index < len(pagestate.media_items):
             clicked_item = pagestate.media_items[selected_index]
             pagestate.selected_media_item_id = clicked_item.id
             pagestate.show_details_dialog = True
-            pagestate.dialog_instance_key += 1 
-            pagestate.url_item_not_found_message = None # Clear any old not found message
+            pagestate.dialog_instance_key += 1
+            pagestate.url_item_not_found_message = (
+                None  # Clear any old not found message
+            )
         else:
             print(f"Error: Invalid index {selected_index} for media item click.")
     except ValueError:
@@ -912,8 +976,10 @@ def on_media_item_click(e: me.ClickEvent):
 def on_close_details_dialog(e: me.ClickEvent):
     pagestate = me.state(PageState)
     pagestate.show_details_dialog = False
-    pagestate.selected_media_item_id = None 
-    pagestate.url_item_not_found_message = None # Clear message when dialog is closed by user
+    pagestate.selected_media_item_id = None
+    pagestate.url_item_not_found_message = (
+        None  # Clear message when dialog is closed by user
+    )
     # Optionally, clear media_id from URL params if desired
     # if "media_id" in me.query_params:
     #    del me.query_params["media_id"]
@@ -927,7 +993,7 @@ def handle_page_change(e: me.ClickEvent):
         return
 
     pagestate.is_loading = True
-    yield # Show loading spinner
+    yield  # Show loading spinner
 
     direction = int(e.key)
     new_page = pagestate.current_page + direction
@@ -935,18 +1001,27 @@ def handle_page_change(e: me.ClickEvent):
     # No need to recalculate total_pages here if total_media is up-to-date
     # It's calculated at the start of library_content
 
-    if 1 <= new_page <= ((pagestate.total_media + pagestate.media_per_page - 1) // pagestate.media_per_page if pagestate.media_per_page > 0 and pagestate.total_media > 0 else 1):
+    if (
+        1
+        <= new_page
+        <= (
+            (pagestate.total_media + pagestate.media_per_page - 1)
+            // pagestate.media_per_page
+            if pagestate.media_per_page > 0 and pagestate.total_media > 0
+            else 1
+        )
+    ):
         pagestate.current_page = new_page
         # Fetch only the items for the new page with current filters
         pagestate.media_items = get_media_for_page(
             pagestate.current_page,
             pagestate.media_per_page,
             pagestate.selected_values,
-            pagestate.error_filter_value
+            pagestate.error_filter_value,
         )
-        pagestate.key += 1 # Refresh grid
+        pagestate.key += 1  # Refresh grid
         pagestate.url_item_not_found_message = None
-    
+
     pagestate.is_loading = False
     yield
 
@@ -954,9 +1029,9 @@ def handle_page_change(e: me.ClickEvent):
 def on_change_selected_type_filters(e: me.ButtonToggleChangeEvent):
     pagestate = me.state(PageState)
     new_filters = e.values
-    
-    if not new_filters: # If all are deselected
-        pagestate.selected_values = ["all"] # Default to "all"
+
+    if not new_filters:  # If all are deselected
+        pagestate.selected_values = ["all"]  # Default to "all"
     elif "all" in new_filters and len(new_filters) > 1:
         # If "all" is selected along with specific types, prioritize specific types
         pagestate.selected_values = [val for val in new_filters if val != "all"]
@@ -970,15 +1045,16 @@ def on_change_selected_type_filters(e: me.ButtonToggleChangeEvent):
     yield
 
     _load_media_and_update_state(pagestate, is_filter_change=True)
-    
+
     pagestate.is_loading = False
     yield
+
 
 def on_change_error_filter(e: me.ButtonToggleChangeEvent):
     """Handles changes to the error message filter."""
     pagestate = me.state(PageState)
-    pagestate.error_filter_value = e.value # This is a single string value
-    
+    pagestate.error_filter_value = e.value  # This is a single string value
+
     pagestate.url_item_not_found_message = None
     pagestate.is_loading = True
     yield

--- a/experiments/veo-app/requirements.txt
+++ b/experiments/veo-app/requirements.txt
@@ -17,7 +17,7 @@ blinker==1.9.0
     # via flask
 cachecontrol==0.14.3
     # via firebase-admin
-cachetools==6.1.0
+cachetools==5.5.2
     # via google-auth
 certifi==2025.7.14
     # via
@@ -46,7 +46,7 @@ cycler==0.12.1
     # via matplotlib
 decorator==5.2.1
     # via ipython
-deepdiff==8.5.0
+deepdiff==6.7.1
     # via mesop
 docstring-parser==0.16
     # via google-cloud-aiplatform
@@ -99,7 +99,7 @@ google-cloud-firestore==2.21.0 ; platform_python_implementation != 'PyPy'
     # via firebase-admin
 google-cloud-resource-manager==1.14.2
     # via google-cloud-aiplatform
-google-cloud-storage==3.2.0
+google-cloud-storage==2.19.0
     # via
     #   firebase-admin
     #   google-cloud-aiplatform
@@ -107,7 +107,7 @@ google-crc32c==1.7.1
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-genai==1.25.0
+google-genai==1.20.0
     # via
     #   google-cloud-aiplatform
     #   veo-app
@@ -261,7 +261,7 @@ pydantic==2.11.7
     #   google-cloud-aiplatform
     #   google-genai
     #   mesop
-pydantic-core==2.35.2
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.2
     # via

--- a/experiments/veo-app/uv.lock
+++ b/experiments/veo-app/uv.lock
@@ -95,11 +95,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.7.9"
+version = "2025.7.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/8a/c729b6b60c66a38f590c4e774decc4b2ec7b0576be8f1aa984a53ffa812a/certifi-2025.7.9.tar.gz", hash = "sha256:c1d2ec05395148ee10cf672ffc28cd37ea0ab0d99f9cc74c43e588cbd111b079", size = 160386, upload-time = "2025-07-09T02:13:58.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/76/52c535bcebe74590f296d6c77c86dabf761c41980e1347a2422e4aa2ae41/certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995", size = 163981, upload-time = "2025-07-14T03:29:28.449Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/f3/80a3f974c8b535d394ff960a11ac20368e06b736da395b551a49ce950cce/certifi-2025.7.9-py3-none-any.whl", hash = "sha256:d842783a14f8fdd646895ac26f719a061408834473cfc10203f6a575beb15d39", size = 159230, upload-time = "2025-07-09T02:13:57.007Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2", size = 162722, upload-time = "2025-07-14T03:29:26.863Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit enhances the media library's detail view.

When inspecting a media item generated by the Virtual Try-On (VTO) model, the dialog now displays the original person and product input images beneath the main carousel.

Key changes:
- Modified `components/library/image_details.py` to conditionally render the two input images.
- The component now checks if the model name in the item's `raw_data` contains 'virtual-try-on', making the check more robust.
- Updated the component to adhere to the Google Python Style Guide, improving readability and maintainability through better docstrings, type hinting, and line length management.