### PR TITLE
Feat/vto generate model

### DIFF
--- a/experiments/veo-app/models/image_models.py
+++ b/experiments/veo-app/models/image_models.py
@@ -154,6 +154,24 @@ def generate_images_from_prompt(
     return generated_uris
 
 
+def generate_image_for_vto(prompt: str) -> bytes:
+    """Generates a single image and returns the image bytes."""
+    cfg = Default()
+    client = ImagenModelSetup.init(model_id=cfg.MODEL_IMAGEN4_FAST)
+    response = client.models.generate_images(
+        model=cfg.MODEL_IMAGEN4_FAST,
+        prompt=prompt,
+        config=types.GenerateImagesConfig(
+            number_of_images=1,
+            aspect_ratio="1:1",
+        ),
+    )
+    if response.generated_images and response.generated_images[0].image.image_bytes:
+        return response.generated_images[0].image.image_bytes
+    else:
+        raise ValueError("Image generation failed or returned no data.")
+
+
 @retry(
     wait=wait_exponential(
         multiplier=1, min=1, max=10

--- a/experiments/veo-app/pages/vto.py
+++ b/experiments/veo-app/pages/vto.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import mesop as me
 from components.header import header
 from components.page_scaffold import page_frame, page_scaffold
@@ -10,6 +24,7 @@ from config.default import Default
 
 config = Default()
 
+
 @me.page(path="/vto")
 def vto():
     state = me.state(PageState)
@@ -19,7 +34,14 @@ def vto():
             header("Virtual Try-On", "checkroom")
 
             with me.box(style=me.Style(display="flex", flex_direction="row", gap=16)):
-                with me.box(style=me.Style(width="calc(50% - 8px)", display="flex", flex_direction="column", align_items="center")):
+                with me.box(
+                    style=me.Style(
+                        width="calc(50% - 8px)",
+                        display="flex",
+                        flex_direction="column",
+                        align_items="center",
+                    )
+                ):
                     me.uploader(
                         label="Upload Person Image",
                         on_upload=lambda e: on_upload_person(e),
@@ -27,9 +49,23 @@ def vto():
                         key="person_uploader",
                     )
                     if state.person_image_gcs:
-                        me.image(src=state.person_image_gcs, style=me.Style(width="400px", margin=me.Margin(top=16), border_radius=12))
+                        me.image(
+                            src=state.person_image_gcs,
+                            style=me.Style(
+                                width="400px",
+                                margin=me.Margin(top=16),
+                                border_radius=12,
+                            ),
+                        )
 
-                with me.box(style=me.Style(width="calc(50% - 8px)", display="flex", flex_direction="column", align_items="center")):
+                with me.box(
+                    style=me.Style(
+                        width="calc(50% - 8px)",
+                        display="flex",
+                        flex_direction="column",
+                        align_items="center",
+                    )
+                ):
                     me.uploader(
                         label="Upload Product Image",
                         on_upload=lambda e: on_upload_product(e),
@@ -37,48 +73,83 @@ def vto():
                         key="product_uploader",
                     )
                     if state.product_image_gcs:
-                        me.image(src=state.product_image_gcs, style=me.Style(width="400px", margin=me.Margin(top=16), border_radius=12))
+                        me.image(
+                            src=state.product_image_gcs,
+                            style=me.Style(
+                                width="400px",
+                                margin=me.Margin(top=16),
+                                border_radius=12,
+                            ),
+                        )
 
             with me.box(style=me.Style(width="400px", margin=me.Margin(top=16))):
-                with me.box(style=me.Style(display="flex", justify_content="space-between")):
-                    me.text("Number of images")
-                    me.text(f"{state.vto_sample_count}")
+                with me.box(
+                    style=me.Style(display="flex", justify_content="space-between"),
+                ):
+                    me.text(f"Number of images: {state.vto_sample_count}")
                 me.slider(
                     min=1,
                     max=4,
                     step=1,
                     value=state.vto_sample_count,
-                    on_value_change=lambda e: on_sample_count_change(e.value),
+                    on_value_change=on_sample_count_change,
                 )
 
-            with me.box(style=me.Style(display="flex", flex_direction="row", gap=16, margin=me.Margin(top=16))):
-              me.button("Generate", on_click=on_generate)
-              me.button("Clear", on_click=on_clear, type="stroked")
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    gap=16,
+                    margin=me.Margin(top=16),
+                )
+            ):
+                me.button("Generate", on_click=on_generate)
+                me.button("Clear", on_click=on_clear, type="stroked")
 
             if state.is_loading:
                 me.progress_spinner()
 
             if state.result_images:
                 print(f"Images: {state.result_images}")
-                with me.box(style=me.Style(display="flex", flex_wrap="wrap", gap=16, margin=me.Margin(top=16))):
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_wrap="wrap",
+                        gap=16,
+                        margin=me.Margin(top=16),
+                    )
+                ):
                     for image in state.result_images:
-                        me.image(src=image, style=me.Style(width="400px", border_radius=12))
+                        me.image(
+                            src=image, style=me.Style(width="400px", border_radius=12)
+                        )
+
 
 def on_upload_person(e: me.UploadEvent):
     """Upload person image handler"""
     state = me.state(PageState)
     state.person_image_file = e.file
-    gcs_url = store_to_gcs("vto_person_images", e.file.name, e.file.mime_type, e.file.getvalue())
-    state.person_image_gcs = gcs_url.replace("gs://", "https://storage.mtls.cloud.google.com/")
+    gcs_url = store_to_gcs(
+        "vto_person_images", e.file.name, e.file.mime_type, e.file.getvalue()
+    )
+    state.person_image_gcs = gcs_url.replace(
+        "gs://", "https://storage.mtls.cloud.google.com/"
+    )
     yield
+
 
 def on_upload_product(e: me.UploadEvent):
     """Upload product image handler"""
     state = me.state(PageState)
     state.product_image_file = e.file
-    gcs_url = store_to_gcs("vto_product_images", e.file.name, e.file.mime_type, e.file.getvalue())
-    state.product_image_gcs = gcs_url.replace("gs://", "https://storage.mtls.cloud.google.com/")
+    gcs_url = store_to_gcs(
+        "vto_product_images", e.file.name, e.file.mime_type, e.file.getvalue()
+    )
+    state.product_image_gcs = gcs_url.replace(
+        "gs://", "https://storage.mtls.cloud.google.com/"
+    )
     yield
+
 
 def on_generate(e: me.ClickEvent):
     """Generate VTO handler"""
@@ -88,7 +159,12 @@ def on_generate(e: me.ClickEvent):
     yield
 
     try:
-        result_gcs_uris = generate_vto_image(state.person_image_gcs, state.product_image_gcs, state.vto_sample_count, state.vto_base_steps)
+        result_gcs_uris = generate_vto_image(
+            state.person_image_gcs,
+            state.product_image_gcs,
+            state.vto_sample_count,
+            state.vto_base_steps,
+        )
         print(f"Result GCS URIs: {result_gcs_uris}")
         state.result_images = [
             uri.replace("gs://", "https://storage.mtls.cloud.google.com/")
@@ -108,10 +184,13 @@ def on_generate(e: me.ClickEvent):
         yield
     yield
 
-def on_sample_count_change(value: int):
+
+def on_sample_count_change(e: me.SliderValueChangeEvent):
+    """Handles changes to the sample count slider."""
     state = me.state(PageState)
-    state.vto_sample_count = value
+    state.vto_sample_count = int(e.value)
     yield
+
 
 def on_clear(e: me.ClickEvent):
     state = me.state(PageState)

--- a/experiments/veo-app/state/vto_state.py
+++ b/experiments/veo-app/state/vto_state.py
@@ -13,5 +13,6 @@ class PageState:
     vto_sample_count: int = 4
     vto_base_steps: int = 0
     is_loading: bool = False
+    is_generating_person_image: bool = False
     error_message: str = ""
     show_error_dialog: bool = False


### PR DESCRIPTION
feat(vto): add virtual model generation and UI improvements

This commit introduces a 'Create Virtual Model' button on the VTO page and addresses several UI bugs and experience improvements.

Key changes:
- Adds a 'Create Virtual Model' button that uses Imagen 4 Fast to  generate a person image directly, providing an alternative to uploading.
- Implements a loading spinner that displays while the virtual model is  being generated.
- Fixes a bug where the 'Number of images' slider did not update its  displayed value. The event handler was refactored to correctly trigger a UI update.
- Creates a consistent, styled container for the person and product   image upload areas. These containers now show a placeholder or a loading spinner for a better user experience.
- Corrects the aspect ratio of the generated virtual model to 1:1 to   ensure it fits properly within its container.
- Refactors the image generation model call to use a configuration   value instead of a hardcoded model name.
