### PR TITLE
feat(recontext): add Product in Scene page and functionality

### DIFF
--- a/experiments/veo-app/components/library/image_details.py
+++ b/experiments/veo-app/components/library/image_details.py
@@ -162,3 +162,26 @@ def image_details(item: MediaItem) -> None:
                                 width="200px", height="auto", border_radius="8px"
                             ),
                         )
+    if item.comment == "product recontext":
+        with me.box(style=me.Style(margin=me.Margin(top=16))):
+            me.text(
+                "Source Images",
+                style=me.Style(font_weight="bold", margin=me.Margin(bottom=8)),
+            )
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    gap=16,
+                    justify_content="center",
+                )
+            ):
+                for uri in item.source_images_gcs:
+                    me.image(
+                        src=uri.replace(
+                            "gs://", "https://storage.mtls.cloud.google.com/"
+                        ),
+                        style=me.Style(
+                            width="100px", height="auto", border_radius="8px"
+                        ),
+                    )

--- a/experiments/veo-app/components/recontext/image_thumbnail.py
+++ b/experiments/veo-app/components/recontext/image_thumbnail.py
@@ -1,0 +1,22 @@
+import mesop as me
+from typing import Callable
+
+@me.component
+def image_thumbnail(image_uri: str, index: int, on_remove: Callable):
+    with me.box(style=me.Style(position="relative", width=100, height=100)):
+        me.image(src=image_uri.replace("gs://", "https://storage.mtls.cloud.google.com/"), style=me.Style(width="100%", height="100%", border_radius=8, object_fit="cover"))
+        with me.box(
+            on_click=on_remove,
+            key=str(index),
+            style=me.Style(
+                background="rgba(0, 0, 0, 0.5)",
+                color="white",
+                position="absolute",
+                top=4,
+                right=4,
+                border_radius=50,
+                padding=me.Padding.all(4),
+                cursor="pointer",
+            ),
+        ):
+            me.icon("close")

--- a/experiments/veo-app/config/default.py
+++ b/experiments/veo-app/config/default.py
@@ -78,6 +78,7 @@ class Default:
     MODEL_IMAGEN4_FAST = "imagen-4.0-fast-generate-preview-06-06"
     MODEL_IMAGEN4_ULTRA = "imagen-4.0-ultra-generate-preview-06-06"
     MODEL_IMAGEN_EDITING = "imagen-3.0-capability-001"
+    MODEL_IMAGEN_PRODUCT_RECONTEXT: str = os.environ.get("MODEL_IMAGEN_PRODUCT_RECONTEXT", "imagen-product-recontext-preview-06-30")
 
     IMAGEN_GENERATED_SUBFOLDER: str = os.environ.get("IMAGEN_GENERATED_SUBFOLDER", "generated_images")
     IMAGEN_EDITED_SUBFOLDER: str = os.environ.get("IMAGEN_EDITED_SUBFOLDER", "edited_images")

--- a/experiments/veo-app/config/navigation.json
+++ b/experiments/veo-app/config/navigation.json
@@ -64,6 +64,13 @@
       "group": "workflows"
     },
     {
+      "id": 43,
+      "display": "Product in Scene",
+      "icon": "scene_based_layout",
+      "route": "/recontextualize",
+      "group": "workflows"
+    },
+    {
       "id": 50,
       "display": "Library",
       "icon": "perm_media",

--- a/experiments/veo-app/main.py
+++ b/experiments/veo-app/main.py
@@ -31,6 +31,7 @@ from pages.imagen import imagen_content
 from pages.library import library_content
 from pages.lyria import lyria_content
 from pages.portraits import motion_portraits_content
+from pages.recontextualize import recontextualize
 from pages.veo import veo_content
 from pages.vto import vto
 from state.state import AppState
@@ -175,6 +176,16 @@ def edit_images_page():
 def vto_page():
     """VTO Page"""
     vto()
+
+
+@me.page(
+    path="/recontextualize",
+    title="GenMedia Creative Studio - Product in Scene",
+    on_load=on_load,
+)
+def recontextualize_page():
+    """Recontextualize Page"""
+    recontextualize()
 
 
 @app.get("/__/auth/")

--- a/experiments/veo-app/pages/library.py
+++ b/experiments/veo-app/pages/library.py
@@ -171,6 +171,7 @@ def get_media_for_page(
                 if raw_item_data.get("gcsuri") is not None
                 else None,
                 gcs_uris=raw_item_data.get("gcs_uris", []),
+                source_images_gcs=raw_item_data.get("source_images_gcs", []),
                 prompt=str(raw_item_data.get("prompt"))
                 if raw_item_data.get("prompt") is not None
                 else None,
@@ -189,6 +190,9 @@ def get_media_for_page(
                 else None,
                 rewritten_prompt=str(raw_item_data.get("rewritten_prompt"))
                 if raw_item_data.get("rewritten_prompt") is not None
+                else None,
+                comment=str(raw_item_data.get("comment"))
+                if raw_item_data.get("comment") is not None
                 else None,
                 raw_data=raw_item_data,
             )

--- a/experiments/veo-app/pages/recontextualize.py
+++ b/experiments/veo-app/pages/recontextualize.py
@@ -1,0 +1,119 @@
+import mesop as me
+from dataclasses import field
+from components.header import header
+from components.page_scaffold import page_frame, page_scaffold
+from common.storage import store_to_gcs
+from models.image_models import recontextualize_product_in_scene
+from common.metadata import add_media_item
+from state.state import AppState
+from config.default import Default
+from components.recontext.image_thumbnail import image_thumbnail
+
+config = Default()
+
+@me.stateclass
+class PageState:
+    """Recontext Page State"""
+    uploaded_images: list[me.UploadedFile] = field(default_factory=list) # pylint: disable=invalid-field-call
+    uploaded_image_gcs_uris: list[str] = field(default_factory=list) # pylint: disable=invalid-field-call
+    prompt: str = ""
+    result_images: list[str] = field(default_factory=list) # pylint: disable=invalid-field-call
+    is_loading: bool = False
+    error_message: str = ""
+    show_error_dialog: bool = False
+
+@me.page(path="/recontextualize")
+def recontextualize():
+    state = me.state(PageState)
+
+    with page_scaffold():  # pylint: disable=not-context-manager
+        with page_frame():  # pylint: disable=not-context-manager
+            header("Product in Scene", "scene_based_layout")
+
+            with me.box(style=me.Style(display="flex", flex_direction="column", gap=16)):
+                me.uploader(
+                    label="Upload Product Images (1-4)",
+                    on_upload=on_upload,
+                    style=me.Style(width="100%"),
+                    key="product_uploader",
+                    multiple=True,
+                )
+
+                if state.uploaded_image_gcs_uris:
+                    with me.box(style=me.Style(display="flex", flex_wrap="wrap", gap=16)):
+                        for i, uri in enumerate(state.uploaded_image_gcs_uris):
+                            image_thumbnail(image_uri=uri, index=i, on_remove=on_remove_image)
+
+                me.input(
+                    label="Scene Prompt",
+                    on_input=lambda e: on_input_prompt(e.value),
+                    style=me.Style(width="100%"),
+                )
+
+                with me.box(style=me.Style(display="flex", flex_direction="row", gap=16)):
+                    me.button("Generate", on_click=on_generate, type="flat")
+                    me.button("Clear", on_click=on_clear, type="stroked")
+
+                if state.is_loading:
+                    with me.box(
+                        style=me.Style(
+                            display="flex", align_items="center", justify_content="center",
+                        )
+                    ):
+                        me.progress_spinner()
+
+                if state.result_images:
+                    with me.box(style=me.Style(display="flex", flex_wrap="wrap", gap=16, justify_content="center", margin=me.Margin(top=16))):
+                        for image in state.result_images:
+                            me.image(src=image, style=me.Style(width="400px", border_radius=12))
+
+def on_upload(e: me.UploadEvent):
+    state = me.state(PageState)
+    for file in e.files:
+        gcs_url = store_to_gcs("recontext_sources", file.name, file.mime_type, file.getvalue())
+        state.uploaded_image_gcs_uris.append(gcs_url)
+    yield
+
+def on_input_prompt(value: str):
+    state = me.state(PageState)
+    state.prompt = value
+    yield
+
+
+def on_remove_image(e: me.ClickEvent):
+    state = me.state(PageState)
+    del state.uploaded_image_gcs_uris[int(e.key)]
+    yield
+
+
+def on_generate(e: me.ClickEvent):
+    app_state = me.state(AppState)
+    state = me.state(PageState)
+    state.result_images = []
+    state.is_loading = True
+    yield
+
+    try:
+        result_gcs_uris = recontextualize_product_in_scene(state.uploaded_image_gcs_uris, state.prompt)
+        state.result_images = [uri.replace("gs://", "https://storage.mtls.cloud.google.com/") for uri in result_gcs_uris]
+        add_media_item(
+            user_email=app_state.user_email,
+            model=config.MODEL_IMAGEN_PRODUCT_RECONTEXT,
+            mime_type="image/png",
+            prompt=state.prompt,
+            gcs_uris=result_gcs_uris,
+            source_images_gcs=state.uploaded_image_gcs_uris,
+            comment="product recontext",
+        )
+    except Exception as e:
+        state.error_message = str(e)
+        state.show_error_dialog = True
+    finally:
+        state.is_loading = False
+        yield
+
+def on_clear(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.uploaded_image_gcs_uris = []
+    state.result_images = []
+    yield

--- a/experiments/veo-app/pages/vto.py
+++ b/experiments/veo-app/pages/vto.py
@@ -16,7 +16,7 @@ import uuid
 
 import mesop as me
 
-from common.metadata import add_vto_metadata
+from common.metadata import add_media_item
 from common.storage import store_to_gcs
 from components.header import header
 from components.page_scaffold import page_frame, page_scaffold
@@ -252,11 +252,13 @@ def on_generate(e: me.ClickEvent):
             uri.replace("gs://", "https://storage.mtls.cloud.google.com/")
             for uri in result_gcs_uris
         ]
-        add_vto_metadata(
+        add_media_item(
+            user_email=app_state.user_email,
+            model=config.VTO_MODEL_ID,
+            mime_type="image/png",
+            gcs_uris=result_gcs_uris,
             person_image_gcs=state.person_image_gcs,
             product_image_gcs=state.product_image_gcs,
-            result_image_gcs=result_gcs_uris,
-            user_email=app_state.user_email,
         )
     except Exception as e:
         state.error_message = str(e)

--- a/experiments/veo-app/requirements.txt
+++ b/experiments/veo-app/requirements.txt
@@ -88,7 +88,7 @@ google-auth-httplib2==0.2.0
     # via google-api-python-client
 google-cloud-aiplatform==1.103.0
     # via veo-app
-google-cloud-bigquery==3.34.0
+google-cloud-bigquery==3.35.0
     # via google-cloud-aiplatform
 google-cloud-core==2.4.3
     # via

--- a/experiments/veo-app/state/vto_state.py
+++ b/experiments/veo-app/state/vto_state.py
@@ -9,7 +9,7 @@ class PageState:
     person_image_gcs: str = ""
     product_image_file: me.UploadedFile = None
     product_image_gcs: str = ""
-    result_images: list[str] = field(default_factory=list)
+    result_images: list[str] = field(default_factory=list)  # pylint: disable=invalid-field-call
     vto_sample_count: int = 4
     vto_base_steps: int = 0
     is_loading: bool = False

--- a/experiments/veo-app/test/recontext_simple.py
+++ b/experiments/veo-app/test/recontext_simple.py
@@ -1,0 +1,147 @@
+"""
+Product Recontextualization brings Google's cutting edge Imagen model to generate high quality images of products "recontextualized" in new scenes and backgrounds.
+you will be exploring the features of Imagen Product Recontextualization using the Vertex AI Python SDK.
+You will
+
+* Generate images by providing images of a product
+  * (Optional) Set a product description
+* Supported product categories
+  * business and industrial
+  * clothing
+  * furniture
+  * garden and yard
+  * health and beauty
+  * jewelry
+  * shoes
+  * sporting goods
+  * toys and games
+
+Product recontextualization using Imagen with PredictionServiceClient
+"""
+
+import base64
+import io
+import os
+import re
+import timeit
+from typing import Any, Dict
+
+from google.cloud import aiplatform
+from google.cloud.aiplatform.gapic import PredictResponse
+
+PROJECT_ID = os.getenv("PROJECT_ID")
+LOCATION = "us-central1"
+RECONTEXT = "imagen-product-recontext-preview-06-30"
+api_regional_endpoint = f"{LOCATION}-aiplatform.googleapis.com"
+model_endpoint = (
+    f"projects/{PROJECT_ID}/locations/us-central1/publishers/google/models/{RECONTEXT}"
+)
+OUTPUT_GCS = os.getenv(
+    "OUTPUT_GCS", f"gs://{PROJECT_ID}-assets",
+)  # gs:// prefix required
+
+client_options = {"api_endpoint": api_regional_endpoint}
+client = aiplatform.gapic.PredictionServiceClient(client_options=client_options)
+
+
+def call_product_recontext(
+    image_bytes_list=None,
+    image_uris_list=None,
+    prompt=None,
+    product_description=None,
+    disable_prompt_enhancement: bool = False,
+    sample_count: int = 1,
+    base_steps=None,
+    safety_setting=None,
+    person_generation=None,
+    output_gcs=None,
+) -> PredictResponse:
+    instances = []
+
+    instance: Dict[str, Any] = {"productImages": []}
+
+    if image_bytes_list:
+        for product_image_bytes in image_bytes_list:
+            product_image = {"image": {"bytesBase64Encoded": product_image_bytes}}
+            instance["productImages"].append(product_image)
+
+    if image_uris_list:
+        for product_image_uri in image_uris_list:
+            product_image = {"image": {"gcsUri": product_image_uri}}
+            instance["productImages"].append(product_image)
+
+    if len(instance["productImages"]) == 0:
+        raise ValueError(
+            "No product images provided. At least one image must be provided."
+        )
+
+    if product_description:
+        instance["productImages"][0]["productConfig"] = {
+            "productDescription": product_description
+        }
+
+    if prompt:
+        instance["prompt"] = prompt
+
+    parameters = {"sampleCount": sample_count}
+
+    if base_steps:
+        parameters["baseSteps"] = base_steps
+
+    if safety_setting:
+        parameters["safetySetting"] = safety_setting
+
+    if person_generation:
+        parameters["personGeneration"] = person_generation
+
+    if disable_prompt_enhancement:
+        parameters["enhancePrompt"] = False
+    
+    if output_gcs:
+        parameters["storageUri"] = output_gcs
+
+    instances.append(instance)
+
+    start = timeit.default_timer()
+
+    response = client.predict(
+        endpoint=model_endpoint, instances=instances, parameters=parameters
+    )
+    end = timeit.default_timer()
+    print(f"Product Recontextualization took {end - start:.2f}s.")
+
+    return response
+
+
+prompt = ""
+product_description = ""
+
+# Parameters
+disable_prompt_enhancement = False
+sample_count = 1  # 1-4
+base_steps = None
+safety_setting = "block_low_and_above"  # ["block_low_and_above", "block_medium_and_above", "block_only_high", "block_none"]
+person_generation = "allow_adult"  # ["dont_allow", "allow_adult", "allow_all"]
+
+
+product_1 = "gs://genai-blackbelt-fishfooding-assets/vto_product_images/product_hawaiian_shirt.png"
+product_2 = "gs://genai-blackbelt-fishfooding-assets/images/generated_images/1752171998606/sample_0.png"
+product_3 = "gs://genai-blackbelt-fishfooding-assets/uploads/girlwithapearlearing_vermeer.jpg"
+
+r = call_product_recontext(
+    prompt=prompt,
+    #image_bytes_list=image_bytes_list,
+    image_uris_list=[
+        product_1, product_2, product_3,
+    ],
+    product_description=product_description,
+    disable_prompt_enhancement=disable_prompt_enhancement,
+    sample_count=sample_count,
+    base_steps=base_steps,
+    safety_setting=safety_setting,
+    person_generation=person_generation,
+    output_gcs=OUTPUT_GCS,
+)
+print(r)
+
+print(list(r.predictions))

--- a/experiments/veo-app/uv.lock
+++ b/experiments/veo-app/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.34.0"
+version = "3.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -449,9 +449,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/f9/e9da2d56d7028f05c0e2f5edf6ce43c773220c3172666c3dd925791d763d/google_cloud_bigquery-3.34.0.tar.gz", hash = "sha256:5ee1a78ba5c2ccb9f9a8b2bf3ed76b378ea68f49b6cac0544dc55cc97ff7c1ce", size = 489091, upload-time = "2025-05-29T17:18:06.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/ee/fc5e651899abd7b7c631afc270fc668c4d757d27403c8ec2c11f0588f226/google_cloud_bigquery-3.35.0.tar.gz", hash = "sha256:b3db627355303ac52e07548d448d6c6cb87e52d80c88e57599cdd64185f40664", size = 496456, upload-time = "2025-07-16T00:36:44.83Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/7e/7115c4f67ca0bc678f25bff1eab56cc37d06eb9a3978940b2ebd0705aa0a/google_cloud_bigquery-3.34.0-py3-none-any.whl", hash = "sha256:de20ded0680f8136d92ff5256270b5920dfe4fae479f5d0f73e90e5df30b1cf7", size = 253555, upload-time = "2025-05-29T17:18:02.904Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2c/663be60fe7c4090d84267a17204fceaa4efd541000325d4f9690f6c6fcdc/google_cloud_bigquery-3.35.0-py3-none-any.whl", hash = "sha256:8c98e304d47c82f1fbba77b2f4c1e6c458474842d713ee117d9c58e61b74a70d", size = 256874, upload-time = "2025-07-16T00:36:43.292Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit introduces the new "Product in Scene" feature, allowing users to upload multiple product images, provide a scene prompt, and generate a new image with the products recontextualized into that scene.

This is a comprehensive feature that includes a new page, backend model integration, state management, and library integration.

Key changes:

- **New Page (`pages/recontextualize.py`):**
    - Creates a new page at the `/recontextualize` route.
    - Implements a multi-file uploader allowing users to select 1-4 source images.
    - Displays thumbnails of uploaded images with the ability to remove individual images.
    - Includes a "Clear" button to reset the interface.

- **Backend (`models/image_models.py`):**
    - Adds a new `recontextualize_product_in_scene` function to call the `imagen-product-recontext` model via the PredictionServiceClient.
    - Configures the model name in `config/default.py` to be sourced from environment variables.

- **Metadata and State:**
    - Adds a `source_images_gcs` field to the `MediaItem` dataclass in `common/metadata.py` to store the input images.
    - Refactors the `add_media_item` function to be more flexible, accepting `**kwargs` to handle unique metadata for different generation types.
    - The VTO page is updated to use this new function, ensuring its specific metadata (`person_image_gcs`, `product_image_gcs`) is preserved.
    - Creates a co-located `PageState` in `pages/recontextualize.py` to manage its UI state, correcting a previous architectural error.

- **Library Integration:**
    - Updates the Library page to correctly parse and display items generated by the new feature.
    - The details dialog for a "product recontext" item now displays the source images used for the generation.

- **Bug Fixes and Refinements:**
    - Corrects a `NameError` by co-locating the `PageState` with its corresponding page logic.
    - Fixes multiple `AttributeError`s by using correct Mesop components (`me.box` with `me.icon` instead of the non-existent `me.icon_button`) and type hints (`Callable` instead of `me.EventHandler`).
    - Ensures the "Generate" button clears previous results for a better user experience.

- **Documentation:**
    - Updates `developers_guide.md` with a new "Core Development Patterns and Lessons Learned" section to capture key architectural conventions and best practices discovered during this feature's development.