### PR TITLE
feat(recontext): add image limits and error handling

### DIFF
--- a/experiments/veo-app/components/dialog.py
+++ b/experiments/veo-app/components/dialog.py
@@ -20,7 +20,7 @@ import mesop as me
 
 @me.content_component
 def dialog(is_open: bool, dialog_style: Optional[me.Style] = None, key: Optional[str] = None):
-    """Renders a dialog component.
+    """Render a dialog component.
 
     The design of the dialog borrows from the Angular component dialog. So basically
     rounded corners and some box shadow.

--- a/experiments/veo-app/models/image_models.py
+++ b/experiments/veo-app/models/image_models.py
@@ -176,7 +176,7 @@ def generate_image_for_vto(prompt: str) -> bytes:
         raise ValueError("Image generation failed or returned no data.")
 
 
-def recontextualize_product_in_scene(image_uris_list: list[str], prompt: str) -> list[str]:
+def recontextualize_product_in_scene(image_uris_list: list[str], prompt: str, sample_count: int) -> list[str]:
     """Recontextualizes a product in a scene and returns a list of GCS URIs."""
     cfg = Default()
     client_options = {"api_endpoint": f"{cfg.LOCATION}-aiplatform.googleapis.com"}
@@ -192,7 +192,7 @@ def recontextualize_product_in_scene(image_uris_list: list[str], prompt: str) ->
     if prompt:
         instance["prompt"] = prompt
 
-    parameters = {"sampleCount": 1}
+    parameters = {"sampleCount": sample_count}
 
     response = client.predict(
         endpoint=model_endpoint, instances=[instance], parameters=parameters

--- a/experiments/veo-app/pages/veo.py
+++ b/experiments/veo-app/pages/veo.py
@@ -298,22 +298,22 @@ def on_upload_last_image(e: me.UploadEvent):
         state.show_error_dialog = True
     yield
 
-def on_upload_image(e: me.UploadEvent):
-    """Upload image to GCS and update state."""
-    state = me.state(PageState)
-    try:
-        # Store the uploaded file to GCS
-        gcs_path = store_to_gcs(
-            "uploads", e.file.name, e.file.mime_type, e.file.getvalue()
-        )
-        # Update the state with the new image details
-        state.reference_image_gcs = gcs_path
-        state.reference_image_uri = gcs_path.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
-        state.reference_image_mime_type = e.file.mime_type
-        print(f"Image uploaded to {gcs_path} with mime type {e.file.mime_type}")
-    except Exception as ex:
-        state.error_message = f"Failed to upload image: {ex}"
-        state.show_error_dialog = True
-    yield
+# def on_upload_image(e: me.UploadEvent):
+#     """Upload image to GCS and update state."""
+#     state = me.state(PageState)
+#     try:
+#         # Store the uploaded file to GCS
+#         gcs_path = store_to_gcs(
+#             "uploads", e.file.name, e.file.mime_type, e.file.getvalue()
+#         )
+#         # Update the state with the new image details
+#         state.reference_image_gcs = gcs_path
+#         state.reference_image_uri = gcs_path.replace(
+#             "gs://", "https://storage.mtls.cloud.google.com/"
+#         )
+#         state.reference_image_mime_type = e.file.mime_type
+#         print(f"Image uploaded to {gcs_path} with mime type {e.file.mime_type}")
+#     except Exception as ex:
+#         state.error_message = f"Failed to upload image: {ex}"
+#         state.show_error_dialog = True
+#     yield

--- a/experiments/veo-app/pages/vto.py
+++ b/experiments/veo-app/pages/vto.py
@@ -134,7 +134,7 @@ def vto():
                     gap=10,
                     align_items="center",
                     justify_content="center",
-                )
+                ),
             ):
                 with me.box(style=me.Style(margin=me.Margin(top=16))):
                     with me.box(
@@ -157,7 +157,7 @@ def vto():
             if state.is_loading:
                 with me.box(
                     style=me.Style(
-                        display="flex", align_items="center", justify_content="center"
+                        display="flex", align_items="center", justify_content="center",
                     )
                 ):
                     me.progress_spinner()


### PR DESCRIPTION
This commit adds several key features and bug fixes to the "Product in Scene" page to improve user experience and robustness.

Key changes:
- **Input Limit:** The UI now correctly limits the number of uploaded source images to 3, matching the likely API constraint.
- **Output Slider:** A slider has been added to allow the user to select between 1 and 4 output images, giving them more control over the generation.
- **Error Handling:** Implemented a proper error dialog. Previously, API errors were "swallowed," leaving the UI in a confusing state. Now, any backend failure will be displayed to the user in a dialog box.
- **Logging:** Added a log statement to print the source image GCS URIs being used for each generation, improving debuggability.
- **Bug Fixes:**
    - Corrected a `NameError` by co-locating the `PageState` class within `pages/recontextualize.py`, adhering to the project's architectural pattern for page-specific state.
    - Fixed multiple `AttributeError` and `TypeError` issues related to incorrect usage of Mesop components (`me.button` vs. a clickable `me.box` with `me.icon`) and the custom `dialog` component, which does not have an `on_close` parameter.