### PR TITLE
Feat/veo3 1080p

### DIFF
--- a/experiments/veo-app/common/metadata.py
+++ b/experiments/veo-app/common/metadata.py
@@ -56,6 +56,7 @@ class MediaItem:
 
     # Video specific (some may also apply to Image/Audio)
     aspect: Optional[str] = None  # e.g., "16:9", "1:1" (also for Image)
+    resolution: Optional[str] = None # e.g., "720p", "1080p"
     duration: Optional[float] = None  # Seconds (also for Audio)
     reference_image: Optional[str] = None  # GCS URI for I2V
     last_reference_image: Optional[str] = None  # GCS URI for I2V interpolation end frame
@@ -86,10 +87,10 @@ def add_media_item_to_firestore(item: MediaItem):
         # Or raise an exception: raise ConnectionError("Firestore client not initialized")
         return
 
-    # Prepare data for Firestore, excluding None values and raw_data
+    # Prepare data for Firestore, excluding None values and the 'id' field
     firestore_data = {}
     for f in field_names(item):
-        if f == "raw_data" or f == "id":  # Exclude raw_data and id from direct storage like this
+        if f == "id":  # Exclude id from direct storage
             continue
         value = getattr(item, f)
         if value is not None:
@@ -206,6 +207,9 @@ def get_media_item_by_id(
                 else None,
                 critique=str(raw_item_data.get("critique"))
                 if raw_item_data.get("critique") is not None
+                else None,
+                resolution=str(raw_item_data.get("resolution"))
+                if raw_item_data.get("resolution") is not None
                 else None,
                 raw_data=raw_item_data,
             )

--- a/experiments/veo-app/components/veo/generation_controls.py
+++ b/experiments/veo-app/components/veo/generation_controls.py
@@ -56,6 +56,20 @@ def generation_controls():
             disabled=selected_config.min_duration == selected_config.max_duration,
         )
 
+        # Resolution Selector
+        me.select(
+            label="resolution",
+            options=[
+                me.SelectOption(label=res, value=res)
+                for res in selected_config.resolutions
+            ],
+            appearance="outline",
+            style=me.Style(),
+            value=state.resolution,
+            on_selection_change=on_selection_change_resolution,
+            disabled=len(selected_config.resolutions) <= 1,
+        )
+
         # Prompt Enhancement Checkbox
         me.checkbox(
             label="auto-enhance prompt",
@@ -90,6 +104,12 @@ def on_selection_change_aspect(e: me.SelectSelectionChangeEvent):
     state.aspect_ratio = e.value
 
 
+def on_selection_change_resolution(e: me.SelectSelectionChangeEvent):
+    """Adjust resolution based on user event."""
+    state = me.state(PageState)
+    state.resolution = e.value
+
+
 def on_selection_change_model(e: me.SelectSelectionChangeEvent):
     """Adjust model based on user event and apply its constraints."""
     state = me.state(PageState)
@@ -101,6 +121,7 @@ def on_selection_change_model(e: me.SelectSelectionChangeEvent):
         state.aspect_ratio = new_config.supported_aspect_ratios[0]
         state.video_length = new_config.default_duration
         state.auto_enhance_prompt = new_config.supports_prompt_enhancement
+        state.resolution = new_config.resolutions[0]
         
         # If the current mode is no longer supported, default to the first supported mode.
         if state.veo_mode not in new_config.supported_modes:
@@ -111,3 +132,4 @@ def on_change_auto_enhance_prompt(e: me.CheckboxChangeEvent):
     """Toggle auto-enhance prompt"""
     state = me.state(PageState)
     state.auto_enhance_prompt = e.checked
+''

--- a/experiments/veo-app/config/veo_models.py
+++ b/experiments/veo-app/config/veo_models.py
@@ -23,6 +23,7 @@ class VeoModelConfig:
     display_name: str
     supported_modes: List[str]
     supported_aspect_ratios: List[str]
+    resolutions: List[str]
     min_duration: int
     max_duration: int
     default_duration: int
@@ -38,6 +39,7 @@ VEO_MODELS: List[VeoModelConfig] = [
         display_name="Veo 2.0",
         supported_modes=["t2v", "i2v", "interpolation"],
         supported_aspect_ratios=["16:9", "9:16"],
+        resolutions=["720p"],
         min_duration=5,
         max_duration=8,
         default_duration=5,
@@ -51,6 +53,7 @@ VEO_MODELS: List[VeoModelConfig] = [
         display_name="Veo 3.0",
         supported_modes=["t2v", "i2v"],
         supported_aspect_ratios=["16:9"],
+        resolutions=["720p", "1080p"],
         min_duration=8,
         max_duration=8,
         default_duration=8,
@@ -64,6 +67,7 @@ VEO_MODELS: List[VeoModelConfig] = [
         display_name="Veo 3.0 Fast",
         supported_modes=["t2v", "i2v"],
         supported_aspect_ratios=["16:9"],
+        resolutions=["720p", "1080p"],
         min_duration=8,
         max_duration=8,
         default_duration=8,

--- a/experiments/veo-app/models/requests.py
+++ b/experiments/veo-app/models/requests.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional
 
 from pydantic import BaseModel, Field

--- a/experiments/veo-app/models/requests.py
+++ b/experiments/veo-app/models/requests.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class VideoGenerationRequest(BaseModel):
+    """
+    Defines the contract for a video generation request.
+    This schema is used by the UI to call the model layer and will be
+    the schema for the future FastAPI endpoint.
+    """
+
+    prompt: str
+    duration_seconds: int = Field(..., gt=0)
+    aspect_ratio: str
+    resolution: str
+    enhance_prompt: bool
+    model_version_id: str
+    reference_image_gcs: Optional[str] = None
+    last_reference_image_gcs: Optional[str] = None
+    reference_image_mime_type: Optional[str] = None
+    last_reference_image_mime_type: Optional[str] = None

--- a/experiments/veo-app/pages/library.py
+++ b/experiments/veo-app/pages/library.py
@@ -145,7 +145,7 @@ def get_media_for_page(
             elif hasattr(raw_timestamp, "isoformat"):  # For Firestore Timestamp objects
                 timestamp_iso_str = raw_timestamp.isoformat()
 
-            print(f"DEBUG: Fetched item with timestamp: {timestamp_iso_str}")
+            # print(f"DEBUG: Fetched item with timestamp: {timestamp_iso_str}")
 
             try:
                 gen_time = (

--- a/experiments/veo-app/pages/library.py
+++ b/experiments/veo-app/pages/library.py
@@ -197,6 +197,9 @@ def get_media_for_page(
                 comment=str(raw_item_data.get("comment"))
                 if raw_item_data.get("comment") is not None
                 else None,
+                resolution=str(raw_item_data.get("resolution"))
+                if raw_item_data.get("resolution") is not None
+                else None,
                 raw_data=raw_item_data,
             )
             all_fetched_items.append(media_item)
@@ -489,6 +492,8 @@ def library_content(app_state: me.state):
                                         pill(m_item.aspect, "aspect")
                                     if m_item.duration is not None:
                                         pill(item_duration_str, "duration")
+                                    if m_item.resolution:
+                                        pill(m_item.resolution, "resolution")
                                     pill("24 fps", "fps")
                                     if (
                                         m_item.enhanced_prompt_used
@@ -834,6 +839,9 @@ def library_content(app_state: me.state):
                         ):
                             if item.duration is not None:
                                 me.text(f"Duration: {item.duration} seconds")
+
+                        if dialog_media_type_group == "video":
+                            me.text(f"Resolution: {item.resolution or '720p'}")
 
                         if dialog_media_type_group == "video":
                             if item.reference_image:

--- a/experiments/veo-app/plans/VEO_1080P_PLAN.md
+++ b/experiments/veo-app/plans/VEO_1080P_PLAN.md
@@ -1,0 +1,71 @@
+# Definitive Plan: Refactor and Enhance Veo Generation for 1080p Support
+
+**Guiding Principle:** Refactor the video generation process to establish a clean, formal boundary between the "frontend" (the Mesop UI) and the "backend" (the model logic). This will be achieved by creating a dedicated request schema, making the model logic independent of the UI, and preparing the codebase for an easy future transition to a dedicated API service like FastAPI.
+
+---
+
+### Detailed Implementation & Task Checklist
+
+This section details every change made during this session, organized by architectural layer.
+
+**Phase 1: Defining the Data Schemas & Contracts** `[X]`
+
+*   `[X]` **API Contract (`models/requests.py`):** Created a new file to define a Pydantic `VideoGenerationRequest` model. This acts as a formal, version-controlled contract between the UI and the model layer.
+*   `[X]` **Model Configuration (`config/veo_models.py`):** Added the `resolutions: List[str]` attribute to the `VeoModelConfig` dataclass and populated the list for all existing Veo models.
+*   `[X]` **Database Schema (`common/metadata.py`):** Promoted `resolution` to a first-class citizen by adding `resolution: Optional[str] = None` as a top-level field to the `MediaItem` dataclass.
+*   `[X]` **UI State (`state/veo_state.py`):** Added the `resolution: str` field to the `PageState` class to hold the user's selection from the UI.
+
+**Phase 2: Refactoring the Backend Logic** `[X]`
+
+*   `[X]` **Model Layer (`models/veo.py`):** Refactored the `generate_video` function. Its signature was changed from `(state, resolution)` to `(request: VideoGenerationRequest)`, making it completely independent of the Mesop UI framework.
+
+**Phase 3: Refactoring the Frontend Logic** `[X]`
+
+*   `[X]` **UI Controller (`pages/veo.py`):** Refactored the `on_click_veo` event handler. It now acts as a translator, creating a formal `VideoGenerationRequest` object from the UI state and passing it to the decoupled model layer.
+*   `[X]` **UI Component (`components/veo/generation_controls.py`):** Modified the "Resolution" `me.select` component to be always visible, but conditionally `disabled` based on the capabilities of the selected Veo model.
+
+**Phase 4: Updating Data Handling & Display** `[X]`
+
+*   `[X]` **Data Write (`pages/veo.py`):** Updated the `on_click_veo` handler to populate the top-level `item_to_log.resolution` field before saving to Firestore.
+*   `[X]` **Data Read (`common/metadata.py`):** Updated the `get_media_item_by_id` and `get_media_for_page` functions to correctly read the new top-level `resolution` field from Firestore documents.
+*   `[X]` **Data Display (`pages/library.py`):** Updated the library UI to correctly display the resolution. This includes the `pill` in the grid view and the text in the details dialog, both of which now read from the top-level `item.resolution` field and default to `"720p"` if it's not present.
+
+---
+
+### Verification Checklist (Manual)
+
+*   `[ ]` **Veo Page UI Verification:**
+    *   `[ ]` **Test Case 1 (Veo 2 Model):** Select a Veo 2 model. **Expected:** The "Resolution" dropdown is visible but *disabled*, and its value is "720p".
+    *   `[ ]` **Test Case 2 (Veo 3 Model):** Select a Veo 3 model. **Expected:** The "Resolution" dropdown is visible and *enabled*, allowing selection between "720p" and "1080p".
+*   `[ ]` **Generation & Firestore Verification:**
+    *   `[ ]` **Test Case 3 (1080p Generation):** Generate a 1080p video with a Veo 3 model. Inspect the new Firestore document. **Expected:** The document contains a top-level field `"resolution": "1080p"`.
+*   `[ ]` **Library Display Verification:**
+    *   `[ ]` **Test Case 4 (New Video):** Open the 1080p video from the previous test in the library. **Expected:** The details dialog shows "Resolution: 1080p".
+    *   `[ ]` **Test Case 5 (Old Video):** Find an older video generated before this change. **Expected:** The details dialog shows "Resolution: 720p" as a fallback.
+
+---
+
+### Architectural Justification & Future-Proofing
+
+This refactoring is a strategic investment in the application's maintainability and future scalability.
+
+**1. Separation of Concerns:** The core benefit is creating a strong boundary between the UI (the "what") and the backend logic (the "how").
+    *   The **UI Layer** (`pages/veo.py`) is responsible for gathering user input.
+    *   The **Model Layer** (`models/veo.py`) is responsible for executing the business logic of video generation.
+    *   The **Contract** (`models/requests.py`) is the single, unambiguous bridge between them.
+
+**2. Preparing for a FastAPI Backend:** This architecture makes a future migration to a dedicated backend service trivial.
+
+*   **Current Flow:**
+    ```
+    Mesop UI State -> VideoGenerationRequest -> generate_video(request)
+    ```
+    The Mesop event handler acts as the "client" that builds the request object.
+
+*   **Future FastAPI Flow:**
+    ```
+    HTTP POST with JSON -> VideoGenerationRequest -> generate_video(request)
+    ```
+    In the future, a FastAPI endpoint will receive an HTTP request. FastAPI will automatically parse the JSON body, validate it against the *exact same* `VideoGenerationRequest` model, and then call the *exact same* `generate_video` function.
+
+The critical `generate_video` function will require **zero changes** to work in the new FastAPI environment. We are effectively building the API-ready backend component *now* and simply calling it from our current UI.

--- a/experiments/veo-app/requirements.txt
+++ b/experiments/veo-app/requirements.txt
@@ -17,7 +17,7 @@ blinker==1.9.0
     # via flask
 cachecontrol==0.14.3
     # via firebase-admin
-cachetools==6.1.0
+cachetools==5.5.2
     # via google-auth
 certifi==2025.7.14
     # via
@@ -46,9 +46,9 @@ cycler==0.12.1
     # via matplotlib
 decorator==5.2.1
     # via ipython
-deepdiff==8.5.0
+deepdiff==6.7.1
     # via mesop
-docstring-parser==0.16
+docstring-parser==0.17.0
     # via google-cloud-aiplatform
 executing==2.2.0
     # via stack-data
@@ -99,7 +99,7 @@ google-cloud-firestore==2.21.0 ; platform_python_implementation != 'PyPy'
     # via firebase-admin
 google-cloud-resource-manager==1.14.2
     # via google-cloud-aiplatform
-google-cloud-storage==3.2.0
+google-cloud-storage==2.19.0
     # via
     #   firebase-admin
     #   google-cloud-aiplatform
@@ -107,7 +107,7 @@ google-crc32c==1.7.1
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-genai==1.26.0
+google-genai==1.20.0
     # via
     #   google-cloud-aiplatform
     #   veo-app
@@ -261,7 +261,7 @@ pydantic==2.11.7
     #   google-cloud-aiplatform
     #   google-genai
     #   mesop
-pydantic-core==2.35.2
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.2
     # via
@@ -306,7 +306,7 @@ sniffio==1.3.1
     # via anyio
 stack-data==0.6.3
     # via ipython
-starlette==0.47.1
+starlette==0.47.2
     # via fastapi
 tenacity==9.1.2
     # via veo-app

--- a/experiments/veo-app/state/veo_state.py
+++ b/experiments/veo-app/state/veo_state.py
@@ -30,6 +30,7 @@ class PageState:
     original_prompt: str
 
     aspect_ratio: str = "16:9"
+    resolution: str = "720p"
     video_length: int = 5  # 5-8
 
     # I2V reference Image

--- a/experiments/veo-app/uv.lock
+++ b/experiments/veo-app/uv.lock
@@ -265,11 +265,11 @@ wheels = [
 
 [[package]]
 name = "docstring-parser"
-version = "0.16"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/12/9c22a58c0b1e29271051222d8906257616da84135af9ed167c9e28f85cb3/docstring_parser-0.16.tar.gz", hash = "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e", size = 26565, upload-time = "2024-03-15T10:39:44.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl", hash = "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637", size = 36533, upload-time = "2024-03-15T10:39:41.527Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -1480,14 +1480,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.47.1"
+version = "0.47.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/69/662169fdb92fb96ec3eaee218cf540a629d629c86d7993d9651226a6789b/starlette-0.47.1.tar.gz", hash = "sha256:aef012dd2b6be325ffa16698f9dc533614fb1cebd593a906b90dc1025529a79b", size = 2583072, upload-time = "2025-06-21T04:03:17.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/95/38ef0cd7fa11eaba6a99b3c4f5ac948d8bc6ff199aabd327a29cc000840c/starlette-0.47.1-py3-none-any.whl", hash = "sha256:5e11c9f5c7c3f24959edbf2dffdc01bba860228acf657129467d8a7468591527", size = 72747, upload-time = "2025-06-21T04:03:15.705Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR  introduces support for 1080p video generation for Veo 3 models and refactors the underlying generation logic for improved architecture and future scalability.

Key changes:

- **1080p Resolution for Veo 3:**
  - Updates `config/veo_models.py` to include a `resolutions` capability list for each model.
  - Adds a "Resolution" selector to the Veo page UI (`components/veo/generation_controls.py`) that is conditionally enabled for Veo 3 models.

- **Architectural Refactoring:**
  - Decouples the model layer from the UI by introducing a formal `VideoGenerationRequest` Pydantic model in a new `models/requests.py` file.
  - The `models/veo.py:generate_video` function is refactored to accept this request object, making it API-ready and independent of the Mesop state.
  - The UI event handler in `pages/veo.py` now translates UI state into this formal request object.

- **Library and Metadata:**
  - Promotes `resolution` to a top-level field in the `common/metadata.py:MediaItem` dataclass for a cleaner Firestore schema.
  - Updates `pages/library.py` to display the video resolution in both the grid view and the details dialog, with a fallback to "720p" for older videos without this field.

- **Bug Fix:**
  - Fixes a critical bug where Veo 3 generations would fail with an internal error. The cause was a missing rule that enforces prompt enhancement on all Veo 3 models, which was lost during the initial refactoring and has now been restored in the model layer.