### PR TITLE
feat(otel): support insecure OTel exporter for local development

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/README.md
@@ -147,6 +147,25 @@ export PROJECT_ID="your-google-cloud-project-id"
 export LOCATION="us-central1"
 ```
 
+### Local Development & OpenTelemetry
+
+When running the MCP servers locally, you may want to connect to a local OpenTelemetry (OTel) collector for tracing. By default, the servers attempt a secure (TLS) connection. If your local collector is running in insecure mode, you will need to set the following environment variable to disable TLS:
+
+```bash
+# This tells the application to use an insecure connection for the OTLP exporter.
+export OTEL_EXPORTER_OTLP_INSECURE=true
+```
+
+When deploying the application to a production environment (like GKE, Cloud Run, etc.), you should **not** set this variable. The application will correctly default to requiring a secure TLS connection to the OTel collector.
+
+You can also specify the OTel collector endpoint using an environment variable:
+
+```bash
+# Example for a local collector
+export OTEL_EXPORTER_OTLP_ENDPOINT="localhost:4317"
+```
+If `OTEL_EXPORTER_OTLP_ENDPOINT` is not set, it will default to `localhost:4317`.
+
 Please refer to the `README.md` file within each server's subdirectory for detailed information on its specific tools, parameters, environment variables, and usage examples.
 
 ## Developing MCP Servers for Genmedia

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/otel.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/otel.go
@@ -3,38 +3,66 @@ package common
 import (
 	"context"
 	"log"
+	"os"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
-	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"google.golang.org/grpc"
 )
 
 // InitTracerProvider initializes and configures the OpenTelemetry tracer provider.
 // It sets up a GRPC exporter to send trace data and configures the tracer with
 // service name and version attributes. This is crucial for observability, allowing
 // for distributed tracing of requests as they flow through the system.
-func InitTracerProvider(serviceName, serviceVersion string) (*tracesdk.TracerProvider, error) {
+func InitTracerProvider(serviceName, serviceVersion string) (*sdktrace.TracerProvider, error) {
 	ctx := context.Background()
 
-	exporter, err := otlptracegrpc.New(ctx)
-	if err != nil {
-		return nil, err
+	// --- Recommended Configuration Logic ---
+
+	// Define the OTLP endpoint, which can also be set via environment variables.
+	// Example: OTEL_EXPORTER_OTLP_ENDPOINT="localhost:4317"
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "localhost:4317" // Default to localhost if not set.
 	}
 
-	tr := tracesdk.NewTracerProvider(
-		tracesdk.WithBatcher(exporter),
-		tracesdk.WithResource(resource.NewWithAttributes(
+	// Default to a secure connection.
+	opts := []otlptracegrpc.Option{
+		otlptracegrpc.WithEndpoint(endpoint),
+		otlptracegrpc.WithDialOption(grpc.WithBlock()),
+	}
+
+	// Check for the standard environment variable to enable insecure mode.
+	if os.Getenv("OTEL_EXPORTER_OTLP_INSECURE") == "true" {
+		log.Println("WARNING: Using insecure connection for OTLP exporter")
+		opts = append(opts, otlptracegrpc.WithInsecure())
+	}
+	// --- End of Recommended Logic ---
+
+	exporter, err := otlptracegrpc.New(ctx, opts...)
+	if err != nil {
+		log.Fatalf("failed to create OTLP trace exporter: %v", err)
+	}
+
+	// Create a new tracer provider.
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(serviceName),
 			semconv.ServiceVersionKey.String(serviceVersion),
 		)),
 	)
 
-	otel.SetTracerProvider(tr)
+	// Register the tracer provider as the global provider.
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 
 	log.Printf("Tracer provider initialized for service: %s, version: %s", serviceName, serviceVersion)
 
-	return tr, nil
+	return tp, nil
 }

--- a/experiments/mcp-genmedia/sample-agents/geminicli/README.md
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/README.md
@@ -66,6 +66,31 @@ A `sample_settings.json` is provided for your convenience.
 
 Please note, you can add `"trust": true` to any of the MCP Servers to allow trusting the MCP server and its tools to bypass confirmations. See the [Configuration docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md).
 
+### Local Development and Tracing
+
+If you are running a local OpenTelemetry (OTel) collector for tracing, you may need to configure the MCP servers to send traces to it using an insecure connection. You can do this by adding the `OTEL_EXPORTER_OTLP_INSECURE` environment variable to your `mcpServers` configuration in `settings.json` or your `gemini-extension.json` file.
+
+Here is an example of how to configure the `veo` server to use an insecure connection:
+
+```json
+{
+  "mcpServers": {
+    "veo": {
+      "command": "mcp-veo-go",
+      "env": {
+        "OTEL_EXPORTER_OTLP_INSECURE": "true",
+        "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "240000",
+        "MCP_SERVER_REQUEST_TIMEOUT": "30000",
+        "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORGE_BUCKET",
+        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+      }
+    }
+  }
+}
+```
+
+When this variable is set to `"true"`, the MCP server will connect to the OTel collector without using TLS. This is useful for local development, but should not be used in production.
+
 
 ## .gemini/extensions/google-genmedia Extension
 


### PR DESCRIPTION
Implements support for the standard `OTEL_EXPORTER_OTLP_INSECURE` environment variable. When set to "true", the OTel gRPC exporter will connect to the collector without TLS, which is a common setup for local development.

This change makes the MCP servers secure by default for production while significantly improving the developer experience for local tracing and debugging.

Updates the following documentation to reflect this new configuration:
- mcp-genmedia-go/README.md
- sample-agents/geminicli/README.md