### PR TITLE
feat(vto): Create virtual model generator and test page

### DIFF
--- a/experiments/veo-app/config/virtual_model_options.json
+++ b/experiments/veo-app/config/virtual_model_options.json
@@ -1,0 +1,65 @@
+{
+  "_citation": "Monk Skin Tone Scale License: Creative Commons Attribution 4.0 International license. Scale Usage Citation: Monk, Ellis. ‘Monk Skin Tone Scale,’ 2019. https://skintone.google",
+  "genders": [
+    {
+      "name": "Feminine-presenting",
+      "prompt_fragment": "a feminine-presenting"
+    },
+    {
+      "name": "Masculine-presenting",
+      "prompt_fragment": "a masculine-presenting"
+    },
+    {
+      "name": "Androgynous",
+      "prompt_fragment": "an androgynous"
+    }
+  ],
+  "MST": [
+    "MST-1",
+    "MST-2",
+    "MST-3",
+    "MST-4",
+    "MST-5",
+    "MST-6",
+    "MST-7",
+    "MST-8",
+    "MST-9",
+    "MST-10"
+  ],
+  "silhouette_presets": [
+    {
+      "name": "Linear & Balanced",
+      "description": "A streamlined form with a subtle waist, creating a clean, straight line through the torso.",
+      "prompt_fragment": "a linear and balanced silhouette where the shoulders, waist, and hips are elegantly aligned"
+    },
+    {
+      "name": "Tapered & Grounded",
+      "description": "A form defined by a tapered torso that gently widens from the waist to the hips.",
+      "prompt_fragment": "a tapered and grounded silhouette, with a torso that gently widens from the waist to the hips"
+    },
+    {
+      "name": "Inverted Triangle",
+      "description": "A silhouette defined by a broad upper body that tapers toward the hips.",
+      "prompt_fragment": "an inverted triangle silhouette, with broad shoulders and a torso that tapers toward the hips"
+    },
+    {
+      "name": "Classic Hourglass",
+      "description": "A silhouette with a distinctly narrow waist that balances a proportional bust and hips.",
+      "prompt_fragment": "a classic hourglass silhouette, with a distinctly narrow waist that balances a proportional bust and hips"
+    }
+  ],
+  "variants": [
+    {
+      "name": "Standard Pose",
+      "prompt_fragment": "facing forward with a natural, relaxed posture and a neutral expression"
+    },
+    {
+      "name": "Walking Pose",
+      "prompt_fragment": "in a walking pose, showing natural movement"
+    },
+    {
+      "name": "Smiling at Camera",
+      "prompt_fragment": "smiling and looking directly at the camera"
+    }
+  ]
+}

--- a/experiments/veo-app/main.py
+++ b/experiments/veo-app/main.py
@@ -40,6 +40,7 @@ from pages.portraits import motion_portraits_content
 from pages.recontextualize import recontextualize
 from pages.test_infinite_scroll import test_infinite_scroll_page
 from pages.test_uploader import test_uploader_page
+from pages.test_vto_prompt_generator import page as test_vto_prompt_generator_page
 from pages.veo import veo_content
 from pages.vto import vto
 from state.state import AppState

--- a/experiments/veo-app/models/virtual_model_generator.py
+++ b/experiments/veo-app/models/virtual_model_generator.py
@@ -1,0 +1,61 @@
+import json
+import random
+from pathlib import Path
+
+# The default prompt, used as a fallback if the user's prompt is invalid.
+DEFAULT_PROMPT = "A full-length studio shot of {gender} model with {silhouette}, posed for a virtual try-on application. The model has an {MST} skin tone. Lighting is bright and even, highlighting the model's form without harsh shadows. The model is {variant}. The focus is sharp and clear, capturing the details of clothing textures and fit, suitable for e-commerce apparel display."
+
+class VirtualModelGenerator:
+    """
+    A class to generate prompts for creating virtual models by substituting placeholders.
+    """
+
+    def __init__(self, base_prompt: str):
+        """
+        Initializes the VirtualModelGenerator with a base prompt.
+
+        Args:
+            base_prompt: The starting prompt to build upon, containing placeholders.
+        """
+        self.base_prompt = base_prompt
+        self.values = {}
+        self._load_options()
+
+    def _load_options(self):
+        """Loads the generation options from the JSON config file."""
+        config_path = Path(__file__).parent.parent / "config/virtual_model_options.json"
+        with open(config_path, "r") as f:
+            self.options = json.load(f)
+
+    def set_value(self, key: str, value: str):
+        """Sets a value for a given placeholder key."""
+        self.values[key] = value
+        return self
+
+    def randomize_all(self):
+        """Sets a random value for all major placeholders."""
+        self.set_value("gender", random.choice(self.options["genders"])["prompt_fragment"])
+        self.set_value("silhouette", random.choice(self.options["silhouette_presets"])["prompt_fragment"])
+        self.set_value("MST", random.choice(self.options["MST"]))
+        return self
+
+    def _validate_prompt(self, prompt_str: str) -> bool:
+        """Checks if the prompt string contains all required placeholders."""
+        required_placeholders = ["{gender}", "{MST}", "{silhouette}", "{variant}"]
+        return all(p in prompt_str for p in required_placeholders)
+
+    def build_prompt(self) -> str:
+        """
+        Builds the final prompt string by substituting placeholders.
+        If the base prompt is invalid, it reverts to the default.
+        """
+        prompt_template = self.base_prompt
+        if not self._validate_prompt(prompt_template):
+            print(f"Warning: Invalid prompt template: '{prompt_template}'. Reverting to default.")
+            prompt_template = DEFAULT_PROMPT
+
+        final_prompt = prompt_template
+        for key, value in self.values.items():
+            final_prompt = final_prompt.replace(f"{{{key}}}", value)
+        
+        return final_prompt

--- a/experiments/veo-app/pages/test_vto_prompt_generator.py
+++ b/experiments/veo-app/pages/test_vto_prompt_generator.py
@@ -1,0 +1,168 @@
+import random
+
+import mesop as me
+import mesop.labs as mel
+import json
+from pathlib import Path
+from dataclasses import field
+
+from models.image_models import generate_virtual_models
+from models.virtual_model_generator import VirtualModelGenerator, DEFAULT_PROMPT
+
+@me.stateclass
+class PageState:
+    base_prompt: str = DEFAULT_PROMPT
+    selected_gender_name: str = "Feminine-presenting"
+    selected_silhouette_name: str = "Linear & Balanced"
+    selected_mst: str = "MST-5"
+    generated_images: list[list[str]] = field(default_factory=list)
+    generated_description: str = ""
+    loading: bool = False
+
+    # Load options once
+    _options: dict = field(default_factory=dict, init=False)
+
+    def __post_init__(self):
+        config_path = Path(__file__).parent.parent / "config/virtual_model_options.json"
+        with open(config_path, "r") as f:
+            self._options = json.load(f)
+
+@me.page(
+    path="/test_vto_prompt_generator",
+    title="VTO Prompt Generator Test Page",
+    security_policy=me.SecurityPolicy(
+        dangerously_disable_trusted_types=True
+    )
+)
+def page():
+    state = me.state(PageState)
+    with me.box(style=me.Style(padding=me.Padding.all(20))):
+        me.text("VTO Prompt Generator Matrix", type="headline-5")
+        me.text("Generate a matrix of virtual models with different attributes.", style=me.Style(margin=me.Margin(bottom=20)))
+
+        # --- CONTROLS ---
+        with me.box(style=me.Style(display="flex", flex_direction="column", gap=20, margin=me.Margin(bottom=20))):
+            me.textarea(
+                label="Base Prompt",
+                value=state.base_prompt,
+                on_input=on_base_prompt_input,
+                rows=5,
+                style=me.Style(width="100%")
+            )
+            with me.box(style=me.Style(display="flex", gap=20)):
+                me.select(
+                    label="Gender Presentation",
+                    options=[me.SelectOption(label=g["name"], value=g["name"]) for g in state._options.get("genders", [])],
+                    value=state.selected_gender_name,
+                    on_selection_change=on_gender_select
+                )
+                me.select(
+                    label="Monk Skin Tone",
+                    options=[me.SelectOption(label=mst, value=mst) for mst in state._options.get("MST", [])],
+                    value=state.selected_mst,
+                    on_selection_change=on_mst_select
+                )
+
+        # --- SILHOUETTE PRESETS ---
+        me.text("Select a Silhouette Preset", type="headline-6", style=me.Style(margin=me.Margin(bottom=10)))
+        with me.box(style=me.Style(display="grid", grid_template_columns="repeat(auto-fill, minmax(250px, 1fr))", gap=15)):
+            for preset in state._options.get("silhouette_presets", []):
+                with me.box(
+                    key=preset["name"],
+                    on_click=on_select_silhouette,
+                    style=me.Style(
+                        border=me.Border.all(me.BorderSide(width=2, style="solid", color=me.theme_var("primary") if state.selected_silhouette_name == preset["name"] else me.theme_var("outline"))),
+                        padding=me.Padding.all(15),
+                        border_radius=12,
+                        cursor="pointer"
+                    )
+                ):
+                    me.text(preset["name"], type="subtitle-1")
+                    me.text(preset["description"], type="body-2")
+
+        with me.box(style=me.Style(display="flex", gap=10, margin=me.Margin(top=20))):
+            me.button("Generate Matrix", on_click=on_click_generate_matrix, type="raised")
+            me.button("I'm Feeling Lucky", on_click=on_click_randomize, type="flat")
+            me.button("Generate Description", on_click=on_click_generate_description, type="flat", disabled=not state.generated_images)
+
+        # --- GENERATED DESCRIPTION ---
+        if state.generated_description:
+            with me.box(style=me.Style(margin=me.Margin(top=20), background=me.theme_var("surface-container-lowest"), padding=me.Padding.all(15), border_radius=8)):
+                me.text("Generated Description", type="subtitle-2")
+                me.text(state.generated_description)
+
+
+        # --- IMAGE MATRIX ---
+        if state.loading:
+            me.progress_spinner()
+        elif state.generated_images:
+            me.text("Generated Models", type="headline-6", style=me.Style(margin=me.Margin(top=20, bottom=10)))
+            with me.box(style=me.Style(display="grid", grid_template_columns="repeat(3, 1fr)", gap=10)):
+                for image_url in state.generated_images[0]: # Displaying the first row of the matrix
+                    me.image(src=image_url.replace("gs://", "https://storage.mtls.cloud.google.com/"), style=me.Style(width="100%"))
+
+def on_base_prompt_input(e: me.InputEvent):
+    me.state(PageState).base_prompt = e.value
+
+def on_gender_select(e: me.SelectSelectionChangeEvent):
+    me.state(PageState).selected_gender_name = e.value
+
+def on_select_silhouette(e: me.ClickEvent):
+    me.state(PageState).selected_silhouette_name = e.key
+
+def on_mst_select(e: me.SelectSelectionChangeEvent):
+    me.state(PageState).selected_mst = e.value
+
+def on_click_randomize(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.selected_gender_name = random.choice(state._options.get("genders", []))["name"]
+    state.selected_silhouette_name = random.choice(state._options.get("silhouette_presets", []))["name"]
+    state.selected_mst = random.choice(state._options.get("MST", []))
+    yield
+
+def on_click_generate_matrix(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.loading = True
+    state.generated_images = []
+    state.generated_description = ""
+    yield
+
+    # Find the selected gender and silhouette objects to get their prompt_fragments
+    selected_gender_obj = next((g for g in state._options["genders"] if g["name"] == state.selected_gender_name), None)
+    selected_silhouette_obj = next((s for s in state._options["silhouette_presets"] if s["name"] == state.selected_silhouette_name), None)
+
+    if not selected_gender_obj or not selected_silhouette_obj:
+        print("Error: Could not find selected gender or silhouette.")
+        state.loading = False
+        yield
+        return
+
+    matrix = []
+    for variant in state._options.get("variants", []):
+        generator = VirtualModelGenerator(state.base_prompt)
+        generator.set_value("gender", selected_gender_obj["prompt_fragment"])
+        generator.set_value("silhouette", selected_silhouette_obj["prompt_fragment"])
+        generator.set_value("MST", state.selected_mst)
+        generator.set_value("variant", variant["prompt_fragment"])
+
+        prompt = generator.build_prompt()
+        print(f"Generating images for prompt: {prompt}")
+        image_urls = generate_virtual_models(prompt=prompt, num_images=1)
+        matrix.append(image_urls)
+
+    state.generated_images = matrix
+    state.loading = False
+    yield
+
+def on_click_generate_description(e: me.ClickEvent):
+    state = me.state(PageState)
+    
+    selected_gender_obj = next((g for g in state._options["genders"] if g["name"] == state.selected_gender_name), {})
+    selected_silhouette_obj = next((s for s in state._options["silhouette_presets"] if s["name"] == state.selected_silhouette_name), {})
+
+    description = (
+        f"A {selected_gender_obj.get('name', 'person')} with an {state.selected_mst} complexion. "
+        f"The model has a {selected_silhouette_obj.get('name', 'defined')} silhouette: {selected_silhouette_obj.get('description', '')}"
+    )
+    state.generated_description = description
+    yield


### PR DESCRIPTION
Implements a new system for generating diverse virtual models for e-commerce applications, showcased on a new test page.

This new feature includes:
- A `VirtualModelGenerator` class that uses a placeholder-based prompt system for flexibility and control.
- A data-driven configuration (`config/virtual_model_options.json`) for silhouette presets, gender presentation, and variants.
- Integration of the Monk Skin Tone (MST) scale for more inclusive and representative skin tones.
- A new test page (`/test_vto_prompt_generator`) with a UI that features:
  - A gallery of selectable silhouette presets with descriptive text.
  - An "I'm Feeling Lucky" button to randomize model attributes.
  - A "Generate Description" button to create detailed metadata for the generated model.
- A new `generate_virtual_models` function in `image_models.py` to support multi-image generation.

Additionally, this change refactors the existing `generate_image_for_vto` function to use the new generator, resolving a regression and ensuring the original VTO page continues to function correctly by generating a single, randomized model.