### PR TITLE
refactor(v.next): limits original images in generation step, fixes #458

### DIFF
--- a/experiments/veo-app/models/character_consistency.py
+++ b/experiments/veo-app/models/character_consistency.py
@@ -138,7 +138,7 @@ def generate_character_video(
     client = genai.Client(vertexai=True, project=cfg.PROJECT_ID, location=cfg.LOCATION)
     edit_model = cfg.CHARACTER_CONSISTENCY_IMAGEN_MODEL
     reference_images_for_generation = []
-    for i, image_bytes in enumerate(reference_image_bytes_list):
+    for i, image_bytes in enumerate(reference_image_bytes_list[:4]):
         image = types.Image(image_bytes=image_bytes)
         reference_images_for_generation.append(
             types.SubjectReferenceImage(
@@ -148,7 +148,7 @@ def generate_character_video(
                     subject_type="SUBJECT_TYPE_PERSON",
                     subject_description=all_descriptions[i],
                 ),
-            )
+            ),
         )
     response = client.models.edit_image(
         model=edit_model,


### PR DESCRIPTION
Fixes #458  by limiting image generation step instead of using # of original images