### PR TITLE
Make $PATH updates relative instead of absolute

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
@@ -52,7 +52,7 @@ check_path() {
     echo "The MCP server binaries will be installed there."
     echo "To run them from your command line, please add the following line to your shell configuration file (e.g., ~/.bashrc, ~/.zshrc):"
     echo ""
-    echo -e "  ${BLUE}export PATH=\"$PATH:$HOME/go/bin\"${NC}"
+    echo -e "  ${BLUE}export PATH=\"\$PATH:$HOME/go/bin\"${NC}"
     echo ""
     echo "You will need to restart your shell or run 'source <your_config_file>' for the change to take effect."
     read -p "Press Enter to continue, or Ctrl+C to exit and configure your PATH."


### PR DESCRIPTION
Tool suggested:

```
  export PATH="/Users/tomasroggero/bin:/Users/tomasroggero/.nvm/versions/node/v22.18.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/git/git-google/bin:/usr/local/git/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/tomasroggero/.cargo/bin:/Users/tomasroggero/go/bin"
```

But in reality, the suggestion should be:

```
  export PATH="$PATH:/Users/tomasroggero/go/bin"
```

So that 1) it's more obvious what's getting added and 2) it doesn't hard-code values that may come from dynamic places (i.e., if upstream there was a PATH addition and eventually is removed)