### PR TITLE
fix: ignore changes to Cloud Run image and client properties

### DIFF
--- a/experiments/veo-app/main.tf
+++ b/experiments/veo-app/main.tf
@@ -190,6 +190,9 @@ resource "google_cloud_run_v2_service" "creative_studio" {
       max_instance_count = 1
     }
   }
+  lifecycle {
+    ignore_changes = [ template.containers[0].image, client ]
+  }
   depends_on = [
     google_service_account_iam_member.build_act_as_creative_studio,
     google_project_iam_member.build_logs_writer,


### PR DESCRIPTION
- Fixes #576 : Applying Terraform Template After Builds Resets Container Image Back to Placeholder
