### PR TITLE
feat(images): add removable thumbnails and automatic saving

### DIFF
--- a/experiments/veo-app/common/metadata.py
+++ b/experiments/veo-app/common/metadata.py
@@ -37,6 +37,7 @@ class MediaItem:
     """Represents a single media item in the library for Firestore storage and retrieval."""
 
     id: Optional[str] = None  # Firestore document ID
+    related_media_item_id: Optional[str] = None # For linking generation sequences
     user_email: Optional[str] = None
     timestamp: Optional[datetime.datetime] = None # Store as datetime object
 
@@ -92,6 +93,12 @@ class MediaItem:
 
     # Chirp and Gemini-TTS specific fields
     custom_pronunciations: List[dict[str, str]] = field(default_factory=list)
+    voice: Optional[str] = None
+    pace: Optional[float] = None
+    volume_gain_db: Optional[float] = None
+    language_code: Optional[str] = None
+    style_prompt: Optional[str] = None
+
 
 
 

--- a/experiments/veo-app/components/image_thumbnail.py
+++ b/experiments/veo-app/components/image_thumbnail.py
@@ -16,7 +16,11 @@ import mesop as me
 from typing import Callable
 
 @me.component
-def image_thumbnail(image_uri: str, index: int, on_remove: Callable):
+def image_thumbnail(image_uri: str, index: int, on_remove: Callable, icon_size: int = 18):
+    # Calculate the container dimension based on the icon size.
+    # This creates a consistent 4px "padding" on all sides.
+    box_dimension = icon_size + 8
+    
     with me.box(style=me.Style(position="relative", width=100, height=100)):
         me.image(src=image_uri.replace("gs://", "https://storage.mtls.cloud.google.com/"), style=me.Style(width="100%", height="100%", border_radius=8, object_fit="cover"))
         with me.box(
@@ -28,9 +32,13 @@ def image_thumbnail(image_uri: str, index: int, on_remove: Callable):
                 position="absolute",
                 top=4,
                 right=4,
-                border_radius=50,
-                padding=me.Padding.all(4),
+                border_radius="50%",  # Use 50% for a perfect circle
                 cursor="pointer",
+                display="flex",
+                align_items="center",
+                justify_content="center",
+                width=box_dimension,
+                height=box_dimension,
             ),
         ):
-            me.icon("close")
+            me.icon("close", style=me.Style(font_size=icon_size, transform="translate(2px, 3px)",))

--- a/experiments/veo-app/pages/chirp_3hd.py
+++ b/experiments/veo-app/pages/chirp_3hd.py
@@ -364,6 +364,10 @@ def on_click_generate(e: me.ClickEvent):
                 mime_type="audio/wav",
                 gcsuri=gcs_url,
                 custom_pronunciations=state.custom_pronunciations,
+                voice=state.selected_voice,
+                pace=state.speaking_rate,
+                volume=state.volume_gain_db,
+                language_code=state.selected_language
             )
             add_media_item_to_firestore(item)
             me.state(AppState).snackbar_message = "Audio saved to library"

--- a/experiments/veo-app/pages/gemini_tts.py
+++ b/experiments/veo-app/pages/gemini_tts.py
@@ -316,6 +316,9 @@ def on_click_generate(e: me.ClickEvent):
                 model=state.selected_model,
                 mime_type="audio/wav",
                 gcsuri=gcs_url,
+                voice=state.selected_voice,
+                language_code=state.selected_language,
+                style_prompt=state.prompt,
             )
             add_media_item_to_firestore(item)
             app_state.snackbar_message = "Audio saved to library"

--- a/experiments/veo-app/pages/recontextualize.py
+++ b/experiments/veo-app/pages/recontextualize.py
@@ -24,7 +24,7 @@ from components.header import header
 from components.library.events import LibrarySelectionChangeEvent
 from components.library.library_chooser_button import library_chooser_button
 from components.page_scaffold import page_frame, page_scaffold
-from components.recontext.image_thumbnail import image_thumbnail
+from components.image_thumbnail import image_thumbnail
 from config.default import Default, ABOUT_PAGE_CONTENT
 from models.image_models import recontextualize_product_in_scene
 from state.state import AppState
@@ -78,6 +78,7 @@ def recontextualize():
             with me.box(
                 style=me.Style(display="flex", flex_direction="column", gap=16),
             ):
+                me.text("Provide 1-3 images of a product, then recast it in a new scene of your choosing.")
                 if len(state.uploaded_image_gcs_uris) < 3:
                     with me.box(
                         style=me.Style(display="flex", flex_direction="row", gap=16, justify_content="center"),


### PR DESCRIPTION
This commit introduces two major feature enhancements to the Gemini Image Generation page: the ability to remove input images and a new, automatic, stateful saving workflow.

Key Changes:

- **Refactored Image Thumbnail Component:**
  - The `image_thumbnail` component was moved from its feature-specific directory to `components/` to be shared across the application.
  - Its CSS was improved to properly center the remove icon and have its background scale dynamically with the icon's size.
  - The component is now used on the Gemini page to allow users to remove specific input images before generation.

- **Automatic "Linked-List" Saving:**
  - The manual "Save" button has been removed in favor of an automatic saving workflow that better captures the iterative creative process.
  - A `related_media_item_id` field was added to the `MediaItem` data model to create a "linked-list" of generated assets.
  - After each generation, a new `MediaItem` is automatically created in Firestore, linking back to the previous generation in the session.
  - The "Clear" and "Continue" actions now correctly break this chain, starting a new session.