### PR TITLE
feat(library): Add multi-image count indicator

### DIFF
--- a/experiments/veo-app/components/library/image_details.py
+++ b/experiments/veo-app/components/library/image_details.py
@@ -56,7 +56,18 @@ def image_details(item: MediaItem) -> None:
         item: The MediaItem to display.
     """
     state = me.state(CarouselState)
+
+    # Handle case where there are no images to display.
+    if not item.gcs_uris:
+        me.text("Image data not available for this item.")
+        return
+
     num_images = len(item.gcs_uris)
+
+    # Defensively reset index if it's out of bounds. This can happen if the
+    # component is re-rendered with a new item that has fewer images.
+    if state.current_index >= num_images:
+        state.current_index = 0
 
     with me.box(
         style=me.Style(
@@ -76,26 +87,27 @@ def image_details(item: MediaItem) -> None:
             ),
         )
 
-        # Carousel controls
-        with me.box(
-            style=me.Style(
-                display="flex",
-                align_items="center",
-                justify_content="center",
-                gap=16,
-            )
-        ):
-            me.button(
-                "Back",
-                on_click=on_prev,
-                disabled=state.current_index == 0,
-            )
-            me.text(f"{state.current_index + 1} / {num_images}")
-            me.button(
-                "Next",
-                on_click=on_next,
-                disabled=state.current_index >= num_images - 1,
-            )
+        # Carousel controls - only show if there is more than one image.
+        if num_images > 1:
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    align_items="center",
+                    justify_content="center",
+                    gap=16,
+                )
+            ):
+                me.button(
+                    "Back",
+                    on_click=on_prev,
+                    disabled=state.current_index == 0,
+                )
+                me.text(f"{state.current_index + 1} / {num_images}")
+                me.button(
+                    "Next",
+                    on_click=on_next,
+                    disabled=state.current_index >= num_images - 1,
+                )
 
     if item.rewritten_prompt:
         me.text(f'Rewritten Prompt: "{item.rewritten_prompt}"')
@@ -187,3 +199,4 @@ def image_details(item: MediaItem) -> None:
                             width="100px", height="auto", border_radius="8px"
                         ),
                     )
+

--- a/experiments/veo-app/components/pill.py
+++ b/experiments/veo-app/components/pill.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Pill mesop component"""
+
 from typing import List, Optional
+
 import mesop as me
 
 
@@ -30,13 +32,17 @@ def pill(label: str, pill_type: str):
     elif pill_type == "aspect":
         background_color = me.theme_var("primary-container")
         text_color = me.theme_var("on-primarycontainer")
-    elif pill_type == "duration" or pill_type == "fps":
+    elif pill_type == "duration" or pill_type == "fps" or pill_type == "multi_image_count":
         background_color = me.theme_var("surface-variant")
         text_color = me.theme_var("on-surface-variant")
     elif pill_type == "resolution":
         background_color = me.theme_var("surface-container-high")
         text_color = me.theme_var("on-surface")
-    elif pill_type == "media_type_audio" or pill_type == "media_type_video" or pill_type == "media_type_image":
+    elif (
+        pill_type == "media_type_audio"
+        or pill_type == "media_type_video"
+        or pill_type == "media_type_image"
+    ):
         background_color = me.theme_var("inverse-primary")
         text_color = me.theme_var("on-surface-variant")
     elif pill_type == "error_present":
@@ -47,7 +53,6 @@ def pill(label: str, pill_type: str):
     elif pill_type == "stage":
         background_color = me.theme_var("secondary-container")
         text_color = me.theme_var("on-scecondary-container")
-    
 
     me.text(
         str(label),  # Ensure label is a string

--- a/experiments/veo-app/plans/LIBRARY_PAGINATION_REFACTOR_PLAN.md
+++ b/experiments/veo-app/plans/LIBRARY_PAGINATION_REFACTOR_PLAN.md
@@ -1,0 +1,65 @@
+# Library Pagination Refactor Plan
+
+This document outlines the long-term architectural changes required to fix pagination issues in the Library page.
+
+## Problem Summary
+
+The current library implementation suffers from two major issues:
+1.  **`list index out of range` errors:** The application crashes when trying to access pages of data that don't exist in its in-memory list.
+2.  **Inaccurate Pagination:** The total number of pages is calculated incorrectly, and users can get "stuck" on a page with no way to proceed.
+
+The root cause is that the application performs **client-side pagination** on a limited subset of data (the last 1000 items) fetched from Firestore, rather than performing true **server-side pagination**.
+
+## Proposed Solution: Server-Side Pagination
+
+To solve this robustly, the pagination logic must be moved from the Python client code to the Firestore query itself. This involves two major changes.
+
+### 1. Implement Cursor-Based Pagination
+
+The `get_media_for_page` function in `common/metadata.py` must be refactored.
+
+-   **Current State:** It fetches a large, fixed number of items and then slices the list in Python.
+-   **Future State:** It should accept a Firestore `DocumentSnapshot` as a "cursor" (or page token). The Firestore query will use this cursor with the `start_after()` method to fetch the next batch of documents directly from the server. This is the standard and scalable way to implement pagination in Firestore.
+
+This change will require modifications to the `PageState` in `pages/library.py` to store the cursor for the next and previous pages.
+
+### 2. Solve the "Total Page Count" Issue
+
+True server-side pagination makes it difficult to get the total count of items that match a filter without reading all the documents, which is slow and expensive. There are two viable options:
+
+#### Option A: Remove the Total Count (Simpler)
+
+-   **Implementation:** Remove the "Page X of Y" text from the UI. The "Next" button's state would be determined by the number of results in the current fetch. If the query for 9 items returns less than 9, we are on the last page, and the "Next" button is disabled.
+-   **Pros:** Easier to implement, avoids costly count operations.
+-   **Cons:** Degrades user experience slightly as the user doesn't know how many total pages exist.
+
+#### Option B: Implement Distributed Counters (More Complex)
+
+-   **Implementation:** Create a separate document in Firestore (e.g., in a `stats` collection) to hold the total count of media items. This counter would be updated using a Cloud Function that triggers whenever a new media item is created or deleted. For filtered counts, a more complex system of counters would be needed.
+-   **Pros:** Provides an accurate total count, offering the best user experience.
+-   **Cons:** Significantly more complex to implement and maintain. It requires setting up Cloud Functions and ensuring the counters are always in sync with the data.
+
+## Implementation Steps
+
+1.  **Refactor `get_media_for_page`:**
+    -   Modify its signature to accept an optional page cursor.
+    -   Change the query logic to use `start_after(cursor)`.
+    -   Remove the client-side list slicing.
+2.  **Update `pages/library.py` State:**
+    -   Modify `PageState` to store the cursor for the last document of the currently displayed page.
+3.  **Update Library UI Logic:**
+    -   The "Next" and "Previous" buttons in `handle_page_change` will now pass the stored cursor to the data fetching function.
+    -   Implement either Option A or B for handling the total page count and "Next" button state.
+4.  **Test Thoroughly:** Since `common/metadata.py` is a shared module, all other pages that use `get_media_for_page` must be tested to ensure they are not broken by this change.
+
+This refactor is a significant but necessary step to create a scalable and bug-free library experience.
+
+## Specific Test Cases for Verification
+
+After implementing the refactor, the following specific scenario, which previously caused bugs, must be tested to verify the fix:
+
+1.  **"Stuck on Backwards Pagination" Test:**
+    -   Navigate several pages forward into the library results (e.g., to page 5).
+    -   From that page, open the details dialog for an item, then close it.
+    -   Navigate backwards page by page.
+    -   **Expected Result:** The user should be able to paginate all the way back to page 1 without getting stuck. The "Previous" button should function correctly on every page.


### PR DESCRIPTION
Adds a pill component to the library grid that displays the total number of images for a media item when it is greater than one. Includes a corresponding style for the new pill.

fix(library): Resolve multiple UI and state bugs

This commit addresses several state management and rendering bugs in the library and media details view:

-   **Wrong Details on Click:** Replaces the unstable list index key on media items with the stable Firestore document ID, preventing the wrong details from being shown after filtering or state changes.
-   **Permalink Filter Bypass:** Ensures items loaded via a direct permalink are validated against the user's current filters (e.g., "Mine Only") before being displayed.
-   **Dialog Crash:** Prevents a `list index out of range` error in the `image_details` component by safely handling items with no associated images. This also fixes a cascading bug where the dialog would become unresponsive after the initial crash.
-   **Carousel State:** Resets the image carousel's index to 0 when the details dialog is closed, so it no longer starts at the previous position when viewing a new item.

docs(library): Create and update pagination refactor plan

Adds a new plan, `LIBRARY_PAGINATION_REFACTOR_PLAN.md`, to document the root causes of pagination bugs and outline a long-term, server-side pagination architecture. The plan is also updated with specific test cases identified during debugging.