### PR TITLE
refactor(gemini): Parameterize GCS storage path in image generation

### DIFF
--- a/experiments/veo-app/models/character_consistency.py
+++ b/experiments/veo-app/models/character_consistency.py
@@ -143,7 +143,11 @@ def generate_character_video(
         )
         # Generate images with Gemini
         gemini_future = executor.submit(
-            generate_image_from_prompt_and_images, final_prompt, reference_image_gcs_uris
+            generate_image_from_prompt_and_images,
+            final_prompt,
+            reference_image_gcs_uris,
+            gcs_folder="character_consistency_candidates",
+            file_prefix="candidate",
         )
 
         imagen_candidate_gcs_uris, imagen_candidate_image_bytes_list = imagen_future.result()

--- a/experiments/veo-app/models/gemini.py
+++ b/experiments/veo-app/models/gemini.py
@@ -56,7 +56,12 @@ cfg = Default()  # Instantiate config
 REWRITER_MODEL_ID = cfg.MODEL_ID  # Use default model from config for rewriter
 
 
-def generate_image_from_prompt_and_images(prompt: str, images: list[str]) -> tuple[list[str], float]:
+def generate_image_from_prompt_and_images(
+    prompt: str,
+    images: list[str],
+    gcs_folder: str = "generated_images",
+    file_prefix: str = "image",
+) -> tuple[list[str], float]:
     """Generates images from a prompt and a list of images."""
     start_time = time.time()
     model_name = cfg.GEMINI_IMAGE_GEN_MODEL
@@ -103,8 +108,8 @@ def generate_image_from_prompt_and_images(prompt: str, images: list[str]) -> tup
                 ):
                     mime_type = part.inline_data.mime_type
                 gcs_uri = store_to_gcs(
-                    folder="character_consistency_candidates",
-                    file_name=f"candidate_{uuid.uuid4()}_{i}.png",
+                    folder=gcs_folder,
+                    file_name=f"{file_prefix}_{uuid.uuid4()}_{i}.png",
                     mime_type=mime_type,
                     contents=part.inline_data.data,
                 )

--- a/experiments/veo-app/models/starter_pack.py
+++ b/experiments/veo-app/models/starter_pack.py
@@ -26,7 +26,10 @@ def generate_starter_pack_from_look(look_image_uri: str) -> str:
     """Generates a starter pack from a look image."""
     prompt = "Analyze the image to extract the featured products for a mood board. Lay out only the articles / items, and not the person."
     generated_images, _ = gemini.generate_image_from_prompt_and_images(
-        prompt=prompt, images=[look_image_uri]
+        prompt=prompt,
+        images=[look_image_uri],
+        gcs_folder="starter_pack_generations",
+        file_prefix="starter_pack_from_look",
     )
     if generated_images:
         return generated_images[0]
@@ -38,7 +41,10 @@ def generate_look_from_starter_pack(
     """Generates a look from a starter pack and model image."""
     prompt = "Try this ensemble on the given model."
     generated_images, _ = gemini.generate_image_from_prompt_and_images(
-        prompt=prompt, images=[starter_pack_uri, model_image_uri]
+        prompt=prompt,
+        images=[starter_pack_uri, model_image_uri],
+        gcs_folder="starter_pack_generations",
+        file_prefix="look_from_starter_pack",
     )
     if generated_images:
         return generated_images[0]

--- a/experiments/veo-app/pages/gemini_image_generation.py
+++ b/experiments/veo-app/pages/gemini_image_generation.py
@@ -353,6 +353,8 @@ def generate_images(e: me.ClickEvent):
         gcs_uris, execution_time = generate_image_from_prompt_and_images(
             prompt=state.prompt,
             images=state.uploaded_image_gcs_uris,
+            gcs_folder="gemini_image_generations",
+            file_prefix="gemini_image",
         )
 
         state.generation_time = execution_time


### PR DESCRIPTION
The shared `generate_image_from_prompt_and_images` function previously used a hardcoded GCS path that was specific to the Character Consistency feature. This caused images from other features (e.g., Gemini Image Generation, Starter Pack) to be saved to an incorrect and misleading location.

This commit refactors the function to accept optional `gcs_folder` and `file_prefix` parameters, allowing callers to specify a storage path. A generic default is provided.

All existing call sites have been updated:
- `character_consistency.py` is updated to pass its original, expected path, ensuring no change in behavior.
- `starter_pack.py` and `gemini_image_generation.py` are updated to save assets to their own dedicated, feature-specific folders.

This change improves asset organization, removes hardcoded values, and makes the shared function more robust and reusable.