### PR TITLE
refactor(library): Refactor library page into modular components

### DIFF
--- a/experiments/veo-app/components/library/audio_details.py
+++ b/experiments/veo-app/components/library/audio_details.py
@@ -1,0 +1,106 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Component for displaying audio details."""
+
+import json
+import mesop as me
+from common.metadata import MediaItem
+from datetime import datetime
+
+
+from typing import Callable
+
+@me.component
+def audio_details(item: MediaItem, on_click_permalink: Callable):
+    """Renders the details for an audio item."""
+    item_display_url = (
+        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
+        if item.gcsuri
+        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
+    )
+
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="column",
+            gap=12,
+            width="100%",
+            max_height="80vh",  # Max viewport height
+            overflow_y="auto",  # Scroll if content exceeds max height
+        )
+    ):
+
+        if item_display_url and not item.error_message:
+            me.audio(
+                src=item_display_url,
+            )
+
+        if item.error_message:
+            me.text(
+                f"Error: {item.error_message}",
+                style=me.Style(
+                    color=me.theme_var("error"),
+                    font_style="italic",
+                    padding=me.Padding.all(8),
+                    background=me.theme_var("error-container"),
+                    border_radius=4,
+                    margin=me.Margin(bottom=10),
+                ),
+            )
+
+        me.text(f"Model: {item.raw_data['model']}")
+        me.text(f'Prompt: "{item.prompt or "N/A"}"')
+        if item.negative_prompt:
+            me.text(f'Negative Prompt: "{item.negative_prompt}"')
+        if item.rewritten_prompt:
+            me.text(f'Rewritten Prompt: "{item.rewritten_prompt}"')
+
+        dialog_timestamp_str_detail = "N/A"
+        if item.timestamp:
+            try:
+                ts_str_detail = item.timestamp
+                if isinstance(item.timestamp, datetime):
+                    ts_str_detail = item.timestamp.isoformat()
+                dialog_timestamp_str_detail = datetime.fromisoformat(
+                    ts_str_detail.replace("Z", "+00:00")
+                ).strftime(
+                    "%Y-%m-%d %H:%M:%S %Z"
+                )
+            except Exception:
+                dialog_timestamp_str_detail = str(item.timestamp)
+        me.text(f"Generated: {dialog_timestamp_str_detail}")
+
+        if item.generation_time is not None:
+            me.text(f"Generation Time: {round(item.generation_time, 2)} seconds")
+
+        if item.model is not None:
+            me.text(f"Model: {item.model}")
+
+        if item.duration is not None:
+            me.text(f"Duration: {item.duration} seconds")
+        
+        with me.content_button(
+            on_click=on_click_permalink,
+            key=item.id or "",  # Ensure key is not None
+        ):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    align_items="center",
+                    gap=5,
+                )
+            ):
+                me.icon(icon="link")
+                me.text("permalink")

--- a/experiments/veo-app/components/library/character_consistency_details.py
+++ b/experiments/veo-app/components/library/character_consistency_details.py
@@ -1,0 +1,111 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Component for displaying character consistency details."""
+
+import mesop as me
+from common.metadata import MediaItem
+
+from typing import Callable
+
+
+@me.component
+def character_consistency_details(item: MediaItem, on_click_permalink: Callable):
+    """Renders the details for a character consistency item."""
+    item_display_url = (
+        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
+        if item.gcsuri
+        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
+    )
+    
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="column",
+            gap=12,
+
+        )
+    ):
+
+        if item.media_type == "character_consistency" and item.best_candidate_image:
+            me.video(
+                src=item_display_url,
+                style=me.Style(
+                    width="100%",
+                    max_height="40vh",
+                    border_radius=8,
+                    background="#000",
+                    display="block",
+                    margin=me.Margin(bottom=16),
+                ),
+            )
+            best_candidate_url = item.best_candidate_image.replace(
+                "gs://", "https://storage.mtls.cloud.google.com/"
+            )
+            me.text(
+                "Best Candidate Image:",
+                style=me.Style(
+                    font_weight="500", margin=me.Margin(top=8)
+                ),
+            )
+            me.image(
+                src=best_candidate_url,
+                style=me.Style(
+                    max_width="250px",
+                    height="auto",
+                    border_radius=6,
+                    margin=me.Margin(top=4),
+                ),
+            )
+            if item.source_character_images:
+                me.text(
+                    "Source Images:",
+                    style=me.Style(
+                        font_weight="500", margin=me.Margin(top=8)
+                    ),
+                )
+                with me.box(
+                    style=me.Style(
+                        display="flex", flex_direction="row", gap=10
+                    )
+                ):
+                    for src_image_uri in item.source_character_images[
+                        :3
+                    ]:
+                        src_url = src_image_uri.replace(
+                            "gs://",
+                            "https://storage.mtls.cloud.google.com/",
+                        )
+                        me.image(
+                            src=src_url,
+                            style=me.Style(
+                                max_width="150px",
+                                height="auto",
+                                border_radius=6,
+                                margin=me.Margin(top=4),
+                            ),
+                        )
+            with me.content_button(
+                on_click=on_click_permalink,
+                key=item.id or "",  # Ensure key is not None
+            ):
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_direction="row",
+                        align_items="center",
+                        gap=5,
+                    )
+                ):
+                    me.icon(icon="link")
+                    me.text("permalink")

--- a/experiments/veo-app/components/library/grid_parts.py
+++ b/experiments/veo-app/components/library/grid_parts.py
@@ -1,0 +1,188 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reusable parts for the library grid items."""
+
+import mesop as me
+from common.metadata import MediaItem
+from components.pill import pill
+
+
+@me.component
+def render_video_pills(item: MediaItem):
+    """Renders the pills for a video item."""
+    item_duration_str = f"{item.duration} sec" if item.duration is not None else "N/A"
+
+    pill("Video", "media_type_video")
+    pill(
+        "t2v" if not item.reference_image else "i2v",
+        "gen_t2v" if not item.reference_image else "gen_i2v",
+    )
+    if item.aspect:
+        pill(item.aspect, "aspect")
+    if item.duration is not None:
+        pill(item_duration_str, "duration")
+    if item.resolution:
+        pill(item.resolution, "resolution")
+    pill("24 fps", "fps")
+    if item.enhanced_prompt_used:
+        with me.tooltip(message="Prompt was auto-enhanced"):
+            me.icon(
+                "auto_fix_normal",
+                style=me.Style(color=me.theme_var("primary")),
+            )
+
+
+@me.component
+def render_image_pills(item: MediaItem):
+    """Renders the pills for an image item."""
+    pill("Image", "media_type_image")
+    if item.aspect:
+        pill(item.aspect, "aspect")
+    if len(item.gcs_uris) > 1:
+        pill(str(len(item.gcs_uris)), "multi_image_count")
+
+
+@me.component
+def render_audio_pills(item: MediaItem):
+    """Renders the pills for an audio item."""
+    item_duration_str = f"{item.duration} sec" if item.duration is not None else "N/A"
+    pill("Audio", "media_type_audio")
+    if item.duration is not None:
+        pill(item_duration_str, "duration")
+
+    if item.rewritten_prompt is not None:
+        with me.tooltip(message="Custom prompt rewriter"):
+            me.icon(
+                "auto_fix_normal",
+                style=me.Style(color=me.theme_var("primary")),
+            )
+
+
+@me.component
+def render_video_preview(item: MediaItem, item_url: str):
+    """Renders the preview for a video item."""
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="row",
+            gap=8,
+            align_items="center",
+            justify_content="center",
+            margin=me.Margin(top=8, bottom=8),
+            min_height="150px",
+        )
+    ):
+        if item_url:
+            me.video(
+                src=item_url,
+                style=me.Style(
+                    width="100%",
+                    height="150px",
+                    border_radius=6,
+                    object_fit="cover",
+                ),
+            )
+        else:
+            me.text(
+                "Video not available.",
+                style=me.Style(
+                    height="150px",
+                    display="flex",
+                    align_items="center",
+                    justify_content="center",
+                    color=me.theme_var("onsurfacevariant"),
+                ),
+            )
+
+        # Reference images for video
+        with me.box(
+            style=me.Style(
+                display="flex",
+                flex_direction="column",
+                gap=5,
+            )
+        ):
+            if item.reference_image:
+                ref_img_url = item.reference_image.replace(
+                    "gs://",
+                    "https://storage.mtls.cloud.google.com/",
+                )
+                me.image(
+                    src=ref_img_url,
+                    style=me.Style(
+                        height="70px",
+                        width="auto",
+                        border_radius=4,
+                        object_fit="contain",
+                    ),
+                )
+            if item.last_reference_image:
+                last_ref_img_url = item.last_reference_image.replace(
+                    "gs://",
+                    "https://storage.mtls.cloud.google.com/",
+                )
+                me.image(
+                    src=last_ref_img_url,
+                    style=me.Style(
+                        height="70px",
+                        width="auto",
+                        border_radius=4,
+                        object_fit="contain",
+                    ),
+                )
+
+@me.component
+def render_image_preview(item: MediaItem, item_url: str):
+    """Renders the preview for an image item."""
+    if item_url:
+        me.image(
+            src=item_url,
+            style=me.Style(
+                max_width="100%",
+                max_height="150px",
+                height="auto",
+                border_radius=6,
+                object_fit="contain",
+            ),
+        )
+    else:
+        me.text(
+            "Image not available.",
+            style=me.Style(
+                height="150px",
+                display="flex",
+                align_items="center",
+                justify_content="center",
+                color=me.theme_var("onsurfacevariant"),
+            ),
+        )
+
+@me.component
+def render_audio_preview(item: MediaItem, item_url: str):
+    """Renders the preview for an audio item."""
+    if item_url:
+        me.audio(
+            src=item_url,
+        )
+    else:
+        me.text(
+            "Audio not available.",
+            style=me.Style(
+                height="150px",
+                display="flex",
+                align_items="center",
+                justify_content="center",
+                color=me.theme_var("onsurfacevariant"),
+            ),
+        )

--- a/experiments/veo-app/components/library/image_details.py
+++ b/experiments/veo-app/components/library/image_details.py
@@ -21,6 +21,8 @@ import mesop as me
 from common.metadata import MediaItem
 
 
+from typing import Callable
+
 @me.stateclass
 class CarouselState:
     """State for the image carousel."""
@@ -49,7 +51,7 @@ def on_prev(e: me.ClickEvent) -> None:
 
 
 @me.component
-def image_details(item: MediaItem) -> None:
+def image_details(item: MediaItem, on_click_permalink: Callable) -> None:
     """A component that displays image details in a carousel.
 
     Args:
@@ -199,4 +201,17 @@ def image_details(item: MediaItem) -> None:
                             width="100px", height="auto", border_radius="8px"
                         ),
                     )
-
+    with me.content_button(
+            on_click=on_click_permalink,
+            key=item.id or "",  # Ensure key is not None
+        ):
+        with me.box(
+            style=me.Style(
+                display="flex",
+                flex_direction="row",
+                align_items="center",
+                gap=5,
+            )
+        ):
+            me.icon(icon="link")
+            me.text("permalink")

--- a/experiments/veo-app/components/library/video_details.py
+++ b/experiments/veo-app/components/library/video_details.py
@@ -1,0 +1,152 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Component for displaying video details."""
+
+import mesop as me
+from common.metadata import MediaItem
+from datetime import datetime
+from typing import Callable
+
+@me.component
+def video_details(item: MediaItem, on_click_permalink: Callable):
+    """Renders the details for a video item."""
+    item_display_url = (
+        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
+        if item.gcsuri
+        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
+    )
+    
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="column",
+            gap=12,
+
+        )
+    ):
+
+        if item_display_url and not item.error_message:
+            me.video(
+                src=item_display_url,
+                style=me.Style(
+                    width="100%",
+                    max_height="40vh",
+                    border_radius=8,
+                    background="#000",
+                    display="block",
+                    margin=me.Margin(bottom=16),
+                ),
+            )
+
+        if item.error_message:
+            me.text(
+                f"Error: {item.error_message}",
+                style=me.Style(
+                    color=me.theme_var("error"),
+                    font_style="italic",
+                    padding=me.Padding.all(8),
+                    background=me.theme_var("error-container"),
+                    border_radius=4,
+                    margin=me.Margin(bottom=10),
+                ),
+            )
+
+        me.text(f"Model: {item.raw_data['model']}")
+        me.text(f'Prompt: "{item.prompt or "N/A"}"')
+        if item.negative_prompt:
+            me.text(f'Negative Prompt: "{item.negative_prompt}"')
+        if item.enhanced_prompt_used:
+            me.text(f'Enhanced Prompt: "{item.enhanced_prompt_used}"')
+
+        dialog_timestamp_str_detail = "N/A"
+        if item.timestamp:
+            try:
+                ts_str_detail = item.timestamp
+                if isinstance(item.timestamp, datetime):
+                    ts_str_detail = item.timestamp.isoformat()
+                dialog_timestamp_str_detail = datetime.fromisoformat(
+                    ts_str_detail.replace("Z", "+00:00")
+                ).strftime(
+                    "%Y-%m-%d %H:%M:%S %Z"
+                )
+            except Exception:
+                dialog_timestamp_str_detail = str(item.timestamp)
+        me.text(f"Generated: {dialog_timestamp_str_detail}")
+
+        if item.generation_time is not None:
+            me.text(f"Generation Time: {round(item.generation_time, 2)} seconds")
+
+        if item.model is not None:
+            me.text(f"Model: {item.model}")
+
+        if item.aspect:
+            me.text(f"Aspect Ratio: {item.aspect}")
+        if item.duration is not None:
+            me.text(f"Duration: {item.duration} seconds")
+        me.text(f"Resolution: {item.resolution or '720p'}")
+
+        if item.reference_image:
+            ref_url = item.reference_image.replace(
+                "gs://", "https://storage.mtls.cloud.google.com/"
+            )
+            me.text(
+                "Reference Image:",
+                style=me.Style(
+                    font_weight="500",
+                    margin=me.Margin(top=8),
+                ),
+            )
+            me.image(
+                src=ref_url,
+                style=me.Style(
+                    max_width="250px",
+                    height="auto",
+                    border_radius=6,
+                    margin=me.Margin(top=4),
+                ),
+            )
+        if item.last_reference_image:
+            last_ref_url = item.last_reference_image.replace(
+                "gs://", "https://storage.mtls.cloud.google.com/"
+            )
+            me.text(
+                "Last Reference Image:",
+                style=me.Style(
+                    font_weight="500", margin=me.Margin(top=8)
+                ),
+            )
+            me.image(
+                src=last_ref_url,
+                style=me.Style(
+                    max_width="250px",
+                    height="auto",
+                    border_radius=6,
+                    margin=me.Margin(top=4),
+                ),
+            )
+            
+        with me.content_button(
+                on_click=on_click_permalink,
+                key=item.id or "",  # Ensure key is not None
+            ):
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_direction="row",
+                        align_items="center",
+                        gap=5,
+                    )
+                ):
+                    me.icon(icon="link")
+                    me.text("permalink")

--- a/experiments/veo-app/components/library/video_grid_item.py
+++ b/experiments/veo-app/components/library/video_grid_item.py
@@ -1,0 +1,127 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Component for displaying a video item in the library grid."""
+
+import mesop as me
+from common.metadata import MediaItem
+from components.pill import pill
+
+
+@me.component
+def video_grid_item(item: MediaItem):
+    """Renders a grid item for a video media type."""
+    item_duration_str = f"{item.duration} sec" if item.duration is not None else "N/A"
+    item_url = (
+        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
+        if item.gcsuri
+        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
+    )
+
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_wrap="wrap",
+            gap=5,
+            margin=me.Margin(bottom=8),
+        )
+    ):
+        pill("Video", "media_type_video")
+        pill(
+            "t2v" if not item.reference_image else "i2v",
+            "gen_t2v" if not item.reference_image else "gen_i2v",
+        )
+        if item.aspect:
+            pill(item.aspect, "aspect")
+        if item.duration is not None:
+            pill(item_duration_str, "duration")
+        if item.resolution:
+            pill(item.resolution, "resolution")
+        pill("24 fps", "fps")
+        if item.enhanced_prompt_used:
+            with me.tooltip(message="Prompt was auto-enhanced"):
+                me.icon(
+                    "auto_fix_normal",
+                    style=me.Style(color=me.theme_var("primary")),
+                )
+
+    # Media Preview Section
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="row",
+            gap=8,
+            align_items="center",
+            justify_content="center",
+            margin=me.Margin(top=8, bottom=8),
+            min_height="150px",
+        )
+    ):
+        if item_url:
+            me.video(
+                src=item_url,
+                style=me.Style(
+                    width="100%",
+                    height="150px",
+                    border_radius=6,
+                    object_fit="cover",
+                ),
+            )
+        else:
+            me.text(
+                "Video not available.",
+                style=me.Style(
+                    height="150px",
+                    display="flex",
+                    align_items="center",
+                    justify_content="center",
+                    color=me.theme_var("onsurfacevariant"),
+                ),
+            )
+
+        # Reference images for video
+        with me.box(
+            style=me.Style(
+                display="flex",
+                flex_direction="column",
+                gap=5,
+            )
+        ):
+            if item.reference_image:
+                ref_img_url = item.reference_image.replace(
+                    "gs://",
+                    "https://storage.mtls.cloud.google.com/",
+                )
+                me.image(
+                    src=ref_img_url,
+                    style=me.Style(
+                        height="70px",
+                        width="auto",
+                        border_radius=4,
+                        object_fit="contain",
+                    ),
+                )
+            if item.last_reference_image:
+                last_ref_img_url = item.last_reference_image.replace(
+                    "gs://",
+                    "https://storage.mtls.cloud.google.com/",
+                )
+                me.image(
+                    src=last_ref_img_url,
+                    style=me.Style(
+                        height="70px",
+                        width="auto",
+                        border_radius=4,
+                        object_fit="contain",
+                    ),
+                )


### PR DESCRIPTION
The library page was becoming difficult to maintain due to a single large file handling the rendering logic for all media types. This led to complex conditional logic and made the code hard to reason about.

This change refactors the library page by breaking it down into smaller, more manageable components, each responsible for a specific media type.

Key changes:
- Created new components for grid and detail views for video, image, audio, and character consistency media types under `components/library/`.
- Simplified the main `library.py` file to act as a dispatcher, delegating rendering to the new specialized components.
- Fixed a persistent bug related to stale state during pagination by fetching the master list of media items once and storing it in the page state.
- Improved the overall maintainability and readability of the codebase.