### PR TITLE
feat(library): add client-side download button for media assets

### DIFF
--- a/experiments/veo-app/components/download_button/download_button.js
+++ b/experiments/veo-app/components/download_button/download_button.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, html, css } from 'https://esm.sh/lit';
+import 'https://esm.sh/@material/mwc-button';
+
+class DownloadButton extends LitElement {
+  static get properties() {
+    return {
+      url: { type: String }, // Expects a gs:// URI
+      filename: { type: String },
+      loading: { type: Boolean, state: true },
+      error: { type: String, state: true },
+    };
+  }
+
+  constructor() {
+    super();
+    this.url = '';
+    this.filename = 'download';
+    this.loading = false;
+    this.error = '';
+  }
+
+  static styles = css`
+    mwc-button {
+      --mdc-theme-primary: var(--mdc-text-button-label-text-color, var(--mat-sys-color-on-surface));
+      --mdc-typography-button-text-transform: none;
+    }
+    .error-message {
+        color: var(--mat-sys-color-error, #B00020);
+        font-size: 12px;
+        margin-top: 4px;
+    }
+  `;
+
+  async _handleDownload() {
+    if (!this.url || !this.url.startsWith('gs://')) {
+      this.error = 'Error: Invalid GCS URI provided.';
+      return;
+    }
+    this.loading = true;
+    this.error = '';
+
+    try {
+      // 1. Get the signed URL from our backend API.
+      const signedUrlResponse = await fetch(`/api/get_signed_url?gcs_uri=${this.url}`);
+      const signedUrlData = await signedUrlResponse.json();
+
+      if (!signedUrlResponse.ok || signedUrlData.error) {
+        throw new Error(signedUrlData.error || `API error! status: ${signedUrlResponse.status}`);
+      }
+      
+      const signedUrl = signedUrlData.signed_url;
+      if (!signedUrl) {
+        throw new Error('Failed to retrieve signed URL from API.');
+      }
+
+      // 2. Fetch the resource using the signed URL.
+      const response = await fetch(signedUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      // 3. Get the data as a blob.
+      const blob = await response.blob();
+
+      // 4. Create a temporary link and trigger the download.
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = this.filename || 'download';
+      document.body.appendChild(link);
+      link.click();
+
+      // 5. Clean up.
+      document.body.removeChild(link);
+      URL.revokeObjectURL(link.href);
+
+    } catch (e) {
+      console.error('Download failed:', e);
+      this.error = e.message || `Download failed. Check CORS policy and network.`;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  render() {
+    const label = this.loading ? 'loading...' : 'download';
+    const iconSvg = this.loading
+      ? html`<svg slot="icon" xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 6v3l4-4-4-4v3c-4.42 0-8 3.58-8 8 0 1.57.46 3.03 1.24 4.26L6.7 14.8c-.45-.83-.7-1.79-.7-2.8 0-3.31 2.69-6 6-6zm6.76 1.74L17.3 9.2c.44.84.7 1.79.7 2.8 0 3.31-2.69 6-6 6v-3l-4 4 4 4v-3c4.42 0 8-3.58 8-8 0-1.57-.46-3.03-1.24-4.26z"/></svg>`
+      : html`<svg slot="icon" xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>`;
+
+    return html`
+      <mwc-button
+        @click="${this._handleDownload}"
+        ?disabled="${this.loading}"
+      >
+        ${iconSvg}
+        <span>${label}</span>
+      </mwc-button>
+      ${this.error ? html`<p class="error-message">${this.error}</p>` : ''}
+    `;
+  }
+}
+
+if (!customElements.get('download-button')) {
+  customElements.define('download-button', DownloadButton);
+}

--- a/experiments/veo-app/components/download_button/download_button.py
+++ b/experiments/veo-app/components/download_button/download_button.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python wrapper for the Download Button Lit component."""
+
+import typing
+
+import mesop as me
+
+
+@me.web_component(path="./download_button.js")
+def download_button(
+    *,
+    # --- Properties ---
+    url: str = "",
+    filename: str = "",
+    key: str | None = None,
+):
+    """Defines the API for the download button web component."""
+    return me.insert_web_component(
+        key=key,
+        name="download-button",
+        properties={
+            "url": url,
+            "filename": filename,
+        },
+    )

--- a/experiments/veo-app/components/library/audio_details.py
+++ b/experiments/veo-app/components/library/audio_details.py
@@ -17,7 +17,8 @@ import json
 import mesop as me
 from common.metadata import MediaItem
 from datetime import datetime
-
+import os
+from components.download_button.download_button import download_button
 
 from typing import Callable
 
@@ -90,17 +91,22 @@ def audio_details(item: MediaItem, on_click_permalink: Callable):
         if item.duration is not None:
             me.text(f"Duration: {item.duration} seconds")
         
-        with me.content_button(
-            on_click=on_click_permalink,
-            key=item.id or "",  # Ensure key is not None
-        ):
-            with me.box(
-                style=me.Style(
-                    display="flex",
-                    flex_direction="row",
-                    align_items="center",
-                    gap=5,
-                )
+        with me.box(style=me.Style(display="flex", flex_direction="row", gap=10, margin=me.Margin(top=16))):
+            with me.content_button(
+                on_click=on_click_permalink,
+                key=item.id or "",  # Ensure key is not None
             ):
-                me.icon(icon="link")
-                me.text("permalink")
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_direction="row",
+                        align_items="center",
+                        gap=5,
+                    )
+                ):
+                    me.icon(icon="link")
+                    me.text("permalink")
+            
+            if item.gcsuri:
+                filename = os.path.basename(item.gcsuri.split('?')[0])
+                download_button(url=item.gcsuri, filename=filename)

--- a/experiments/veo-app/components/library/character_consistency_details.py
+++ b/experiments/veo-app/components/library/character_consistency_details.py
@@ -15,6 +15,8 @@
 
 import mesop as me
 from common.metadata import MediaItem
+import os
+from components.download_button.download_button import download_button
 
 from typing import Callable
 
@@ -95,17 +97,22 @@ def character_consistency_details(item: MediaItem, on_click_permalink: Callable)
                                 margin=me.Margin(top=4),
                             ),
                         )
-            with me.content_button(
-                on_click=on_click_permalink,
-                key=item.id or "",  # Ensure key is not None
-            ):
-                with me.box(
-                    style=me.Style(
-                        display="flex",
-                        flex_direction="row",
-                        align_items="center",
-                        gap=5,
-                    )
+            with me.box(style=me.Style(display="flex", flex_direction="row", gap=10, margin=me.Margin(top=16))):
+                with me.content_button(
+                    on_click=on_click_permalink,
+                    key=item.id or "",  # Ensure key is not None
                 ):
-                    me.icon(icon="link")
-                    me.text("permalink")
+                    with me.box(
+                        style=me.Style(
+                            display="flex",
+                            flex_direction="row",
+                            align_items="center",
+                            gap=5,
+                        )
+                    ):
+                        me.icon(icon="link")
+                        me.text("permalink")
+
+                if item.gcsuri:
+                    filename = os.path.basename(item.gcsuri.split('?')[0])
+                    download_button(url=item.gcsuri, filename=filename)

--- a/experiments/veo-app/components/library/image_details.py
+++ b/experiments/veo-app/components/library/image_details.py
@@ -19,7 +19,8 @@
 import mesop as me
 
 from common.metadata import MediaItem
-
+import os
+from components.download_button.download_button import download_button
 
 from typing import Callable
 
@@ -201,17 +202,23 @@ def image_details(item: MediaItem, on_click_permalink: Callable) -> None:
                             width="100px", height="auto", border_radius="8px"
                         ),
                     )
-    with me.content_button(
-            on_click=on_click_permalink,
-            key=item.id or "",  # Ensure key is not None
-        ):
-        with me.box(
-            style=me.Style(
-                display="flex",
-                flex_direction="row",
-                align_items="center",
-                gap=5,
-            )
-        ):
-            me.icon(icon="link")
-            me.text("permalink")
+    with me.box(style=me.Style(display="flex", flex_direction="row", gap=10, margin=me.Margin(top=16))):
+        with me.content_button(
+                on_click=on_click_permalink,
+                key=item.id or "",  # Ensure key is not None
+            ):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    align_items="center",
+                    gap=5,
+                )
+            ):
+                me.icon(icon="link")
+                me.text("permalink")
+
+        if image_url:
+            gcs_uri = item.gcs_uris[state.current_index]
+            filename = os.path.basename(gcs_uri.split('?')[0])
+            download_button(url=gcs_uri, filename=filename)

--- a/experiments/veo-app/components/library/video_details.py
+++ b/experiments/veo-app/components/library/video_details.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,15 @@
 # limitations under the License.
 """Component for displaying video details."""
 
-import mesop as me
-from common.metadata import MediaItem
+import os
 from datetime import datetime
 from typing import Callable
+
+import mesop as me
+
+from common.metadata import MediaItem
+from components.download_button.download_button import download_button
+
 
 @me.component
 def video_details(item: MediaItem, on_click_permalink: Callable):
@@ -24,15 +29,18 @@ def video_details(item: MediaItem, on_click_permalink: Callable):
     item_display_url = (
         item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
         if item.gcsuri
-        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
+        else (
+            item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/")
+            if item.gcs_uris
+            else ""
+        )
     )
-    
+
     with me.box(
         style=me.Style(
             display="flex",
             flex_direction="column",
             gap=12,
-
         )
     ):
 
@@ -77,9 +85,7 @@ def video_details(item: MediaItem, on_click_permalink: Callable):
                     ts_str_detail = item.timestamp.isoformat()
                 dialog_timestamp_str_detail = datetime.fromisoformat(
                     ts_str_detail.replace("Z", "+00:00")
-                ).strftime(
-                    "%Y-%m-%d %H:%M:%S %Z"
-                )
+                ).strftime("%Y-%m-%d %H:%M:%S %Z")
             except Exception:
                 dialog_timestamp_str_detail = str(item.timestamp)
         me.text(f"Generated: {dialog_timestamp_str_detail}")
@@ -122,9 +128,7 @@ def video_details(item: MediaItem, on_click_permalink: Callable):
             )
             me.text(
                 "Last Reference Image:",
-                style=me.Style(
-                    font_weight="500", margin=me.Margin(top=8)
-                ),
+                style=me.Style(font_weight="500", margin=me.Margin(top=8)),
             )
             me.image(
                 src=last_ref_url,
@@ -135,8 +139,13 @@ def video_details(item: MediaItem, on_click_permalink: Callable):
                     margin=me.Margin(top=4),
                 ),
             )
-            
-        with me.content_button(
+
+        with me.box(
+            style=me.Style(
+                display="flex", flex_direction="row", gap=10, margin=me.Margin(top=16)
+            )
+        ):
+            with me.content_button(
                 on_click=on_click_permalink,
                 key=item.id or "",  # Ensure key is not None
             ):
@@ -150,3 +159,7 @@ def video_details(item: MediaItem, on_click_permalink: Callable):
                 ):
                     me.icon(icon="link")
                     me.text("permalink")
+
+            if item.gcsuri:
+                filename = os.path.basename(item.gcsuri.split("?")[0])
+                download_button(url=item.gcsuri, filename=filename)

--- a/experiments/veo-app/plans/DOWNLOAD_BUTTON_COMPONENT_PLAN.md
+++ b/experiments/veo-app/plans/DOWNLOAD_BUTTON_COMPONENT_PLAN.md
@@ -1,0 +1,20 @@
+# Plan: Lit Download Button Component
+
+This plan outlines the steps to create and integrate a Lit-based web component for providing a true file download experience.
+
+## Phase 1: Component Creation
+
+- [x] Create the component directory: `components/download_button`
+- [x] Create the Python wrapper: `components/download_button/download_button.py`
+- [x] Create the Lit component JS: `components/download_button/download_button.js`
+
+## Phase 2: Integration
+
+- [x] Integrate the `download_button` into `components/library/audio_details.py`
+- [x] Integrate the `download_button` into `components/library/character_consistency_details.py`
+- [x] Integrate the `download_button` into `components/library/image_details.py`
+- [x] Integrate the `download_button` into `components/library/video_details.py`
+
+## Phase 3: Verification
+
+- [ ] Manually verify that the download button works for all media types and does not cause page navigation.


### PR DESCRIPTION
Adds a "Download" button to the media details dialog in the library. This allows users to download generated assets directly to their local machine.

Previously, there was no way to download assets. Initial attempts using `me.link` or `me.html` with a `download` attribute were unsuccessful, as they either opened the asset in a new tab or caused page navigation, providing a poor user experience.

This change introduces a new Lit web component, `download-button`, which encapsulates the download logic:
- It calls a backend API to get a temporary signed URL for the GCS asset.
- It then uses the JavaScript `fetch` API to retrieve the asset as a blob.
- It creates an object URL and programmatically clicks a temporary link to trigger a true browser download.

The new component is styled to match the existing flat buttons for visual consistency, including theme-aware colors and the Material ripple effect.

New files:
- `components/download_button/download_button.js`
- `components/download_button/download_button.py`
- `plans/DOWNLOAD_BUTTON_COMPONENT_PLAN.md`

Modified files:
- `components/library/audio_details.py`
- `components/library/character_consistency_details.py`
- `components/library/image_details.py`
- `components/library/video_details.py`