### PR TITLE
feat(image_gen): add image actions and multi-image generation

### DIFF
--- a/experiments/veo-app/requirements.txt
+++ b/experiments/veo-app/requirements.txt
@@ -46,7 +46,7 @@ cycler==0.12.1
     # via matplotlib
 decorator==5.2.1
     # via ipython
-deepdiff==8.6.1
+deepdiff==6.7.1
     # via mesop
 docstring-parser==0.17.0
     # via google-cloud-aiplatform
@@ -111,7 +111,7 @@ google-crc32c==1.7.1
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-genai==1.32.0
+google-genai==1.33.0
     # via
     #   google-cloud-aiplatform
     #   veo-app

--- a/experiments/veo-app/uv.lock
+++ b/experiments/veo-app/uv.lock
@@ -597,7 +597,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.32.0"
+version = "1.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -609,9 +609,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/ab/e6cdd8fa957c647ef00c4da7c59d0e734354bd49ed8d98c860732d8e1944/google_genai-1.32.0.tar.gz", hash = "sha256:349da3f5ff0e981066bd508585fcdd308d28fc4646f318c8f6d1aa6041f4c7e3", size = 240802, upload-time = "2025-08-27T22:16:32.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/506221067750087ba1346f0a31f6e1714fda4b612d45a54cd2164750e05a/google_genai-1.33.0.tar.gz", hash = "sha256:7d3a5ebad712d95a0d1775842505886eb43cc52f9f478aa4ab0e2d25412499a2", size = 241006, upload-time = "2025-09-03T22:54:10.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/55/be09472f7a656af1208196d2ef9a3d2710f3cbcf695f51acbcbe28b9472b/google_genai-1.32.0-py3-none-any.whl", hash = "sha256:c0c4b1d45adf3aa99501050dd73da2f0dea09374002231052d81a6765d15e7f6", size = 241680, upload-time = "2025-08-27T22:16:31.409Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8e/55052fe488d6604309b425360beb72e6d65f11fa4cc1cdde17ccfe93e1bc/google_genai-1.33.0-py3-none-any.whl", hash = "sha256:1710e958af0a0f3d19521fabbefd86b22d1f212376103f18fed11c9d96fa48e8", size = 241753, upload-time = "2025-09-03T22:54:08.789Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements several new features and UX improvements on the Gemini Image Generation page.

Features:
- Adds "Image Preset" buttons (e.g., "Rotate left") that act as one-click modifiers for the current image.
- Adds a "Number of Images" dropdown (1-4) that dynamically appends a suffix to the prompt (e.g., "Give me 4 options.") to request multiple variations.

Implementation Details:
- Refactored the core generation and Firestore persistence logic into a reusable `_generate_and_save` function.
- The preset action buttons now intelligently target the user's selected generated image, or fall back to the first uploaded image if none is selected.
- The preset buttons are now visible as soon as an image is uploaded, improving workflow.

Bug Fixes:
- Fixes a regression where the main "Generate Images" button was broken due to the `_generate_and_save` generator not being called correctly with `yield from`.
- Fixes a bug where error snackbars would not appear. A blocking `time.sleep()` was removed and a missing `yield` was restored to the `show_snackbar` function.