### PR TITLE
Update 'deepdiff' requirements.txt

### DIFF
--- a/experiments/veo-app/requirements.txt
+++ b/experiments/veo-app/requirements.txt
@@ -46,7 +46,7 @@ cycler==0.12.1
     # via matplotlib
 decorator==5.2.1
     # via ipython
-deepdiff==8.6.1
+deepdiff
     # via mesop
 docstring-parser==0.17.0
     # via google-cloud-aiplatform


### PR DESCRIPTION
Cannot install "requirements.txt"
deepdiff==8.6.1 because these package versions have conflicting dependencies.

If you do not specify the version of deepdiff, the package will install without any problems.