### PR TITLE
feat(gcs): Centralize GCS URL to HTTPS conversion

### DIFF
--- a/experiments/veo-app/GEMINI.md
+++ b/experiments/veo-app/GEMINI.md
@@ -230,20 +230,9 @@ This section summarizes the process of creating the Virtual Try-On (VTO) page, i
 
 - **API Error Handling:** When an API returns an "Internal error" with an Operation ID, it signifies a server-side issue. The best course of action is to wait and retry, and if the problem persists, report the Operation ID to Google Cloud support.
 
-- **GCS URI Construction:** When working with GCS URIs, be mindful of duplicate prefixes. The `store_to_gcs` function returns a full `gs://` URI, so do not prepend the prefix again in the calling function. This applies to both creating display URLs (e.g., `https://storage.mtls.cloud.google.com/`) and passing URIs to the API.
-
-### 1. Initial Scaffolding and Page Creation
-
-- **File Structure:** Following the existing architecture, we created three new files:
-    - `pages/vto.py`: For the UI and page logic.
-    - `state/vto_state.py`: For managing the page's state.
-    - `models/vto.py`: For handling the VTO model interaction.
-- **Page Registration:** The new page was registered in `main.py` and added to the navigation in `config/navigation.json`.
-
-### 2. File Uploads and GCS Integration
-
-- **GCS Uploads:** We used the existing `common/storage.py` module to upload the person and product images to Google Cloud Storage.
-- **Displaying GCS Images:** We learned that the `me.image` component requires a public HTTPS URL, not a `gs://` URI. The correct way to display GCS images is to replace `gs://` with `https://storage.mtls.cloud.google.com/`.
+- **GCS URI Handling:** To ensure consistency and maintainability, always use the central utility functions in `common/utils.py` for converting between GCS URIs and public HTTPS URLs.
+    - **`gcs_uri_to_https_url(gcs_uri)`:** Use this function to convert a `gs://` URI to a public URL suitable for display in `me.image` or `me.video`.
+    - **`https_url_to_gcs_uri(url)`:** Use this function to convert a public URL back to a `gs://` URI, which is often required before passing a URL to a model API.
 
 ### 3. Interacting with the VTO Model
 

--- a/experiments/veo-app/common/utils.py
+++ b/experiments/veo-app/common/utils.py
@@ -97,8 +97,33 @@ def print_keys(obj, prefix=""):
             # Current behavior: treats list items as potentially new objects to explore.
             print_keys(item, prefix + f"  [{i}] ")  # indicate list index in prefix
 
-def gcs_uri_to_https_url(gcs_uri: str) -> str:
-    """Converts a GCS URI to a public HTTPS URL."""
-    if gcs_uri and gcs_uri.startswith("gs://"):
-        return gcs_uri.replace("gs://", "https://storage.mtls.cloud.google.com/")
+GCS_PUBLIC_URL_PREFIX = "https://storage.mtls.cloud.google.com/"
+
+
+def gcs_uri_to_https_url(gcs_uri: str | None) -> str:
+    """
+    Converts a GCS URI to a publicly accessible URL.
+
+    Handles None, empty strings, and already-formatted URLs gracefully.
+    """
+    if not gcs_uri:
+        return ""
+    if gcs_uri.startswith("https://"):
+        return gcs_uri
+    if gcs_uri.startswith("gs://"):
+        return gcs_uri.replace("gs://", GCS_PUBLIC_URL_PREFIX)
+    # Return as-is if it's not a recognized format
     return gcs_uri
+
+
+def https_url_to_gcs_uri(url: str | None) -> str:
+    """
+    Converts a public GCS HTTPS URL back to a gs:// URI.
+    """
+    if not url:
+        return ""
+    if url.startswith("gs://"):
+        return url
+    if url.startswith(GCS_PUBLIC_URL_PREFIX):
+        return url.replace(GCS_PUBLIC_URL_PREFIX, "gs://")
+    return url

--- a/experiments/veo-app/components/image_thumbnail.py
+++ b/experiments/veo-app/components/image_thumbnail.py
@@ -14,6 +14,7 @@
 
 import mesop as me
 from typing import Callable
+from common.utils import gcs_uri_to_https_url
 
 @me.component
 def image_thumbnail(image_uri: str, index: int, on_remove: Callable, icon_size: int = 18):
@@ -22,7 +23,7 @@ def image_thumbnail(image_uri: str, index: int, on_remove: Callable, icon_size: 
     box_dimension = icon_size + 8
     
     with me.box(style=me.Style(position="relative", width=100, height=100)):
-        me.image(src=image_uri.replace("gs://", "https://storage.mtls.cloud.google.com/"), style=me.Style(width="100%", height="100%", border_radius=8, object_fit="cover"))
+        me.image(src=gcs_uri_to_https_url(image_uri), style=me.Style(width="100%", height="100%", border_radius=8, object_fit="cover"))
         with me.box(
             on_click=on_remove,
             key=str(index),

--- a/experiments/veo-app/components/imagen/image_output.py
+++ b/experiments/veo-app/components/imagen/image_output.py
@@ -18,6 +18,8 @@ from components.styles import _BOX_STYLE
 from state.imagen_state import PageState
 from svg_icon.svg_icon_component import svg_icon_component
 
+from common.utils import gcs_uri_to_https_url
+
 
 @me.component
 def image_output():
@@ -62,14 +64,8 @@ def image_output():
                 ):
                     for img_uri in state.image_output:
                         if img_uri:
-                            final_img_src = img_uri
-                            if img_uri.startswith("gs://"):
-                                final_img_src = img_uri.replace(
-                                    "gs://", "https://storage.mtls.cloud.google.com/"
-                                )
-
                             me.image(
-                                src=final_img_src,
+                                src=gcs_uri_to_https_url(img_uri),
                                 style=me.Style(
                                     width="300px",
                                     height="300px",

--- a/experiments/veo-app/components/library/audio_details.py
+++ b/experiments/veo-app/components/library/audio_details.py
@@ -16,6 +16,7 @@
 import json
 import mesop as me
 from common.metadata import MediaItem
+from common.utils import gcs_uri_to_https_url
 from datetime import datetime
 import os
 from components.download_button.download_button import download_button
@@ -25,11 +26,8 @@ from typing import Callable
 @me.component
 def audio_details(item: MediaItem, on_click_permalink: Callable):
     """Renders the details for an audio item."""
-    item_display_url = (
-        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
-        if item.gcsuri
-        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
-    )
+    gcs_uri = item.gcsuri if item.gcsuri else (item.gcs_uris[0] if item.gcs_uris else None)
+    item_display_url = gcs_uri_to_https_url(gcs_uri)
 
     with me.box(
         style=me.Style(

--- a/experiments/veo-app/components/library/character_consistency_details.py
+++ b/experiments/veo-app/components/library/character_consistency_details.py
@@ -15,6 +15,7 @@
 
 import mesop as me
 from common.metadata import MediaItem
+from common.utils import gcs_uri_to_https_url
 import os
 from components.download_button.download_button import download_button
 
@@ -24,11 +25,8 @@ from typing import Callable
 @me.component
 def character_consistency_details(item: MediaItem, on_click_permalink: Callable):
     """Renders the details for a character consistency item."""
-    item_display_url = (
-        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
-        if item.gcsuri
-        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
-    )
+    gcs_uri = item.gcsuri if item.gcsuri else (item.gcs_uris[0] if item.gcs_uris else None)
+    item_display_url = gcs_uri_to_https_url(gcs_uri)
     
     with me.box(
         style=me.Style(
@@ -51,9 +49,7 @@ def character_consistency_details(item: MediaItem, on_click_permalink: Callable)
                     margin=me.Margin(bottom=16),
                 ),
             )
-            best_candidate_url = item.best_candidate_image.replace(
-                "gs://", "https://storage.mtls.cloud.google.com/"
-            )
+            best_candidate_url = gcs_uri_to_https_url(item.best_candidate_image)
             me.text(
                 "Best Candidate Image:",
                 style=me.Style(
@@ -84,10 +80,7 @@ def character_consistency_details(item: MediaItem, on_click_permalink: Callable)
                     for src_image_uri in item.source_character_images[
                         :3
                     ]:
-                        src_url = src_image_uri.replace(
-                            "gs://",
-                            "https://storage.mtls.cloud.google.com/",
-                        )
+                        src_url = gcs_uri_to_https_url(src_image_uri)
                         me.image(
                             src=src_url,
                             style=me.Style(

--- a/experiments/veo-app/components/library/grid_parts.py
+++ b/experiments/veo-app/components/library/grid_parts.py
@@ -15,6 +15,7 @@
 
 import mesop as me
 from common.metadata import MediaItem
+from common.utils import gcs_uri_to_https_url
 from components.pill import pill
 
 
@@ -114,10 +115,7 @@ def render_video_preview(item: MediaItem, item_url: str):
             )
         ):
             if item.reference_image:
-                ref_img_url = item.reference_image.replace(
-                    "gs://",
-                    "https://storage.mtls.cloud.google.com/",
-                )
+                ref_img_url = gcs_uri_to_https_url(item.reference_image)
                 me.image(
                     src=ref_img_url,
                     style=me.Style(
@@ -128,10 +126,7 @@ def render_video_preview(item: MediaItem, item_url: str):
                     ),
                 )
             if item.last_reference_image:
-                last_ref_img_url = item.last_reference_image.replace(
-                    "gs://",
-                    "https://storage.mtls.cloud.google.com/",
-                )
+                last_ref_img_url = gcs_uri_to_https_url(item.last_reference_image)
                 me.image(
                     src=last_ref_img_url,
                     style=me.Style(

--- a/experiments/veo-app/components/library/image_details.py
+++ b/experiments/veo-app/components/library/image_details.py
@@ -22,6 +22,7 @@ from typing import Callable
 import mesop as me
 
 from common.metadata import MediaItem
+from common.utils import gcs_uri_to_https_url, https_url_to_gcs_uri
 from components.download_button.download_button import download_button
 
 
@@ -58,9 +59,7 @@ def on_send_to_veo(e: me.ClickEvent):
     state = me.state(CarouselState)
 
     # Convert back to GCS URI to pass a clean identifier
-    gcs_uri = state.current_index_gcsuri.replace(
-        "https://storage.mtls.cloud.google.com/", "gs://"
-    )
+    gcs_uri = https_url_to_gcs_uri(state.current_index_gcsuri)
 
     me.navigate(
         url="/veo",
@@ -96,9 +95,7 @@ def image_details(item: MediaItem, on_click_permalink: Callable) -> None:
         )
     ):
         # Image display
-        image_url = item.gcs_uris[state.current_index].replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        image_url = gcs_uri_to_https_url(item.gcs_uris[state.current_index])
         me.image(
             src=image_url,
             style=me.Style(
@@ -166,9 +163,7 @@ def image_details(item: MediaItem, on_click_permalink: Callable) -> None:
                         )
                     ):
                         me.text("Person Image")
-                        person_url = person_gcs_uri.replace(
-                            "gs://", "https://storage.mtls.cloud.google.com/"
-                        )
+                        person_url = gcs_uri_to_https_url(person_gcs_uri)
                         me.image(
                             src=person_url,
                             style=me.Style(
@@ -188,9 +183,7 @@ def image_details(item: MediaItem, on_click_permalink: Callable) -> None:
                         )
                     ):
                         me.text("Product Image")
-                        product_url = product_gcs_uri.replace(
-                            "gs://", "https://storage.mtls.cloud.google.com/"
-                        )
+                        product_url = gcs_uri_to_https_url(product_gcs_uri)
                         me.image(
                             src=product_url,
                             style=me.Style(
@@ -213,9 +206,7 @@ def image_details(item: MediaItem, on_click_permalink: Callable) -> None:
             ):
                 for uri in item.source_images_gcs:
                     me.image(
-                        src=uri.replace(
-                            "gs://", "https://storage.mtls.cloud.google.com/"
-                        ),
+                        src=gcs_uri_to_https_url(uri),
                         style=me.Style(
                             width="100px", height="auto", border_radius="8px"
                         ),

--- a/experiments/veo-app/components/library/infinite_scroll_library.js
+++ b/experiments/veo-app/components/library/infinite_scroll_library.js
@@ -16,6 +16,8 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit';
 
+const GCS_PUBLIC_URL_PREFIX = 'https://storage.mtls.cloud.google.com/';
+
 class InfiniteScrollLibrary extends LitElement {
   static properties = {
     items: { type: Array },
@@ -87,7 +89,16 @@ class InfiniteScrollLibrary extends LitElement {
   }
 
   _formatGcsUri(uri) {
-    return uri.replace('gs://', 'https://storage.mtls.cloud.google.com/');
+    if (!uri) {
+      return "";
+    }
+    if (uri.startsWith("https://")) {
+      return uri;
+    }
+    if (uri.startsWith("gs://")) {
+      return uri.replace('gs://', GCS_PUBLIC_URL_PREFIX);
+    }
+    return uri;
   }
 }
 

--- a/experiments/veo-app/components/library/library_image_selector.py
+++ b/experiments/veo-app/components/library/library_image_selector.py
@@ -17,6 +17,7 @@ from typing import Callable, List
 import mesop as me
 
 from common.metadata import MediaItem
+from common.utils import gcs_uri_to_https_url
 from components.library.events import LibrarySelectionChangeEvent
 
 
@@ -51,9 +52,7 @@ def library_image_selector(
                             style=me.Style(cursor="pointer"),
                         ):
                             me.image(
-                                src=image_uri.replace(
-                                    "gs://", "https://storage.mtls.cloud.google.com/"
-                                ),
+                                src=gcs_uri_to_https_url(image_uri),
                                 style=me.Style(
                                     width="100%",
                                     border_radius=8,
@@ -67,9 +66,7 @@ def library_image_selector(
                         style=me.Style(cursor="pointer"),
                     ):
                         me.image(
-                            src=item.gcsuri.replace(
-                                "gs://", "https://storage.mtls.cloud.google.com/"
-                            ),
+                            src=gcs_uri_to_https_url(item.gcsuri),
                             style=me.Style(
                                 width="100%",
                                 border_radius=8,

--- a/experiments/veo-app/components/library/video_details.py
+++ b/experiments/veo-app/components/library/video_details.py
@@ -20,21 +20,15 @@ from typing import Callable
 import mesop as me
 
 from common.metadata import MediaItem
+from common.utils import gcs_uri_to_https_url
 from components.download_button.download_button import download_button
 
 
 @me.component
 def video_details(item: MediaItem, on_click_permalink: Callable):
     """Renders the details for a video item."""
-    item_display_url = (
-        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
-        if item.gcsuri
-        else (
-            item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/")
-            if item.gcs_uris
-            else ""
-        )
-    )
+    gcs_uri = item.gcsuri if item.gcsuri else (item.gcs_uris[0] if item.gcs_uris else None)
+    item_display_url = gcs_uri_to_https_url(gcs_uri)
 
     with me.box(
         style=me.Style(
@@ -103,9 +97,7 @@ def video_details(item: MediaItem, on_click_permalink: Callable):
         me.text(f"Resolution: {item.resolution or '720p'}")
 
         if item.reference_image:
-            ref_url = item.reference_image.replace(
-                "gs://", "https://storage.mtls.cloud.google.com/"
-            )
+            ref_url = gcs_uri_to_https_url(item.reference_image)
             me.text(
                 "Reference Image:",
                 style=me.Style(
@@ -123,9 +115,7 @@ def video_details(item: MediaItem, on_click_permalink: Callable):
                 ),
             )
         if item.last_reference_image:
-            last_ref_url = item.last_reference_image.replace(
-                "gs://", "https://storage.mtls.cloud.google.com/"
-            )
+            last_ref_url = gcs_uri_to_https_url(item.last_reference_image)
             me.text(
                 "Last Reference Image:",
                 style=me.Style(font_weight="500", margin=me.Margin(top=8)),

--- a/experiments/veo-app/components/library/video_grid_item.py
+++ b/experiments/veo-app/components/library/video_grid_item.py
@@ -15,6 +15,7 @@
 
 import mesop as me
 from common.metadata import MediaItem
+from common.utils import gcs_uri_to_https_url
 from components.pill import pill
 
 
@@ -22,11 +23,8 @@ from components.pill import pill
 def video_grid_item(item: MediaItem):
     """Renders a grid item for a video media type."""
     item_duration_str = f"{item.duration} sec" if item.duration is not None else "N/A"
-    item_url = (
-        item.gcsuri.replace("gs://", "https://storage.mtls.cloud.google.com/")
-        if item.gcsuri
-        else (item.gcs_uris[0].replace("gs://", "https://storage.mtls.cloud.google.com/") if item.gcs_uris else "")
-    )
+    gcs_uri = item.gcsuri if item.gcsuri else (item.gcs_uris[0] if item.gcs_uris else None)
+    item_url = gcs_uri_to_https_url(gcs_uri)
 
     with me.box(
         style=me.Style(
@@ -98,10 +96,7 @@ def video_grid_item(item: MediaItem):
             )
         ):
             if item.reference_image:
-                ref_img_url = item.reference_image.replace(
-                    "gs://",
-                    "https://storage.mtls.cloud.google.com/",
-                )
+                ref_img_url = gcs_uri_to_https_url(item.reference_image)
                 me.image(
                     src=ref_img_url,
                     style=me.Style(
@@ -112,10 +107,7 @@ def video_grid_item(item: MediaItem):
                     ),
                 )
             if item.last_reference_image:
-                last_ref_img_url = item.last_reference_image.replace(
-                    "gs://",
-                    "https://storage.mtls.cloud.google.com/",
-                )
+                last_ref_img_url = gcs_uri_to_https_url(item.last_reference_image)
                 me.image(
                     src=last_ref_img_url,
                     style=me.Style(

--- a/experiments/veo-app/components/library/video_infinite_scroll_library.js
+++ b/experiments/veo-app/components/library/video_infinite_scroll_library.js
@@ -16,6 +16,8 @@
 
 import { LitElement, html, css } from 'https://esm.sh/lit';
 
+const GCS_PUBLIC_URL_PREFIX = 'https://storage.mtls.cloud.google.com/';
+
 class VideoInfiniteScrollLibrary extends LitElement {
   static properties = {
     items: { type: Array },
@@ -87,7 +89,16 @@ class VideoInfiniteScrollLibrary extends LitElement {
   }
 
   _formatGcsUri(uri) {
-    return uri.replace('gs://', 'https://storage.mtls.cloud.google.com/');
+    if (!uri) {
+      return "";
+    }
+    if (uri.startsWith("https://")) {
+      return uri;
+    }
+    if (uri.startsWith("gs://")) {
+      return uri.replace('gs://', GCS_PUBLIC_URL_PREFIX);
+    }
+    return uri;
   }
 }
 

--- a/experiments/veo-app/components/veo/video_display.py
+++ b/experiments/veo-app/components/veo/video_display.py
@@ -14,6 +14,7 @@
 
 import mesop as me
 
+from common.utils import gcs_uri_to_https_url
 from state.veo_state import PageState
 
 
@@ -35,10 +36,7 @@ def video_display():
             if state.is_loading:
                 me.progress_spinner()
             elif state.result_video:
-                video_url = state.result_video.replace(
-                    "gs://",
-                    "https://storage.mtls.cloud.google.com/",
-                )
+                video_url = gcs_uri_to_https_url(state.result_video)
                 print(f"video_url: {video_url}")
                 me.video(
                     src=video_url,

--- a/experiments/veo-app/developers_guide.md
+++ b/experiments/veo-app/developers_guide.md
@@ -526,17 +526,9 @@ Here is how to use it on a page:
 
 ## Key Takeaways from the VTO Page Development
 
-- **GCS URI Handling:** This is a critical and recurring theme. The `common.storage.store_to_gcs` function returns a **full** GCS URI (e.g., `gs://your-bucket/your-object.png`). When using this value, you must be careful not to prepend the `gs://` prefix or the bucket name again. Doing so will create an invalid path and lead to "No such object" errors.
-    - **For API Calls:** Pass the GCS URI returned from `store_to_gcs` directly to the API.
-    - **For Displaying in Mesop:** To create a public URL for the `me.image` component, use the `.replace("gs://", "https://storage.mtls.cloud.google.com/")` method on the full GCS URI.
-
-- **Displaying GCS Images:** The `me.image` component requires a public HTTPS URL, not a `gs://` URI. To display images from GCS, replace `gs://` with `https://storage.mtls.cloud.google.com/`.
-
-- **State Management:** Avoid using mutable default values (like `[]`) in your state classes. Instead, use `field(default_factory=list)` to ensure that a new list is created for each user session.
-
-- **UI Components:** If a component doesn't support a specific parameter (like `label` on `me.slider`), you can often achieve the same result by wrapping it in a `me.box` and using other components (like `me.text`) to create the desired layout.
-
-- **Generator Functions:** When working with generator functions (those that use `yield`), make sure to include a `yield` statement after updating the state to ensure that the UI is updated.
+- **GCS URI Handling:** To ensure consistency and maintainability, always use the central utility functions in `common/utils.py` for converting between GCS URIs and public HTTPS URLs.
+    - **`gcs_uri_to_https_url(gcs_uri)`:** Use this function to convert a `gs://` URI to a public URL suitable for display in `me.image` or `me.video`.
+    - **`https_url_to_gcs_uri(url)`:** Use this function to convert a public URL back to a `gs://` URI, which is often required before passing a URL to a model API.
 
 ## Key Takeaways from the Veo Model Refactor
 

--- a/experiments/veo-app/models/veo.py
+++ b/experiments/veo-app/models/veo.py
@@ -19,6 +19,8 @@ from dotenv import load_dotenv
 from google import genai
 from google.genai import types
 
+from common.utils import gcs_uri_to_https_url
+
 from common.error_handling import GenerationError
 from config.default import Default
 from config.veo_models import get_veo_model_config

--- a/experiments/veo-app/models/vto.py
+++ b/experiments/veo-app/models/vto.py
@@ -22,6 +22,7 @@ from google.cloud import aiplatform
 from google.cloud.aiplatform.gapic import PredictResponse
 
 from common.storage import store_to_gcs
+from common.utils import https_url_to_gcs_uri
 from config.default import Default
 from models.model_setup import GeminiModelSetup, VtoModelSetup
 
@@ -79,17 +80,13 @@ def generate_vto_image(
     instance = {
         "personImage": {
             "image": {
-                "gcsUri": person_gcs_url.replace(
-                    "https://storage.mtls.cloud.google.com/", "gs://"
-                )
+                "gcsUri": https_url_to_gcs_uri(person_gcs_url)
             }
         },
         "productImages": [
             {
                 "image": {
-                    "gcsUri": product_gcs_url.replace(
-                        "https://storage.mtls.cloud.google.com/", "gs://"
-                    )
+                    "gcsUri": https_url_to_gcs_uri(product_gcs_url)
                 }
             }
         ],

--- a/experiments/veo-app/pages/character_consistency.py
+++ b/experiments/veo-app/pages/character_consistency.py
@@ -19,6 +19,7 @@ import mesop as me
 
 from common.metadata import get_media_item_by_id
 from common.storage import store_to_gcs
+from common.utils import gcs_uri_to_https_url
 from components.header import header
 from components.page_scaffold import page_frame, page_scaffold
 from models.character_consistency import generate_character_video
@@ -89,9 +90,7 @@ def character_consistency_page_content():
                 with me.box(style=me.Style(display="flex", flex_wrap="wrap", gap=10, justify_content="center")):
                     for uri in state.uploaded_image_gcs_uris:
                         me.image(
-                            src=uri.replace(
-                                "gs://", "https://storage.mtls.cloud.google.com/"
-                            ),
+                            src=gcs_uri_to_https_url(uri),
                             style=me.Style(width=200, height=200, object_fit="contain", border_radius="12px",
                                 box_shadow="0 2px 4px rgba(0,0,0,0.1)"),
                         )
@@ -215,15 +214,15 @@ def on_generate_click(e: me.ClickEvent):
             if step_result.data:
                 if "candidate_image_gcs_uris" in step_result.data:
                     state.candidate_image_urls = [
-                        uri.replace("gs://", "https://storage.mtls.cloud.google.com/")
+                        gcs_uri_to_https_url(uri)
                         for uri in step_result.data["candidate_image_gcs_uris"]
                     ]
                 if "best_image_gcs_uri" in step_result.data:
-                    state.best_image_url = step_result.data["best_image_gcs_uri"].replace("gs://", "https://storage.mtls.cloud.google.com/")
+                    state.best_image_url = gcs_uri_to_https_url(step_result.data["best_image_gcs_uri"])
                 if "outpainted_image_gcs_uri" in step_result.data:
-                    state.outpainted_image_url = step_result.data["outpainted_image_gcs_uri"].replace("gs://", "https://storage.mtls.cloud.google.com/")
+                    state.outpainted_image_url = gcs_uri_to_https_url(step_result.data["outpainted_image_gcs_uri"])
                 if "video_gcs_uri" in step_result.data:
-                    state.final_video_url = step_result.data["video_gcs_uri"].replace("gs://", "https://storage.mtls.cloud.google.com/")
+                    state.final_video_url = gcs_uri_to_https_url(step_result.data["video_gcs_uri"])
             yield
 
         state.status_message = f"Workflow complete! Total time: {state.total_generation_time:.2f} seconds"

--- a/experiments/veo-app/pages/lyria.py
+++ b/experiments/veo-app/pages/lyria.py
@@ -21,6 +21,7 @@ import mesop as me
 import datetime # Required for timestamp
 
 from common.metadata import MediaItem, add_media_item_to_firestore # Updated import
+from common.utils import gcs_uri_to_https_url
 from components.dialog import dialog, dialog_actions
 from components.header import header
 from components.page_scaffold import (
@@ -435,9 +436,7 @@ def on_click_lyria(e: me.ClickEvent):
     try:
         destination_blob_path = generate_music_with_lyria(prompt_for_api)
         gcs_uri_for_analysis_and_metadata = destination_blob_path
-        state.music_upload_uri = destination_blob_path.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        state.music_upload_uri = gcs_uri_to_https_url(destination_blob_path)
 
         print(f"Music generated: {state.music_upload_uri}")
         generated_successfully = True

--- a/experiments/veo-app/pages/portraits.py
+++ b/experiments/veo-app/pages/portraits.py
@@ -29,6 +29,7 @@ from tenacity import (
 
 from common.metadata import MediaItem, add_media_item_to_firestore
 from common.storage import store_to_gcs
+from common.utils import gcs_uri_to_https_url
 from components.dialog import dialog
 from components.header import header
 from components.library.events import LibrarySelectionChangeEvent
@@ -421,9 +422,7 @@ def motion_portraits_content(app_state: me.state):
                                 margin=me.Margin(bottom=10),
                             ),
                         )
-                        video_url = state.result_video.replace(
-                            "gs://", "https://storage.mtls.cloud.google.com/"
-                        )
+                        video_url = gcs_uri_to_https_url(state.result_video)
                         print(f"Displaying result video: {video_url}")
                         me.video(
                             src=video_url,
@@ -560,9 +559,7 @@ def on_click_upload(e: me.UploadEvent):
     )
     state.reference_image_gcs = destination_blob_name
     # url
-    state.reference_image_uri = destination_blob_name.replace(
-        "gs://", f"https://storage.mtls.cloud.google.com/"
-    )
+    state.reference_image_uri = gcs_uri_to_https_url(destination_blob_name)
     # log
     print(
         f"{destination_blob_name} with contents len {len(contents)} of type {e.file.mime_type} uploaded to {config.GENMEDIA_BUCKET}."
@@ -573,9 +570,7 @@ def on_portrait_image_from_library(e: LibrarySelectionChangeEvent):
     """Portrait image from library handler."""
     state = me.state(PageState)
     state.reference_image_gcs = e.gcs_uri
-    state.reference_image_uri = e.gcs_uri.replace(
-        "gs://", f"https://storage.mtls.cloud.google.com/"
-    )
+    state.reference_image_uri = gcs_uri_to_https_url(e.gcs_uri)
     yield
 
 

--- a/experiments/veo-app/pages/recontextualize.py
+++ b/experiments/veo-app/pages/recontextualize.py
@@ -19,6 +19,7 @@ import mesop as me
 
 from common.metadata import add_media_item
 from common.storage import store_to_gcs
+from common.utils import gcs_uri_to_https_url
 from components.dialog import dialog
 from components.header import header
 from components.library.events import LibrarySelectionChangeEvent
@@ -233,8 +234,7 @@ def on_generate(e: me.ClickEvent):
             state.uploaded_image_gcs_uris, state.prompt, state.recontext_sample_count
         )
         state.result_images = [
-            uri.replace("gs://", "https://storage.mtls.cloud.google.com/")
-            for uri in result_gcs_uris
+            gcs_uri_to_https_url(uri) for uri in result_gcs_uris
         ]
         add_media_item(
             user_email=app_state.user_email,

--- a/experiments/veo-app/pages/veo.py
+++ b/experiments/veo-app/pages/veo.py
@@ -22,6 +22,7 @@ from common.analytics import track_model_call
 from common.error_handling import GenerationError
 from common.metadata import MediaItem, add_media_item_to_firestore  # Updated import
 from common.storage import store_to_gcs
+from common.utils import gcs_uri_to_https_url
 from components.dialog import dialog, dialog_actions
 from components.header import header
 from components.library.events import LibrarySelectionChangeEvent
@@ -52,9 +53,7 @@ def on_veo_load(e: me.LoadEvent):
     if source_image_uri:
         # Set the image from the query parameter
         state.reference_image_gcs = source_image_uri
-        state.reference_image_uri = source_image_uri.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        state.reference_image_uri = gcs_uri_to_https_url(source_image_uri)
         # Switch to the Image-to-Video tab
         state.veo_mode = "i2v"
         # Provide a default prompt for a better user experience
@@ -411,9 +410,7 @@ def on_upload_image(e: me.UploadEvent):
         )
         # Update the state with the new image details
         state.reference_image_gcs = gcs_path
-        state.reference_image_uri = gcs_path.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        state.reference_image_uri = gcs_uri_to_https_url(gcs_path)
         state.reference_image_mime_type = e.file.mime_type
         print(f"Image uploaded to {gcs_path} with mime type {e.file.mime_type}")
     except Exception as ex:
@@ -432,9 +429,7 @@ def on_upload_last_image(e: me.UploadEvent):
         )
         # Update the state with the new image details
         state.last_reference_image_gcs = gcs_path
-        state.last_reference_image_uri = gcs_path.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        state.last_reference_image_uri = gcs_uri_to_https_url(gcs_path)
         state.last_reference_image_mime_type = e.file.mime_type
     except Exception as ex:
         state.error_message = f"Failed to upload image: {ex}"
@@ -450,12 +445,8 @@ def on_veo_image_from_library(e: LibrarySelectionChangeEvent):
         or e.chooser_id == "first_frame_library_chooser"
     ):
         state.reference_image_gcs = e.gcs_uri
-        state.reference_image_uri = e.gcs_uri.replace(
-            "gs://", f"https://storage.mtls.cloud.google.com/"
-        )
+        state.reference_image_uri = gcs_uri_to_https_url(e.gcs_uri)
     elif e.chooser_id == "last_frame_library_chooser":
         state.last_reference_image_gcs = e.gcs_uri
-        state.last_reference_image_uri = e.gcs_uri.replace(
-            "gs://", f"https://storage.mtls.cloud.google.com/"
-        )
+        state.last_reference_image_uri = gcs_uri_to_https_url(e.gcs_uri)
     yield

--- a/experiments/veo-app/pages/vto.py
+++ b/experiments/veo-app/pages/vto.py
@@ -23,6 +23,7 @@ import mesop as me
 
 from common.metadata import add_media_item
 from common.storage import store_to_gcs
+from common.utils import gcs_uri_to_https_url
 from components.header import header
 from components.library.events import LibrarySelectionChangeEvent
 from components.library.library_chooser_button import library_chooser_button
@@ -93,9 +94,7 @@ def on_upload_person(e: me.UploadEvent):
     gcs_url = store_to_gcs(
         "vto_person_images", e.file.name, e.file.mime_type, e.file.getvalue()
     )
-    state.person_image_gcs = gcs_url.replace(
-        "gs://", "https://storage.mtls.cloud.google.com/"
-    )
+    state.person_image_gcs = gcs_uri_to_https_url(gcs_url)
     yield
 
 
@@ -106,14 +105,10 @@ def on_library_chooser(e: LibrarySelectionChangeEvent):
     state = me.state(PageState)
     if e.chooser_id == "person_library_chooser":
         print("STATE: person image")
-        state.person_image_gcs = e.gcs_uri.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        state.person_image_gcs = gcs_uri_to_https_url(e.gcs_uri)
     elif e.chooser_id == "product_library_chooser":
         print("STATE: prod image")
-        state.product_image_gcs = e.gcs_uri.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        state.product_image_gcs = gcs_uri_to_https_url(e.gcs_uri)
     yield
 
 
@@ -124,9 +119,7 @@ def on_upload_product(e: me.UploadEvent):
     gcs_url = store_to_gcs(
         "vto_product_images", e.file.name, e.file.mime_type, e.file.getvalue()
     )
-    state.product_image_gcs = gcs_url.replace(
-        "gs://", "https://storage.mtls.cloud.google.com/"
-    )
+    state.product_image_gcs = gcs_uri_to_https_url(gcs_url)
     yield
 
 
@@ -162,9 +155,7 @@ def on_click_generate_person(e: me.ClickEvent):
         # The result from generate_virtual_models is a GCS URI, so we can use it directly
         gcs_url = image_urls[0]
 
-        state.person_image_gcs = gcs_url.replace(
-            "gs://", "https://storage.mtls.cloud.google.com/"
-        )
+        state.person_image_gcs = gcs_uri_to_https_url(gcs_url)
 
     except Exception as e:
         state.error_message = str(e)
@@ -190,8 +181,7 @@ def on_generate(e: me.ClickEvent):
         )
         print(f"Result GCS URIs: {result_gcs_uris}")
         state.result_images = [
-            uri.replace("gs://", "https://storage.mtls.cloud.google.com/")
-            for uri in result_gcs_uris
+            gcs_uri_to_https_url(uri) for uri in result_gcs_uris
         ]
         add_media_item(
             user_email=app_state.user_email,


### PR DESCRIPTION
This commit refactors the entire application to use a central utility function for converting GCS URIs to public HTTPS URLs.

Previously, this conversion was done with dozens of manual `.replace()` calls across Python components, pages, and JavaScript files. This approach was repetitive and error-prone.

This change enhances two central utility functions in `common/utils.py`:
- `gcs_uri_to_https_url()`
- `https_url_to_gcs_uri()`

All relevant files have been updated to use these functions, improving code maintainability, readability, and robustness.

Additionally, the documentation (`GEMINI.md`, `developers_guide.md`) has been updated to reflect this new best practice.