### PR TITLE
refactor: convenience parsing of GENMEDIA_BUCKET

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/README.md
@@ -125,6 +125,7 @@ This repository provides AI application samples for:
 
 *   [Google ADK (Agent Development Kit)](../sample-agents/adk/README.md)
 *   [Google Firebase Genkit](../sample-agents/genkit/README.md)
+*   [Google Gemini CLI](../sample-agents/geminicli/README.md)
 
 
 ## Available Go MCP Servers:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/config.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/config.go
@@ -3,6 +3,7 @@ package common
 import (
 	"log"
 	"os"
+	"strings"
 )
 
 type Config struct {
@@ -18,10 +19,15 @@ func LoadConfig() *Config {
 		log.Fatal("PROJECT_ID environment variable not set. Please set the env variable, e.g. export PROJECT_ID=$(gcloud config get project)")
 	}
 
+	genmediaBucket := GetEnv("GENMEDIA_BUCKET", "")
+	if genmediaBucket != "" {
+		genmediaBucket = strings.TrimPrefix(genmediaBucket, "gs://")
+	}
+
 	return &Config{
 		ProjectID:      projectID,
 		Location:       GetEnv("LOCATION", "us-central1"),
-		GenmediaBucket: GetEnv("GENMEDIA_BUCKET", ""),
+		GenmediaBucket: genmediaBucket,
 		ApiEndpoint:    os.Getenv("VERTEX_API_ENDPOINT"), // Use os.Getenv for optional value
 	}
 }


### PR DESCRIPTION
* Addresses #649  - more permissing GENMEDIA_BUCKET parsing (allows for gs:// or no gs:// prefix)
* Updates README to add reference to Gemini CLI configs

