### PR TITLE
fix: changed Portraits page to persist gcsuri as a string, not an array of strings

### DIFF
--- a/experiments/veo-app/common/metadata.py
+++ b/experiments/veo-app/common/metadata.py
@@ -189,6 +189,15 @@ def get_media_item_by_id(
                 )
             except (ValueError, TypeError):
                 item_duration = None
+            
+            gcsuri: str = None
+            
+            if isinstance(raw_item_data.get("gcsuri"), list):
+                gcsuri = raw_item_data.get("gcsuri")[0] if raw_item_data.get("gcsuri") else None
+            elif raw_item_data.get("gcsuri") is not None:
+                gcsuri = str(raw_item_data.get("gcsuri"))
+            else:
+                gcsuri = None
 
             media_item = MediaItem(
                 id=doc.id,
@@ -198,9 +207,7 @@ def get_media_item_by_id(
                 aspect=str(raw_item_data.get("aspect"))
                 if raw_item_data.get("aspect") is not None
                 else None,
-                gcsuri=str(raw_item_data.get("gcsuri"))
-                if raw_item_data.get("gcsuri") is not None
-                else None,
+                gcsuri=gcsuri,
                 gcs_uris=raw_item_data.get("gcs_uris", []),
                 prompt=str(raw_item_data.get("original_prompt"))
                 if raw_item_data.get("original_prompt") is not None
@@ -369,9 +376,19 @@ def get_media_for_page(
         all_fetched_items: List[MediaItem] = []
         for doc in query.limit(fetch_limit).stream():
             raw_item_data = doc.to_dict()
+            
             if raw_item_data is None:
                 print(f"Warning: doc.to_dict() returned None for doc ID: {doc.id}")
                 continue
+
+            gcsuri: str = None
+
+            if isinstance(raw_item_data.get("gcsuri"), list):
+                gcsuri = raw_item_data.get("gcsuri")[0] if raw_item_data.get("gcsuri") else None
+            elif raw_item_data.get("gcsuri") is not None:
+                gcsuri = str(raw_item_data.get("gcsuri"))
+            else:
+                gcsuri = None
 
             mime_type = raw_item_data.get("mime_type", "")
             error_message_present = bool(raw_item_data.get("error_message"))
@@ -442,9 +459,7 @@ def get_media_for_page(
                 aspect=str(raw_item_data.get("aspect"))
                 if raw_item_data.get("aspect") is not None
                 else None,
-                gcsuri=str(raw_item_data.get("gcsuri"))
-                if raw_item_data.get("gcsuri") is not None
-                else None,
+                gcsuri=gcsuri,
                 gcs_uris=raw_item_data.get("gcs_uris", []),
                 source_images_gcs=raw_item_data.get("source_images_gcs", []),
                 prompt=str(raw_item_data.get("prompt"))
@@ -559,6 +574,13 @@ def get_media_for_page_optimized(
             if raw_item_data is None:
                 continue
 
+            if isinstance(raw_item_data.get("gcsuri"), list):
+                gcsuri = raw_item_data.get("gcsuri")[0] if raw_item_data.get("gcsuri") else None
+            elif raw_item_data.get("gcsuri") is not None:
+                gcsuri = str(raw_item_data.get("gcsuri"))
+            else:
+                gcsuri = None
+
             timestamp_iso_str: Optional[str] = None
             raw_timestamp = raw_item_data.get("timestamp")
             if isinstance(raw_timestamp, datetime.datetime):
@@ -591,9 +613,7 @@ def get_media_for_page_optimized(
                 aspect=str(raw_item_data.get("aspect"))
                 if raw_item_data.get("aspect") is not None
                 else None,
-                gcsuri=str(raw_item_data.get("gcsuri"))
-                if raw_item_data.get("gcsuri") is not None
-                else None,
+                gcsuri=gcsuri,
                 gcs_uris=raw_item_data.get("gcs_uris", []),
                 source_images_gcs=raw_item_data.get("source_images_gcs", []),
                 prompt=str(raw_item_data.get("prompt"))

--- a/experiments/veo-app/pages/portraits.py
+++ b/experiments/veo-app/pages/portraits.py
@@ -422,7 +422,7 @@ def motion_portraits_content(app_state: me.state):
                                 margin=me.Margin(bottom=10),
                             ),
                         )
-                        video_url = gcs_uri_to_https_url(state.result_video[0])
+                        video_url = gcs_uri_to_https_url(state.result_video)
                         print(f"Displaying result video: {video_url}")
                         me.video(
                             src=video_url,
@@ -684,6 +684,7 @@ Do not describe the frame. There should be no lip movement like speaking, but th
         state.timing = f"Generation time: {round(execution_time)} seconds"
 
         if gcs_uri:
+            gcs_uri = gcs_uri[0]
             state.result_video = gcs_uri
             print(f"Video generated: {gcs_uri}.")
         else:


### PR DESCRIPTION
- Persisting as array of strings broke logic in other locations that assumed gcsuri was a single GCS URI
- Changed media item retrieval to handle gcsuri possibly containing an array of strings to select the first one.