### PR TITLE
fix: add CORS configuration to Terraform template

### DIFF
--- a/experiments/veo-app/developers_guide.md
+++ b/experiments/veo-app/developers_guide.md
@@ -88,11 +88,7 @@ This section outlines the key architectural patterns and best practices that are
 
 *   **Problem:** You need to display a GCS object (like an image or video) in the browser, or a web component needs to fetch the data of a GCS object.
 *   **The Challenge:** Directly using `gs://` or even `https://storage.cloud.google.com` URLs in the frontend will fail due to browser security policies (CORS, CSP) and GCS redirects.
-*   **The Solution:** The correct and most secure pattern is to use **signed URLs**.
-    1.  Create a FastAPI endpoint (e.g., `/api/get_signed_url`) that takes a `gs://` URI as input.
-    2.  This endpoint uses the Python GCS client library to generate a short-lived, publicly accessible signed URL.
-    3.  The frontend (either a Mesop component or a custom web component) calls this endpoint to get the signed URL and then uses that URL to display or fetch the resource.
-*   **For full implementation details**, including how to handle local development vs. a deployed Cloud Run environment (with IAP), see the detailed `plans/WEB_COMPONENT_INTEGRATION_GUIDE.md`.
+*   **The Solution:** Set the allow_local_domain_cors_requests Terraform variable to true in your `terraform.tfvars` file. This will instruct the Terraform template to allow requests from the "0.0.0.0:8080" and "localhost:8080" domains.
 
 ### Error Handling Philosophy
 

--- a/experiments/veo-app/variables.tf
+++ b/experiments/veo-app/variables.tf
@@ -20,7 +20,7 @@ variable "project_id" {
 
 variable "region" {
   description = "Location for load balancer and Cloud Run resources"
-  type = string
+  type        = string
   default     = "us-central1"
 }
 
@@ -38,38 +38,38 @@ variable "domain" {
 
 variable "initial_container_image" {
   description = "Container image to use for the Cloud Run service hosting Creative Studio. Because infra is deployed through Terraform this defaults to placeholder image; however, if you are applying Terraform template post initial deployment, use the latest built image to avoid reverting back to the placeholder."
-  type = string
-  default = "us-docker.pkg.dev/cloudrun/container/placeholder"
+  type        = string
+  default     = "us-docker.pkg.dev/cloudrun/container/placeholder"
 }
 
 variable "model_id" {
   description = "Veo model ID to use for video generation"
-  type = string
-  default = "gemini-2.5-flash"
+  type        = string
+  default     = "gemini-2.5-flash"
 }
 
 variable "veo_model_id" {
   description = "Veo model ID to use for video generation"
-  type = string
-  default = "veo-3.0-generate-001"
+  type        = string
+  default     = "veo-3.0-generate-001"
 }
 
 variable "veo_exp_model_id" {
   description = "Experimental Veo model ID to use for video generation"
-  type = string
-  default = "veo-3.0-generate-preview"
+  type        = string
+  default     = "veo-3.0-generate-preview"
 }
 
 variable "lyria_model_id" {
   description = "Lyria model ID to use for audio generation"
-  type = string
-  default = "lyria-002"
+  type        = string
+  default     = "lyria-002"
 }
 
 variable "edit_images_enabled" {
   description = "Feature flag for Edit Images feature"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "enable_data_deletion" {
@@ -80,7 +80,13 @@ variable "enable_data_deletion" {
 
 variable "initial_user" {
   description = "Email address of initial user that will be granted access to Creative Studio in IAP"
-  type = string
-  nullable = true
-  default = null
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "allow_local_domain_cors_requests" {
+  description = "Whether to allow local domain requests to the assets GCS bucket"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
- Added CORS settings to Terraform file and new allow_local_domain_cors_requests variable which can be used to set bucket's CORS policy to allow requests from 0.0.0.0 and localhost domains.
- Updated developer guide to note new variable.