### PR TITLE
feat(theme): Persist theme mode across sessions

### DIFF
--- a/components/page_scaffold.py
+++ b/components/page_scaffold.py
@@ -23,6 +23,13 @@ from components.styles import (
     SIDENAV_MAX_WIDTH,
     SIDENAV_MIN_WIDTH,
 )
+from components.theme_manager.theme_manager import theme_manager
+
+def on_theme_load(e: me.WebEvent):
+    s = me.state(AppState)
+    s.theme_mode = e.value["theme"]
+    me.set_theme_mode(s.theme_mode)
+    yield
 
 
 @me.content_component
@@ -32,6 +39,8 @@ def page_scaffold(page_name: str):
     app_state = me.state(AppState)
     app_state.current_page = page_name
     log_page_view(page_name=page_name, session_id=app_state.session_id)
+
+    theme_manager(theme=app_state.theme_mode, on_theme_load=on_theme_load)
 
     sidenav("")
 

--- a/components/theme_manager/theme_manager.js
+++ b/components/theme_manager/theme_manager.js
@@ -1,0 +1,36 @@
+import { LitElement } from 'https://esm.sh/lit';
+
+class ThemeManager extends LitElement {
+  static get properties() {
+    return {
+      theme: { type: String },
+      themeLoaded: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this.theme = '';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme) {
+      this.dispatchEvent(new MesopEvent(this.themeLoaded, { theme: storedTheme }));
+    }
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('theme') && this.theme) {
+      localStorage.setItem('theme', this.theme);
+    }
+  }
+
+  render() {
+    // This component is non-visual
+    return '';
+  }
+}
+
+customElements.define('theme-manager', ThemeManager);

--- a/components/theme_manager/theme_manager.py
+++ b/components/theme_manager/theme_manager.py
@@ -1,0 +1,18 @@
+import mesop as me
+import typing
+
+@me.web_component(path="./theme_manager.js")
+def theme_manager(
+    *,
+    theme: str,
+    on_theme_load: typing.Callable[[me.WebEvent], None],
+):
+    return me.insert_web_component(
+        name="theme-manager",
+        properties={
+            "theme": theme,
+        },
+        events={
+            "themeLoaded": on_theme_load,
+        },
+    )

--- a/main.py
+++ b/main.py
@@ -234,6 +234,8 @@ app.mount(
     name="assets",
 )
 
+
+
 app.mount(
     "/",
     WSGIMiddleware(

--- a/pages/test_index.py
+++ b/pages/test_index.py
@@ -14,6 +14,9 @@
 
 import mesop as me
 from components.header import header
+from components.page_scaffold import on_theme_load
+from components.theme_manager.theme_manager import theme_manager
+from state.state import AppState
 
 
 def on_navigate(e: me.ClickEvent):
@@ -24,6 +27,9 @@ def on_navigate(e: me.ClickEvent):
     path="/labs",
 )
 def page():
+    app_state = me.state(AppState)
+    theme_manager(theme=app_state.theme_mode, on_theme_load=on_theme_load)
+
     test_pages = [
         {
             "title": "VTO Model Composite Card Generator",

--- a/pages/test_vto_prompt_generator.py
+++ b/pages/test_vto_prompt_generator.py
@@ -24,6 +24,8 @@ from common.metadata import add_media_item
 from common.utils import gcs_uri_to_https_url
 from components.dialog import dialog
 from components.header import header
+from components.page_scaffold import on_theme_load
+from components.theme_manager.theme_manager import theme_manager
 from models.image_models import generate_virtual_models
 from models.virtual_model_generator import DEFAULT_PROMPT, VirtualModelGenerator
 from state.state import AppState

--- a/pages/welcome.py
+++ b/pages/welcome.py
@@ -18,6 +18,8 @@ import mesop as me
 
 from common.analytics import log_page_view
 from components.welcome_hero.welcome_hero import welcome_hero
+from components.page_scaffold import on_theme_load
+from components.theme_manager.theme_manager import theme_manager
 from state.state import AppState
 
 
@@ -40,6 +42,8 @@ def page():
     """Define the Mesop page route for the welcome page."""
     app_state = me.state(AppState)
     log_page_view(page_name="welcome", session_id=app_state.session_id)
+
+    theme_manager(theme=app_state.theme_mode, on_theme_load=on_theme_load)
 
     tiles_data = [
         {"icon": "home", "route": "/home"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ google-cloud-storage==2.19.0
     # via
     #   firebase-admin
     #   google-cloud-aiplatform
-google-cloud-texttospeech==2.29.0
+google-cloud-texttospeech==2.30.0
     # via veo-app (pyproject.toml)
 google-crc32c==1.7.1
     # via
@@ -401,11 +401,11 @@ uritemplate==4.2.0
     # via google-api-python-client
 urllib3==2.5.0
     # via requests
-uvicorn==0.35.0
+uvicorn==0.36.0
     # via veo-app (pyproject.toml)
 watchdog==6.0.0
     # via mesop
-wcwidth==0.2.13
+wcwidth==0.2.14
     # via prompt-toolkit
 websockets==15.0.1
     # via google-genai

--- a/state/state.py
+++ b/state/state.py
@@ -21,7 +21,7 @@ class AppState:
     """Mesop Application State"""
 
     sidenav_open: bool = False
-    theme_mode: str = "light"
+    theme_mode: str = "dark"
     user_email: str = "anonymous@google.com"
     session_id: str = ""
     current_page: str = ""

--- a/uv.lock
+++ b/uv.lock
@@ -366,16 +366,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.116.2"
+version = "0.117.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/64/1296f46d6b9e3b23fb22e5d01af3f104ef411425531376212f1eefa2794d/fastapi-0.116.2.tar.gz", hash = "sha256:231a6af2fe21cfa2c32730170ad8514985fc250bec16c9b242d3b94c835ef529", size = 298595, upload-time = "2025-09-16T18:29:23.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/7e/d9788300deaf416178f61fb3c2ceb16b7d0dc9f82a08fdb87a5e64ee3cc7/fastapi-0.117.1.tar.gz", hash = "sha256:fb2d42082d22b185f904ca0ecad2e195b851030bd6c5e4c032d1c981240c631a", size = 307155, upload-time = "2025-09-20T20:16:56.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/e4/c543271a8018874b7f682bf6156863c416e1334b8ed3e51a69495c5d4360/fastapi-0.116.2-py3-none-any.whl", hash = "sha256:c3a7a8fb830b05f7e087d920e0d786ca1fc9892eb4e9a84b227be4c1bc7569db", size = 95670, upload-time = "2025-09-16T18:29:21.329Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/45/d9d3e8eeefbe93be1c50060a9d9a9f366dba66f288bb518a9566a23a8631/fastapi-0.117.1-py3-none-any.whl", hash = "sha256:33c51a0d21cab2b9722d4e56dbb9316f3687155be6b276191790d8da03507552", size = 95959, upload-time = "2025-09-20T20:16:53.661Z" },
 ]
 
 [[package]]
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-texttospeech"
-version = "2.29.0"
+version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -673,9 +673,9 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/22/f9ac9fb703ccb31a4bbbfe5a188642d3cce6f41e2d402c7f7d86982fdbdf/google_cloud_texttospeech-2.29.0.tar.gz", hash = "sha256:2c0b7378ba7639f70737f4a39de2493d30c85d387b8c16822c6e7e100c1c75a3", size = 184019, upload-time = "2025-09-04T14:54:38.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/04/2c56fcdf8bbc9b11218229c47106a2b937e7fbdc3fc509c6f8ec75455486/google_cloud_texttospeech-2.30.0.tar.gz", hash = "sha256:bc190a1199f2928f30d2843a6cafe5afa68b5520090e5606e8e212c36516e394", size = 184352, upload-time = "2025-09-22T16:51:18.838Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/21/9f6d8166691b153f7814e8e2aa0fdbdc1df44f7c61b8a3c98bc9abce39b6/google_cloud_texttospeech-2.29.0-py3-none-any.whl", hash = "sha256:fde126e928379958d5ef8fa7bad84ac7ede6291a6fccea8d4b218b7520b91d52", size = 190381, upload-time = "2025-09-04T14:54:25.222Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3e/2d3a8aa76820766a41f1a855fcacccd33cb36899bd04ebe0808b37218e7c/google_cloud_texttospeech-2.30.0-py3-none-any.whl", hash = "sha256:73e98fe47ab61a17db9c711e9ee4f813fd921c2ebe86d8ae5251648b420380eb", size = 190838, upload-time = "2025-09-22T16:51:04.686Z" },
 ]
 
 [[package]]
@@ -1652,11 +1652,11 @@ crypto = [
 
 [[package]]
 name = "pyparsing"
-version = "3.2.4"
+version = "3.2.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/c9/b4594e6a81371dfa9eb7a2c110ad682acf985d96115ae8b25a1d63b4bf3b/pyparsing-3.2.4.tar.gz", hash = "sha256:fff89494f45559d0f2ce46613b419f632bbb6afbdaed49696d322bcf98a58e99", size = 1098809, upload-time = "2025-09-13T05:47:19.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b8/fbab973592e23ae313042d450fc26fa24282ebffba21ba373786e1ce63b4/pyparsing-3.2.4-py3-none-any.whl", hash = "sha256:91d0fcde680d42cd031daf3a6ba20da3107e08a75de50da58360e7d94ab24d36", size = 113869, upload-time = "2025-09-13T05:47:17.863Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
 ]
 
 [[package]]
@@ -1933,14 +1933,14 @@ wheels = [
 
 [[package]]
 name = "tifffile"
-version = "2025.9.9"
+version = "2025.9.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/a7/b77bd01f97d72bb70194f036e77f45927978f43017254762c784d7e10f49/tifffile-2025.9.9.tar.gz", hash = "sha256:6cf97ef548970eee9940cf8fc4203e57b4462a72e1e5e7a667ecdeb96113bc5f", size = 369652, upload-time = "2025-09-10T00:02:19.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/1d/99d2eb1d50f0832d6e6e057f7d3239b77210d663a048780b029d10324b14/tifffile-2025.9.20.tar.gz", hash = "sha256:a0fed4c613ff728979cb6abfd40832b6f36dc9da8183e52840418a25a00552eb", size = 368988, upload-time = "2025-09-20T17:24:43.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/c5/0d57e3547add58285f401afbc421bd3ffeddbbd275a2c0b980b9067fda4a/tifffile-2025.9.9-py3-none-any.whl", hash = "sha256:239247551fa10b5679036ee030cdbeb7762bc1b3f11b1ddaaf50759ef8b4eb26", size = 230668, upload-time = "2025-09-10T00:02:17.839Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/15/e38bf2234e8c09fccc6ec53a7a4374e38a86f7a9d8394fb9c06e1a0f25a5/tifffile-2025.9.20-py3-none-any.whl", hash = "sha256:549dda2f2c65cc63b3d946942b9b43c09ae50caaae0aa7ea3d91a915acd45444", size = 230101, upload-time = "2025-09-20T17:24:41.831Z" },
 ]
 
 [[package]]
@@ -2014,15 +2014,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.35.0"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/5e/f0cd46063a02fd8515f0e880c37d2657845b7306c16ce6c4ffc44afd9036/uvicorn-0.36.0.tar.gz", hash = "sha256:527dc68d77819919d90a6b267be55f0e76704dca829d34aea9480be831a9b9d9", size = 80032, upload-time = "2025-09-20T01:07:14.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+    { url = "https://files.pythonhosted.org/packages/96/06/5cc0542b47c0338c1cb676b348e24a1c29acabc81000bced518231dded6f/uvicorn-0.36.0-py3-none-any.whl", hash = "sha256:6bb4ba67f16024883af8adf13aba3a9919e415358604ce46780d3f9bdc36d731", size = 67675, upload-time = "2025-09-20T01:07:12.984Z" },
 ]
 
 [[package]]
@@ -2101,11 +2101,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.2.13"
+version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Previously, the theme mode was not retained across page reloads. This was because the theme was only stored in the application state, which is ephemeral.

This change introduces a `theme_manager` web component that uses the browser's `localStorage` to persist the theme mode.

The `page_scaffold` now includes the `theme_manager` component, which loads the theme from `localStorage` on initial load and saves it whenever it changes.

This ensures that the user's theme preference is maintained across sessions.


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
