### PR TITLE
fix(rewriter): Improve prompt to prevent multiple outputs

### DIFF
--- a/config/rewriters.py
+++ b/config/rewriters.py
@@ -47,7 +47,7 @@ For each image, provide a critique in the following format:
 """
 
 
-REWRITER_PROMPT = """Write a prompt for a text-to-image model following the style of the examples of prompts, and then I will give you a prompt that I want you to rewrite.
+REWRITER_PROMPT = """You are an expert prompt engineer. Your task is to rewrite the following prompt to be more descriptive and detailed, following the style of the examples provided.
 
 Examples of prompts:
 
@@ -64,9 +64,9 @@ A Dalmatian dog in front of a pink background in a full body dynamic pose shot w
 A massive spaceship floating above an industrial city, with the lights of thousands of buildings glowing in the dusk. The atmosphere is dark and mysterious, in the cyberpunk style, and cinematic
 An architectural photograph of an interior space made from interwoven, organic forms and structures inspired in the style of coral reefs and patterned textures. The scene is bathed in the warm glow of natural light, creating intricate shadows that accentuate the fluidity and harmony between the different elements within the design
 
-Prompt to rewrite:
+Rewrite the following prompt:
 
 '{}'
 
-Don’t generate images, provide only the rewritten prompt.
+Your response should be a single, rewritten prompt and nothing else.
 """


### PR DESCRIPTION
The previous rewriter prompt was sometimes causing the model to generate multiple, separate prompts instead of a single, rewritten prompt.

This commit improves the rewriter prompt to be more direct and less ambiguous. It now explicitly asks the model to rewrite the user's prompt and to only provide a single, rewritten prompt in its response.

This ensures that the rewriter consistently returns a single, high-quality prompt.

Fixes #757


**Fixes #<Issue Number>** (if applicable)

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [ ] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
