### PR TITLE
refactor(interior_design): Componentize v2 page and rename v1

### DIFF
--- a/components/interior_design/design_studio.py
+++ b/components/interior_design/design_studio.py
@@ -1,0 +1,69 @@
+"""
+Component for the Design Studio.
+"""
+
+from typing import Callable
+import mesop as me
+
+from common.utils import gcs_uri_to_https_url
+from components.library.events import LibrarySelectionChangeEvent
+from components.library.library_chooser_button import library_chooser_button
+from components.veo_button.veo_button import veo_button
+
+
+@me.component
+def design_studio(
+    storyboard_item: dict,
+    design_image_uri: str,
+    is_designing: bool,
+    on_upload_design_image: Callable,
+    on_select_design_image: Callable,
+    on_design_prompt_blur: Callable,
+    on_clear_design: Callable,
+    on_design_click: Callable,
+):
+    """
+    Component for the Design Studio.
+    """
+    with me.box(
+        style=me.Style(
+            display="flex", flex_direction="column", gap=16, width=300
+        )
+    ):
+        me.text("Design Studio", type="headline-6")
+        with me.box(style=me.Style(
+            flex_direction="column", display="flex",
+        )):
+            me.uploader(
+                label="Upload Design Image",
+                on_upload=on_upload_design_image,
+                style=me.Style(width="100%"),
+                accepted_file_types=["image/jpeg", "image/png", "image/webp"],
+            )
+            library_chooser_button(
+                key="design_image_library_chooser",
+                on_library_select=on_select_design_image,
+                button_label="Add from Library",
+            )
+        if design_image_uri:
+            me.image(
+                src=gcs_uri_to_https_url(design_image_uri),
+                style=me.Style(width="100%", border_radius=8, margin=me.Margin(top=8)),
+            )
+        me.textarea(
+            label="Design Modifications",
+            on_blur=on_design_prompt_blur,
+            style=me.Style(width="100%"),
+        )
+        with me.box(style=me.Style(display="flex", flex_direction="row", gap=8)):
+            me.button("Clear", on_click=on_clear_design, type="stroked")
+            with me.content_button(
+                on_click=on_design_click,
+                type="raised",
+                disabled=is_designing,
+            ):
+                if is_designing:
+                    me.progress_spinner(diameter=18)
+                else:
+                    me.text("Design")
+        veo_button(gcs_uri=storyboard_item["styled_image_uri"] if storyboard_item else "")

--- a/components/interior_design/floor_plan_uploader.py
+++ b/components/interior_design/floor_plan_uploader.py
@@ -1,0 +1,79 @@
+"""
+Component for uploading a floor plan.
+"""
+
+from typing import Callable
+import mesop as me
+
+from common.storage import store_to_gcs
+from common.utils import gcs_uri_to_https_url
+from components.library.events import LibrarySelectionChangeEvent
+from components.library.library_chooser_button import library_chooser_button
+from state.interior_design_v2_state import PageState
+
+
+IMAGE_PLACEHOLDER_STYLE = me.Style(
+    width=400,
+    height=400,
+    border=me.Border.all(
+        me.BorderSide(width=2, style="dashed", color=me.theme_var("outline-variant")),
+    ),
+    border_radius=8,
+    display="flex",
+    align_items="center",
+    justify_content="center",
+    flex_direction="column",
+    gap=8,
+)
+
+
+@me.component
+def floor_plan_uploader(
+    storyboard: dict,
+    on_upload: Callable,
+    on_library_select: Callable,
+):
+    """
+    Component for uploading a floor plan.
+    """
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="column",
+            gap=10,
+            align_items="center",
+        )
+    ):
+        me.text("Floor Plan", type="headline-6")
+        with me.box(
+            style=me.Style(
+                display="flex",
+                flex_direction="row",
+                gap=8,
+                align_items="center",
+                min_height=48,
+            )
+        ):
+            me.uploader(
+                label="Upload Floor Plan",
+                on_upload=on_upload,
+                accepted_file_types=["image/jpeg", "image/png", "image/webp"],
+                style=me.Style(width="100%"),
+            )
+            library_chooser_button(
+                key="floor_plan", on_library_select=on_library_select
+            )
+        with me.box(style=IMAGE_PLACEHOLDER_STYLE):
+            if storyboard and storyboard.get("original_floor_plan_uri"):
+                me.image(
+                    src=gcs_uri_to_https_url(storyboard["original_floor_plan_uri"]),
+                    style=me.Style(
+                        height="100%",
+                        width="100%",
+                        border_radius=8,
+                        object_fit="contain",
+                    ),
+                )
+            else:
+                me.icon("floorplan")
+                me.text("Add a floor plan")

--- a/components/interior_design/generated_3d_view.py
+++ b/components/interior_design/generated_3d_view.py
@@ -1,0 +1,74 @@
+"""
+Component for generating and displaying the 3D view.
+"""
+
+from typing import Callable
+import mesop as me
+
+from common.utils import gcs_uri_to_https_url
+
+
+IMAGE_PLACEHOLDER_STYLE = me.Style(
+    width=400,
+    height=400,
+    border=me.Border.all(
+        me.BorderSide(width=2, style="dashed", color=me.theme_var("outline-variant")),
+    ),
+    border_radius=8,
+    display="flex",
+    align_items="center",
+    justify_content="center",
+    flex_direction="column",
+    gap=8,
+)
+
+
+@me.component
+def generated_3d_view(
+    storyboard: dict,
+    is_generating: bool,
+    on_generate: Callable,
+):
+    """
+    Component for generating and displaying the 3D view.
+    """
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="column",
+            gap=10,
+            align_items="center",
+        )
+    ):
+        me.text("Generated 3D View", type="headline-6")
+        with me.box(
+            style=me.Style(
+                display="flex",
+                flex_direction="row",
+                gap=8,
+                align_items="center",
+                min_height=48,
+            )
+        ):
+            me.button(
+                "Generate 3D View",
+                on_click=on_generate,
+                disabled=not (storyboard and storyboard.get("original_floor_plan_uri")) or is_generating,
+                type="raised",
+            )
+        with me.box(style=IMAGE_PLACEHOLDER_STYLE):
+            if is_generating:
+                me.progress_spinner()
+            elif storyboard and storyboard.get("generated_3d_view_uri"):
+                me.image(
+                    src=gcs_uri_to_https_url(storyboard["generated_3d_view_uri"]),
+                    style=me.Style(
+                        height="100%",
+                        width="100%",
+                        border_radius=8,
+                        object_fit="contain",
+                    ),
+                )
+            else:
+                me.icon("view_in_ar")
+                me.text("Your 3D view will appear here")

--- a/components/interior_design/room_selector.py
+++ b/components/interior_design/room_selector.py
@@ -1,0 +1,39 @@
+"""
+Component for selecting a room.
+"""
+
+from typing import Callable
+import mesop as me
+
+
+@me.component
+def room_selector(
+    storyboard: dict,
+    is_generating_zoom: bool,
+    on_room_select: Callable,
+):
+    """
+    Component for selecting a room.
+    """
+    if storyboard and storyboard.get("room_names"):
+        print(f"room_selector: Rendering buttons for rooms: {storyboard.get('room_names')}")
+        with me.box(
+            style=me.Style(
+                display="flex",
+                flex_direction="column",
+                align_items="center",
+                gap=10,
+            )
+        ):
+            me.text("Identified Rooms", type="headline-6")
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    gap=10,
+                    flex_wrap="wrap",
+                    justify_content="center",
+                )
+            ):
+                for room in storyboard["room_names"]:
+                    me.text(f"TEST: {room}")

--- a/components/interior_design/room_view.py
+++ b/components/interior_design/room_view.py
@@ -1,0 +1,39 @@
+"""
+Component for displaying the room view.
+"""
+
+import mesop as me
+
+from common.utils import gcs_uri_to_https_url
+
+
+@me.component
+def room_view(storyboard: dict, is_generating_zoom: bool):
+    """
+    Component for displaying the room view.
+    """
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="column",
+            align_items="center",
+            gap=10,
+            flex_grow=1,
+        )
+    ):
+        storyboard_item = next((item for item in storyboard["storyboard_items"] if item["room_name"] == storyboard["selected_room"]), None)
+        if storyboard_item:
+            me.text(f"Room View: {storyboard_item['room_name']}", type="headline-6")
+            if is_generating_zoom:
+                me.progress_spinner()
+            elif storyboard_item["styled_image_uri"]:
+                me.image(
+                    src=gcs_uri_to_https_url(storyboard_item["styled_image_uri"]),
+                    style=me.Style(
+                        height="100%",
+                        width="100%",
+                        max_width="600px",
+                        border_radius=8,
+                        object_fit="contain",
+                    ),
+                )

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -71,3 +71,31 @@ from common.analytics import track_model_call
 with track_model_call("my-generative-model-v1", prompt_length=len(prompt)):
     model.generate_content(...)
 ```
+
+## State Management
+
+### Working with Dataclasses
+
+When using dataclasses in the Mesop state, it's important to be aware of how they are serialized. Mesop's state management system does not automatically serialize dataclasses that contain non-serializable objects, such as `datetime.datetime`.
+
+To work around this, you have two options:
+
+1.  **Use simple types:** The simplest solution is to use only simple types (e.g., `str`, `int`, `float`, `bool`, `list`, `dict`) in your dataclasses. For example, instead of using a `datetime.datetime` object for a timestamp, you can use an ISO 8601 string.
+
+2.  **Use `asdict`:** If you need to use complex types in your dataclasses, you can use the `asdict` function from Python's `dataclasses` module to convert the dataclass instance to a dictionary before assigning it to the state.
+
+    **Example:**
+
+    ```python
+    from dataclasses import asdict
+
+    # ...
+
+    state.my_dataclass = asdict(MyDataClass(timestamp=datetime.datetime.now()))
+    ```
+
+    When you access the dataclass from the state, you will need to access it as a dictionary:
+
+    ```python
+    timestamp = state.my_dataclass["timestamp"]
+    ```

--- a/main.py
+++ b/main.py
@@ -50,7 +50,8 @@ from pages import recontextualize as recontextualize_page
 from pages import starter_pack as starter_pack_page
 from pages import veo
 from pages import vto as vto_page
-from pages import interior_design as interior_design_page
+from pages import interior_design_v1 as interior_design_v1_page
+from pages import interior_design_v2 as interior_design_v2_page
 from pages import welcome as welcome_page
 from pages.edit_images import content as edit_images_content
 from pages.test_character_consistency import page as test_character_consistency_page

--- a/models/interior_design.py
+++ b/models/interior_design.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data structures for the Interior Design feature."""
+
+from dataclasses import dataclass, field
+import datetime
+
+
+@dataclass
+class StoryboardItem:
+    room_name: str
+    styled_image_uri: str
+    # This list will store the history of styled images for this room
+    style_history: list[str] = field(default_factory=list)
+    transition_prompt: str | None = None
+
+
+@dataclass
+class InteriorDesignStoryboard:
+    user_email: str
+    timestamp: str
+    # These are now optional
+    original_floor_plan_uri: str | None = None
+    generated_3d_view_uri: str | None = None
+    room_names: list[str] = field(default_factory=list)
+    storyboard_items: list[StoryboardItem] = field(default_factory=list)
+    final_video_uri: str | None = None

--- a/pages/interior_design_v2.py
+++ b/pages/interior_design_v2.py
@@ -1,0 +1,383 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interior Design page."""
+
+import datetime
+from dataclasses import field, asdict
+import uuid
+import json
+
+import mesop as me
+
+from common.analytics import log_ui_click, track_click
+
+from common.metadata import MediaItem, add_media_item_to_firestore
+from common.storage import store_to_gcs
+from components.header import header
+from components.dialog import dialog
+from components.info_dialog.info_dialog import info_dialog
+from components.library.events import LibrarySelectionChangeEvent
+from components.page_scaffold import page_frame, page_scaffold
+from components.interior_design.floor_plan_uploader import floor_plan_uploader
+from components.interior_design.generated_3d_view import generated_3d_view
+from components.interior_design.room_selector import room_selector
+from components.interior_design.room_view import room_view
+from components.interior_design.design_studio import design_studio
+from config.default import Default as cfg
+from models.gemini import (
+    extract_room_names_from_image,
+    generate_image_from_prompt_and_images,
+)
+from state.state import AppState
+
+
+with open("config/about_content.json", "r") as f:
+    about_content = json.load(f)
+    INTERIOR_DESIGN_INFO = next(
+        (
+            s
+            for s in about_content["sections"]
+            if s.get("id") == "interior_design"
+        ),
+        None,
+    )
+
+
+from state.state import AppState
+from state.interior_design_v2_state import PageState
+
+
+@me.page(
+    path="/interior_design",
+    title="Interior Design V2",
+)
+def interior_design_page():
+    with page_scaffold(page_name="interior_design_v2"):  # pylint: disable=E1129:not-context-manager
+        with page_frame():  # pylint: disable=E1129:not-context-manager
+            header("Interior Design", "chair", show_info_button=True, on_info_click=open_info_dialog)
+            page_content()
+
+
+def page_content():
+    state = me.state(PageState)
+
+    info_dialog(
+        is_open=state.info_dialog_open,
+        info_data=INTERIOR_DESIGN_INFO,
+        on_close=close_info_dialog,
+        default_title="Interior Design",
+    )
+
+    with me.box(
+        style=me.Style(
+            display="flex", flex_direction="column", gap=24, align_items="center"
+        )
+    ):
+        # Input and Output Area
+        with me.box(
+            style=me.Style(
+                display="flex", flex_direction="row", gap=32, justify_content="center"
+            )
+        ):
+            floor_plan_uploader(
+                storyboard=state.storyboard,
+                on_upload=on_upload_floor_plan,
+                on_library_select=on_select_floor_plan,
+            )
+            generated_3d_view(
+                storyboard=state.storyboard,
+                is_generating=state.is_generating,
+                on_generate=on_generate_3d_view_click,
+            )
+
+        if state.storyboard and state.storyboard.get("room_names"):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="column",
+                    align_items="center",
+                    gap=10,
+                )
+            ):
+                me.text("Identified Rooms", type="headline-6")
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_direction="row",
+                        gap=10,
+                        flex_wrap="wrap",
+                        justify_content="center",
+                    )
+                ):
+                    for room in state.storyboard["room_names"]:
+                        with me.content_button(
+                            key=room, on_click=on_room_button_click, type="stroked"
+                        ):
+                            if state.is_generating_zoom and state.storyboard.get("selected_room") == room:
+                                me.progress_spinner(diameter=18)
+                            else:
+                                me.text(room)
+
+        # Display the zoomed-in room view and design controls
+        if state.storyboard and state.storyboard.get("storyboard_items"):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    gap=24,
+                    margin=me.Margin(top=24),
+                    width="100%",
+                    justify_content="center",
+                )
+            ):
+                room_view(
+                    storyboard=state.storyboard,
+                    is_generating_zoom=state.is_generating_zoom,
+                )
+                design_studio(
+                    storyboard_item=next((item for item in state.storyboard["storyboard_items"] if item["room_name"] == state.storyboard["selected_room"]), None),
+                    design_image_uri=state.design_image_uri,
+                    is_designing=state.is_designing,
+                    on_upload_design_image=on_upload_design_image,
+                    on_select_design_image=on_select_design_image,
+                    on_design_prompt_blur=on_design_prompt_blur,
+                    on_clear_design=on_clear_design,
+                    on_design_click=on_design_click,
+                )
+
+        if state.error_message:
+            me.text(state.error_message, style=me.Style(color="red"))
+
+
+# --- Event Handlers ---
+
+
+def on_upload_floor_plan(e: me.UploadEvent):
+    """Upload floor plan handler."""
+    state = me.state(PageState)
+    app_state = me.state(AppState)
+    file = e.files[0]
+    gcs_url = store_to_gcs(
+        "interior_design_uploads", file.name, file.mime_type, file.getvalue()
+    )
+    state.storyboard = {
+        "user_email": app_state.user_email,
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "original_floor_plan_uri": gcs_url,
+        "room_names": [],
+        "storyboard_items": [],
+        "selected_room": "",
+    }
+    print(f"storyboard created: {state.storyboard}")
+    yield
+
+
+def on_select_floor_plan(e: LibrarySelectionChangeEvent):
+    """Floor plan selection from library handler."""
+    state = me.state(PageState)
+    app_state = me.state(AppState)
+    state.storyboard = {
+        "user_email": app_state.user_email,
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "original_floor_plan_uri": e.gcs_uri,
+        "room_names": [],
+        "storyboard_items": [],
+        "selected_room": "",
+    }
+    print(f"storyboard created: {state.storyboard}")
+    yield
+
+
+@track_click(element_id="interior_design_generate_3d_view_button")
+def on_generate_3d_view_click(e: me.ClickEvent):
+    """Handles the 3D view generation."""
+    state = me.state(PageState)
+    state.is_generating = True
+    state.storyboard["generated_3d_view_uri"] = ""
+    state.storyboard["room_names"] = []
+    state.error_message = ""
+    yield
+
+    try:
+        prompt = "create a 3D version for the floor plan. make it realistic. keep the furnitures as per the floor plan and follow the measurement. retain the names of rooms in the appropriate location"
+
+        gcs_uris, _ = generate_image_from_prompt_and_images(
+            prompt=prompt,
+            images=[state.storyboard["original_floor_plan_uri"]],
+            gcs_folder="interior_design_generations",
+        )
+
+        if gcs_uris:
+            state.storyboard["generated_3d_view_uri"] = gcs_uris[0]
+
+            try:
+                room_names = extract_room_names_from_image(state.storyboard["original_floor_plan_uri"])
+                state.storyboard["room_names"] = room_names
+            except Exception as room_ex:
+                print(f"Could not extract room names: {room_ex}")
+                state.error_message = "An error occurred while extracting room names from the floor plan."
+
+        else:
+            state.error_message = "Image generation failed to return a result."
+
+    except Exception as ex:
+        state.error_message = f"An error occurred during generation: {ex}"
+    finally:
+        state.is_generating = False
+        yield
+
+
+@track_click(element_id="interior_design_room_button")
+def on_room_button_click(e: me.ClickEvent):
+    """Handles the generation of a zoomed-in view for a specific room."""
+    state = me.state(PageState)
+    room_name = e.key
+
+    # Find the existing storyboard item for this room, or create a new one
+    storyboard_item = next((item for item in state.storyboard["storyboard_items"] if item["room_name"] == room_name), None)
+    if not storyboard_item:
+        storyboard_item = {"room_name": room_name, "styled_image_uri": "", "style_history": []}
+        state.storyboard["storyboard_items"].append(storyboard_item)
+
+    state.is_generating_zoom = True
+    state.storyboard["selected_room"] = room_name
+    storyboard_item["styled_image_uri"] = ""
+    state.error_message = ""
+    yield
+
+    try:
+        prompt = f"Using the provided 3D rendering as a layout guide, create a photorealistic interior photograph. The photo should be from a first-person perspective, as if a person is standing in the hallway or adjacent room and looking through the doorway into the {room_name}. Capture the sense of entering the room for the first time on a house tour. Ensure the lighting and furniture placement are consistent with the 3D model."
+
+        gcs_uris, _ = generate_image_from_prompt_and_images(
+            prompt=prompt,
+            images=[state.storyboard["generated_3d_view_uri"]],  # Use the 3D view as input
+            gcs_folder="interior_design_zoomed_views",
+        )
+
+        if gcs_uris:
+            storyboard_item["styled_image_uri"] = gcs_uris[0]
+            storyboard_item["style_history"].append(gcs_uris[0])
+        else:
+            state.error_message = "Zoomed view generation failed to return a result."
+
+    except Exception as ex:
+        state.error_message = f"An error occurred during zoom generation: {ex}"
+    finally:
+        state.is_generating_zoom = False
+        yield
+
+
+def on_design_prompt_blur(e: me.InputBlurEvent):
+    """Updates the design prompt in the page state."""
+    app_state = me.state(AppState)
+    log_ui_click(
+        element_id="interior_design_design_prompt",
+        page_name=app_state.current_page,
+        session_id=app_state.session_id,
+        extras={"value": e.value},
+    )
+    state = me.state(PageState)
+    state.design_prompt = e.value
+
+
+def on_clear_design(e: me.ClickEvent):
+    """Clear design prompt and image."""
+    state = me.state(PageState)
+    state.design_prompt = ""
+    state.design_image_uri = ""
+    yield
+
+
+def on_upload_design_image(e: me.UploadEvent):
+    """Upload design image handler."""
+    state = me.state(PageState)
+    file = e.files[0]
+    gcs_url = store_to_gcs(
+        "interior_design_uploads", file.name, file.mime_type, file.getvalue()
+    )
+    state.design_image_uri = gcs_url
+    yield
+
+
+def on_select_design_image(e: LibrarySelectionChangeEvent):
+    """Design image selection from library handler."""
+    state = me.state(PageState)
+    state.design_image_uri = e.gcs_uri
+    yield
+
+
+@track_click(element_id="interior_design_design_button")
+def on_design_click(e: me.ClickEvent):
+    """Handles the iterative design generation."""
+    state = me.state(PageState)
+
+    if not state.design_prompt:
+        state.error_message = "Please enter a design modification prompt."
+        yield
+        return
+
+    state.is_designing = True
+    state.error_message = ""
+    yield
+
+    try:
+        # Find the current storyboard item
+        storyboard_item = next((item for item in state.storyboard["storyboard_items"] if item["room_name"] == state.storyboard["selected_room"]), None)
+        if not storyboard_item:
+            state.error_message = "Could not find the current room to style."
+            yield
+            return
+
+        images = [storyboard_item["styled_image_uri"]]
+        if state.design_image_uri:
+            images.append(state.design_image_uri)
+
+        gcs_uris, _ = generate_image_from_prompt_and_images(
+            prompt=state.design_prompt,
+            images=images,  # Use the current zoomed view as input
+            gcs_folder="interior_design_iterations",
+        )
+
+        if gcs_uris:
+            # Update the styled image with the new image, creating the loop
+            storyboard_item["styled_image_uri"] = gcs_uris[0]
+            storyboard_item["style_history"].append(gcs_uris[0])
+
+            # Clear the prompt for the next input
+            state.design_prompt = ""
+            state.design_image_uri = ""
+        else:
+            state.error_message = "Design generation failed to return a result."
+
+    except Exception as ex:
+        state.error_message = f"An error occurred during design generation: {ex}"
+    finally:
+        state.is_designing = False
+        yield
+
+def open_info_dialog(e: me.ClickEvent):
+    """Open the info dialog."""
+    print("DEBUG: open_info_dialog called")
+    state = me.state(PageState)
+    state.info_dialog_open = True
+    yield
+
+
+@track_click(element_id="interior_design_close_info_dialog_button")
+def close_info_dialog(e: me.ClickEvent):
+    """Close the info dialog."""
+    state = me.state(PageState)
+    state.info_dialog_open = False
+    yield

--- a/state/interior_design_v2_state.py
+++ b/state/interior_design_v2_state.py
@@ -1,0 +1,21 @@
+"""
+State for the Interior Design V2 page.
+"""
+
+from dataclasses import field
+import mesop as me
+
+
+@me.stateclass
+class PageState:
+    """State for the Interior Design page."""
+
+    storyboard: dict = field(default_factory=dict)
+    is_generating: bool = False
+    is_generating_zoom: bool = False
+    is_designing: bool = False
+    error_message: str = ""
+    design_prompt: str = ""
+    design_image_uri: str = ""
+
+    info_dialog_open: bool = False


### PR DESCRIPTION
## Description


This refactoring breaks down the monolithic `interior_design_v2.py` page into smaller, more manageable components. This improves maintainability, readability, and makes the code easier to debug.

Key changes:
- Created a new `components/interior_design/` directory to house the new components:
  - `floor_plan_uploader`
  - `generated_3d_view`
  - `room_selector`
  - `room_view`
  - `design_studio`
- Created `state/interior_design_v2_state.py` to define the page's state and resolve a circular import dependency that arose during the refactoring.
- Fixed several UI bugs related to spinner visibility and state management that were identified and resolved as part of this refactoring effort.

Additionally, the previous interior design page has been renamed to `interior_design_v1` and its route has been updated to `/interior_design_v1` to avoid conflicts and preserve the old version.



## Checklist

- [X] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [X] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [X] **Authorship:** I am listed as the author (if applicable).
- [X] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [ ] **Sync:** My Fork is synced with the upstream.
- [X] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
