### PR TITLE
fix(veo): Correctly log model ID for all Veo versions

### DIFF
--- a/pages/veo.py
+++ b/pages/veo.py
@@ -370,13 +370,14 @@ def on_click_veo(e: me.ClickEvent):  # pylint: disable=unused-argument
         original_prompt=(
             state.original_prompt if state.original_prompt else request.prompt
         ),
-        model=(
-            config.VEO_EXP_MODEL_ID
-            if request.model_version_id == "3.0"
-            else config.VEO_EXP_FAST_MODEL_ID
-            if request.model_version_id == "3.0-fast"
-            else config.VEO_MODEL_ID
-        ),
+        #model=(
+        #    config.VEO_EXP_MODEL_ID
+        #    if request.model_version_id == "3.0"
+        #    else config.VEO_EXP_FAST_MODEL_ID
+        #    if request.model_version_id == "3.0-fast"
+        #    else config.VEO_MODEL_ID
+        #),
+        model=get_veo_model_config(request.model_version_id).model_name,
         mime_type="video/mp4",
         aspect=request.aspect_ratio,
         duration=float(request.duration_seconds),


### PR DESCRIPTION
This commit resolves an issue where generations from the Veo 2.0 experimental model were being incorrectly logged with the standard `veo-2.0-generate-001` model ID in Firestore.

The previous implementation used a brittle `if/elif/else` block that did not account for the `2.0-exp` version_id. This has been replaced with a more robust, data-driven approach.

The `model` field for the `MediaItem` is now determined by dynamically looking up the `model_name` from the `VEO_MODELS` configuration list using the `get_veo_model_config` helper function. This ensures that the correct model ID is always logged, regardless of which version is used, and makes the system easier to maintain as new models are added.

Fixes #784


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
