### PR TITLE
feat(data): Add `mode` field to MediaItem for better workflow tracking

### DIFF
--- a/common/metadata.py
+++ b/common/metadata.py
@@ -54,6 +54,7 @@ class MediaItem:
     mime_type: Optional[str] = None  # e.g., "video/mp4", "image/png", "audio/wav"
     generation_time: Optional[float] = None  # Seconds for generation
     error_message: Optional[str] = None  # If any error occurred during generation
+    mode: Optional[str] = None
 
     # URI fields
     gcsuri: Optional[str] = (
@@ -275,6 +276,7 @@ def _create_media_item_from_dict(doc_id: str, raw_item_data: dict) -> MediaItem:
         rewritten_prompt=raw_item_data.get("rewritten_prompt"),
         model=raw_item_data.get("model"),
         mime_type=raw_item_data.get("mime_type"),
+        mode=raw_item_data.get("mode"),
         generation_time=gen_time,
         error_message=raw_item_data.get("error_message"),
         gcsuri=gcsuri,

--- a/components/media_tile/media_tile.py
+++ b/components/media_tile/media_tile.py
@@ -22,7 +22,12 @@ def get_pills_for_item(item: MediaItem, https_url: str) -> str:
         pills.append({"label": "Video"})
         if item.gcs_uris and len(item.gcs_uris) > 1:
             pills.append({"label": f"{len(item.gcs_uris)}"})
-        pills.append({"label": "t2v" if not item.reference_image else "i2v"})
+        if item.r2v_reference_images or item.r2v_style_image:
+            pills.append({"label": "r2v"})
+        elif item.mode:
+            pills.append({"label": item.mode})
+        else:
+            pills.append({"label": "t2v" if not item.reference_image else "i2v"})
         if item.aspect:
             pills.append({"label": item.aspect})
         if item.duration is not None:

--- a/pages/interior_design_v2.py
+++ b/pages/interior_design_v2.py
@@ -518,8 +518,9 @@ def on_generate_video_click(e: me.ClickEvent):
         media_item = MediaItem(
             id=media_item_id,
             user_email=app_state.user_email,
-            timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat(), # Convert to string
+            timestamp=datetime.datetime.now(datetime.UTC).isoformat(), # Convert to string
             media_type="video",
+            mode="Interior Design",
             gcs_uris=[final_video_uri],
             thumbnail_uri=final_video_uri,
             storyboard_id=state.storyboard["id"],
@@ -555,13 +556,13 @@ def item_detail_dialog(on_close: Callable):
         me.text("Error: Could not find selected item.")
         return
 
-    with dialog(is_open=True):
+    with dialog(is_open=True):  # pylint: disable=E1129:not-context-manager
         me.text(f"Details for {item['room_name']}", type="headline-6")
         with me.box(style=me.Style(display="flex", flex_direction="row", gap=16, margin=me.Margin(top=16))):
             with me.box(style=me.Style(flex_grow=1)):
                 me.text("Source Image", type="headline-5")
                 me.image(src=gcs_uri_to_https_url(item["styled_image_uri"]), style=me.Style(width="100%", border_radius=8))
-            
+
             with me.box(style=me.Style(flex_grow=1)):
                 me.text("Generated Video", type="headline-5")
                 if item.get("generated_video_uri"):

--- a/pages/veo.py
+++ b/pages/veo.py
@@ -365,20 +365,14 @@ def on_click_veo(e: me.ClickEvent):  # pylint: disable=unused-argument
 
     item_to_log = MediaItem(
         user_email=app_state.user_email,
-        timestamp=datetime.datetime.now(datetime.timezone.utc),
+        timestamp=datetime.datetime.now(datetime.UTC),
         prompt=request.prompt,
         original_prompt=(
             state.original_prompt if state.original_prompt else request.prompt
         ),
-        #model=(
-        #    config.VEO_EXP_MODEL_ID
-        #    if request.model_version_id == "3.0"
-        #    else config.VEO_EXP_FAST_MODEL_ID
-        #    if request.model_version_id == "3.0-fast"
-        #    else config.VEO_MODEL_ID
-        #),
         model=get_veo_model_config(request.model_version_id).model_name,
         mime_type="video/mp4",
+        mode=state.veo_mode,
         aspect=request.aspect_ratio,
         duration=float(request.duration_seconds),
         reference_image=request.reference_image_gcs,


### PR DESCRIPTION
This commit introduces a new `mode` field to the `MediaItem` dataclass to provide more specific context about the generation workflow, fixing an issue where complex workflows were incorrectly labeled in the library.

Previously, complex workflows like "Interior Design" that produce a video were generically labeled as "t2v" because the UI pill logic only checked for the presence of a prompt.

Changes:
- **`common/metadata.py`**: The `MediaItem` dataclass now includes an optional `mode: str` field.
- **`pages/veo.py`**: When logging a Veo generation, the `item_to_log.mode` is now set from the page's `veo_mode` state (e.g., "t2v", "i2v", "r2v").
- **`pages/interior_design_v2.py`**: When creating the final video for a tour, the `MediaItem` is now created with `mode="Interior Design"`.
- **`components/media_tile/media_tile.py`**: The `get_pills_for_item` function now checks for the `item.mode` field first to display a more descriptive pill, falling back to the old inference logic for older data.

This ensures that assets in the library are labeled accurately according to the workflow that produced them, providing better context to users.

Fixes #787



## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
