### PR TITLE
feat/mcp refactors

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -1,3 +1,5 @@
+// Package main implements an MCP server for audio and video processing.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffmpeg_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffmpeg_commands.go
@@ -1,3 +1,5 @@
+// Package main implements an MCP server for audio and video processing.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
@@ -1,3 +1,5 @@
+// Package main implements an MCP server for audio and video processing.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
@@ -1,3 +1,5 @@
+// Package main implements an MCP server for audio and video processing.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
@@ -1,3 +1,5 @@
+// Package main implements an MCP server for Google's Chirp3 text-to-speech models.
+
 package main
 
 import (
@@ -26,7 +28,6 @@ import (
 )
 
 var (
-	projectID, location string
 	ttsClient           *texttospeech.Client // Global Text-to-Speech client
 	availableVoices     []*texttospeechpb.Voice
 	transport           string
@@ -422,7 +423,7 @@ func chirpTTSHandler(client *texttospeech.Client, ctx context.Context, request m
 	}
 
 	// Handle custom pronunciations
-	pronunciationsParam, _ := request.GetArguments()["pronunciations"] // This will be []interface{} or nil
+	pronunciationsParam := request.GetArguments()["pronunciations"] // This will be []interface{} or nil
 	pronunciationEncodingStr, _ := request.GetArguments()["pronunciation_encoding"].(string)
 	if pronunciationEncodingStr == "" { // Apply default if not provided
 		pronunciationEncodingStr = "ipa"

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
@@ -30,14 +30,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.53.0/go.mod h1:jUZ5LYlw40WMd07qxcQJD5M40aUxrfwqQX1g7zxYnrQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20250928012544-f0a212df243d h1:m05KKyepiXeUaMEHiob84ZXpfVVXYm0gPmxM+OiUpdQ=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20250928012544-f0a212df243d/go.mod h1:WoFxuaQNUwkp/1D6EcIhv5I55AP1tZjJ0fy9/LV05OY=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20250928202155-4d1c9a4e5881 h1:7Y/YHC/xW3xNGftsNMEm4+ylgq5IoORvrL4lX5bnygE=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20250928202155-4d1c9a4e5881/go.mod h1:WoFxuaQNUwkp/1D6EcIhv5I55AP1tZjJ0fy9/LV05OY=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251001190937-54c64196fd57 h1:mATeFgwNhIhAwKuRK8sI9BeM648mwYjwclSycfoIjFE=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251001190937-54c64196fd57/go.mod h1:WoFxuaQNUwkp/1D6EcIhv5I55AP1tZjJ0fy9/LV05OY=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251001212520-c5c43b6d3a1d h1:wYHMGuD9Ra9jUTTc8sR21jDlod9EdY1adEgUwsHkHz8=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251001212520-c5c43b6d3a1d/go.mod h1:WoFxuaQNUwkp/1D6EcIhv5I55AP1tZjJ0fy9/LV05OY=
 github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251002034231-6906a8e2bb87 h1:APxQjqoBKJkS+kGBX+rhSeqP+RRTfSVmS9TMQiP7/34=
 github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251002034231-6906a8e2bb87/go.mod h1:WoFxuaQNUwkp/1D6EcIhv5I55AP1tZjJ0fy9/LV05OY=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/config.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/config.go
@@ -1,3 +1,5 @@
+// Package common provides shared utilities for the MCP Genmedia servers.
+
 package common
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/file_utils.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/file_utils.go
@@ -1,3 +1,5 @@
+// Package common provides shared utilities for the MCP Genmedia servers.
+
 package common
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils.go
@@ -1,3 +1,5 @@
+// Package common provides shared utilities for the MCP Genmedia servers.
+
 package common
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils_test.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +46,7 @@ func TestDownloadFromGCS(t *testing.T) {
 	}
 
 	// Create a temporary file to upload
-	tempFile, err := ioutil.TempFile("", "gcs_test_*")
+	tempFile, err := os.CreateTemp("", "gcs_test_*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +70,7 @@ func TestDownloadFromGCS(t *testing.T) {
 	}
 
 	// Download the file
-	tempDir, err := ioutil.TempDir("", "gcs_test_download_*")
+	tempDir, err := os.MkdirTemp("", "gcs_test_download_*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +82,7 @@ func TestDownloadFromGCS(t *testing.T) {
 	}
 
 	// Verify the content
-	downloadedContent, err := ioutil.ReadFile(localPath)
+	downloadedContent, err := os.ReadFile(localPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package common provides shared utilities for the MCP Genmedia servers.
+
 package common
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/otel.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/otel.go
@@ -1,3 +1,5 @@
+// Package common provides shared utilities for the MCP Genmedia servers.
+
 package common
 
 import (
@@ -11,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
-	"google.golang.org/grpc"
 )
 
 // InitTracerProvider initializes and configures the OpenTelemetry tracer provider.
@@ -37,7 +38,6 @@ func InitTracerProvider(serviceName, serviceVersion string) (*sdktrace.TracerPro
 	// Default to a secure connection.
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithDialOption(grpc.WithBlock()),
 	}
 
 	// Check for the standard environment variable to enable insecure mode.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Gemini models.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Gemini models.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
@@ -1,3 +1,5 @@
+// Package main implements an MCP server for Google's Gemini models.
+
 package main
 
 import (
@@ -294,7 +296,7 @@ func geminiAudioTTSHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 				contentItems = append(contentItems, mcp.AudioContent{Type: "audio", Data: base64AudioData, MIMEType: mimeType})
 			} else {
 				fileSaveMessage = fmt.Sprintf("Audio saved to: %s (%d bytes).", savedFilename, len(audioBytes))
-				log.Printf(fileSaveMessage)
+				log.Print(fileSaveMessage)
 			}
 		}
 	} else {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen-editing.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen-editing.go
@@ -1,3 +1,5 @@
+// Package main implements an MCP server for Google's Imagen models.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Imagen models.
+
 package main
 
 import (
@@ -274,8 +276,7 @@ func imagenGenerationHandler(client *genai.Client, ctx context.Context, request 
 	modelDetails := common.SupportedImagenModels[model]
 
 	var numberOfImages int32 = 1
-	numImagesArg, ok := request.GetArguments()["num_images"].(interface{})
-	if ok {
+	if numImagesArg, ok := request.GetArguments()["num_images"]; ok {
 		if numImagesFloat, okFloat := numImagesArg.(float64); okFloat {
 			numberOfImages = int32(numImagesFloat)
 		} else {
@@ -405,7 +406,7 @@ func imagenGenerationHandler(client *genai.Client, ctx context.Context, request 
 
 	if response == nil || len(response.GeneratedImages) == 0 {
 		noImageText := fmt.Sprintf("Sorry, I couldn't generate any images for the prompt \"%s\".", prompt)
-		log.Printf(noImageText)
+		log.Print(noImageText)
 		contentItems = append(contentItems, mcp.TextContent{Type: "text", Text: noImageText})
 		return &mcp.CallToolResult{Content: contentItems}, nil
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Lyria models.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Veo models.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
@@ -143,7 +143,7 @@ func veoImageToVideoHandler(client *genai.Client, ctx context.Context, request m
 		log.Printf("Incoming i2v context for image_uri \"%s\" was already canceled: %v", imageURI, ctx.Err())
 		return mcp.NewToolResultError(fmt.Sprintf("request processing canceled early: %v", ctx.Err())), nil
 	default:
-		log.Printf("Handling Veo i2v request: ImageURI=\"%%s\", MimeType=\"%%s\", Prompt=\"%%s\", GCSBucket=%s, OutputDir='%s', Model=%s, NumVideos=%d, AspectRatio=%s, Duration=%ds", imageURI, mimeType, prompt, gcsBucket, outputDir, modelName, numberOfVideos, finalAspectRatio, durationSecs)
+		log.Printf("Handling Veo i2v request: ImageURI=\"%s\", MimeType=\"%s\", Prompt=\"%s\", GCSBucket=%s, OutputDir='%s', Model=%s, NumVideos=%d, AspectRatio=%s, Duration=%ds", imageURI, mimeType, prompt, gcsBucket, outputDir, modelName, numberOfVideos, finalAspectRatio, durationSecs)
 	}
 
 	inputImage := &genai.Image{

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/utils.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/utils.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Veo models.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Veo models.
+
 package main
 
 import (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/video_logic.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/video_logic.go
@@ -95,7 +95,7 @@ func callGenerateVideosAPI(
 	log.Printf("GenerateVideos operation (%s) initiated successfully. Operation Name: %s", callType, operation.Name)
 
 	if progressToken != nil && mcpServer != nil {
-		mcpServer.SendNotificationToClient(
+		if err := mcpServer.SendNotificationToClient(
 			ctx, // Use parentCtx for notifications as it's tied to the client request
 			"notifications/progress",
 			map[string]interface{}{
@@ -103,7 +103,9 @@ func callGenerateVideosAPI(
 				"message":       fmt.Sprintf("Video generation (%s) initiated. Polling for completion...", callType),
 				"status":        "initiated", // Add a status field
 			},
-		)
+		); err != nil {
+			log.Printf("Warning: Failed to send 'initiated' progress notification: %v", err)
+		}
 	}
 
 	pollingStartTime := time.Now()
@@ -126,7 +128,7 @@ func callGenerateVideosAPI(
 			// Send a proactive heartbeat notification BEFORE making the potentially slow network call.
 			// This resets the client's inactivity timer.
 			if progressToken != nil && mcpServer != nil {
-				mcpServer.SendNotificationToClient(
+				if err := mcpServer.SendNotificationToClient(
 					ctx,
 					"notifications/progress",
 					map[string]interface{}{
@@ -134,7 +136,9 @@ func callGenerateVideosAPI(
 						"message":       fmt.Sprintf("Checking video status (polling attempt %d)...", pollingAttempt),
 						"status":        "polling",
 					},
-				)
+				); err != nil {
+					log.Printf("Warning: Failed to send 'polling' progress notification: %v", err)
+				}
 			}
 
 			var getOpOpts genai.GetOperationConfig
@@ -148,7 +152,7 @@ func callGenerateVideosAPI(
 				}
 				// For other errors, notify and continue (could be transient)
 				if progressToken != nil && mcpServer != nil {
-					mcpServer.SendNotificationToClient(
+					if err := mcpServer.SendNotificationToClient(
 						ctx,
 						"notifications/progress",
 						map[string]interface{}{
@@ -156,7 +160,9 @@ func callGenerateVideosAPI(
 							"message":       fmt.Sprintf("Polling attempt %d for %s video encountered an issue. Retrying...", pollingAttempt, callType),
 							"status":        "polling_issue",
 						},
-					)
+					); err != nil {
+						log.Printf("Warning: Failed to send 'polling_issue' progress notification: %v", err)
+					}
 				}
 				continue // Continue polling
 			}
@@ -188,7 +194,9 @@ func callGenerateVideosAPI(
 					payload["progress"] = progressPercent
 					payload["total"] = 100
 				}
-				mcpServer.SendNotificationToClient(ctx, "notifications/progress", payload)
+				if err := mcpServer.SendNotificationToClient(ctx, "notifications/progress", payload); err != nil {
+					log.Printf("Warning: Failed to send 'processing' progress notification: %v", err)
+				}
 			}
 		}
 	}
@@ -203,7 +211,7 @@ func callGenerateVideosAPI(
 			finalStatus = "completed_with_error"
 			finalMessage = fmt.Sprintf("Video generation (%s) failed after %v.", callType, operationDuration.Round(time.Second))
 		}
-		mcpServer.SendNotificationToClient(
+		if err := mcpServer.SendNotificationToClient(
 			ctx,
 			"notifications/progress",
 			map[string]interface{}{
@@ -213,7 +221,9 @@ func callGenerateVideosAPI(
 				"progress":      100, // Mark as 100% complete
 				"total":         100,
 			},
-		)
+		); err != nil {
+			log.Printf("Warning: Failed to send final progress notification: %v", err)
+		}
 	}
 
 	if operation.Error != nil {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/video_logic.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/video_logic.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main implements an MCP server for Google's Veo models.
+
 package main
 
 import (


### PR DESCRIPTION
refactor(mcp-go): Apply linting fixes and add package comments

This commit improves the overall code quality and adherence to Go best practices across all `mcp-genmedia-go` packages by addressing issues found by `golangci-lint` and ensuring all files have proper package documentation.

Key changes:

- **Add Package Comments**: Added standard package comments to every `.go` file across all services (`mcp-common`, `mcp-avtool-go`, `mcp-chirp3-go`, `mcp-gemini-go`, `mcp-imagen-go`, `mcp-lyria-go`, `mcp-veo-go`).

- **Handle Unchecked Errors**: Added error handling for previously ignored error return values from `mcpServer.SendNotificationToClient` in the `mcp-veo-go` package to improve robustness.

- **Fix Deprecated Code**:
    - Replaced the deprecated `io/ioutil` package with the `os` package in tests.
    - Removed the deprecated `grpc.WithBlock` option in `mcp-common`'s OpenTelemetry setup.

- **Correct Linter Warnings**:
    - Fixed `log.Printf` calls that used dynamic strings without format verbs.
    - Removed unused global variables in the `mcp-chirp3-go` package.
    - Corrected invalid map access and type assertions flagged by the linter.

These changes make the code cleaner, more maintainable, and more aligned with the Google Go Style Guide.

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
