### PR TITLE
feat(library): Display source assets for composited media

### DIFF
--- a/common/metadata.py
+++ b/common/metadata.py
@@ -66,6 +66,9 @@ class MediaItem:
     source_images_gcs: List[str] = field(
         default_factory=list
     )  # For multi-file input media (e.g., recontext) -> list of gs://bucket/path
+    source_uris: List[str] = field(
+        default_factory=list
+    )  # For generic source media of any type (e.g., Pixie compositor)
     thumbnail_uri: Optional[str] = None
 
     # Video specific (some may also apply to Image/Audio)
@@ -119,7 +122,7 @@ class MediaItem:
     volume_gain_db: Optional[float] = None
     language_code: Optional[str] = None
     style_prompt: Optional[str] = None
-    
+
     # Interior Design Storyboard
     storyboard_id: Optional[str] = None
 
@@ -282,6 +285,7 @@ def _create_media_item_from_dict(doc_id: str, raw_item_data: dict) -> MediaItem:
         gcsuri=gcsuri,
         gcs_uris=raw_item_data.get("gcs_uris", []),
         source_images_gcs=raw_item_data.get("source_images_gcs", []),
+        source_uris=raw_item_data.get("source_uris", []),
         thumbnail_uri=thumbnail,
         aspect=raw_item_data.get("aspect"),
         resolution=raw_item_data.get("resolution"),

--- a/components/media_detail_viewer/media_detail_viewer.js
+++ b/components/media_detail_viewer/media_detail_viewer.js
@@ -213,21 +213,6 @@ class MediaDetailViewer extends LitElement {
     `;
   }
 
-  renderSourceImages() {
-    try {
-      const sourceUrls = JSON.parse(this.sourceUrlsJson);
-      if (sourceUrls.length === 0) return html``;
-
-      return html`
-        <h3>Source Images</h3>
-        <div class="source-images">
-          ${sourceUrls.map((url) => html`<img .src=${url} />`)}
-        </div>
-      `;
-    } catch (e) {
-      return html``;
-    }
-  }
 
   renderMetadata() {
     try {
@@ -316,7 +301,6 @@ class MediaDetailViewer extends LitElement {
         <div class="left-column">
           <div class="main-asset">${this.renderPrimaryAsset()}</div>
           ${this.renderActions()}
-          ${this.renderSourceImages()}
         </div>
         <div class="right-column">
           <div class="tabs">

--- a/config/default.py
+++ b/config/default.py
@@ -53,7 +53,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class"""
 
-    VERSION: str = "1.0.7" # Gemini TTS GA
+    VERSION: str = "1.0.8" # Library fixes
     APP_ENV: str = os.environ.get("APP_ENV", "")
 
     SERVICE_ACCOUNT_EMAIL: str = os.environ.get("SERVICE_ACCOUNT_EMAIL")

--- a/pages/pixie_compositor.py
+++ b/pages/pixie_compositor.py
@@ -409,7 +409,7 @@ def on_layer_audio_click(e: me.ClickEvent):
                 user_email=app_state.user_email,
                 timestamp=datetime.datetime.now(datetime.timezone.utc),
                 mime_type="video/mp4",
-                source_images_gcs=[state.selected_video_for_audio, state.selected_audio],
+                source_uris=[state.selected_video_for_audio, state.selected_audio],
                 comment="Produced by Pixie Compositor: Video + Audio",
                 model="pixie-compositor-v1-audio-layer",
             )
@@ -491,7 +491,7 @@ def on_process_click(e: me.ClickEvent):
                 user_email=app_state.user_email,
                 timestamp=datetime.datetime.now(datetime.timezone.utc),
                 mime_type="video/mp4",
-                source_images_gcs=video_uris_to_process,
+                source_uris=video_uris_to_process,
                 comment=f"Produced by Pixie Compositor with {state.selected_transition} transition",
                 model="pixie-compositor-v1",
             )


### PR DESCRIPTION
Refactors the library detail view to correctly handle and display the source media for items created by tools like the Pixie Compositor.

Previously, source videos and audio files were stored in a field intended for images, causing the UI to render them as broken image tags.

This commit resolves the issue by:
- Introducing a new, generic `source_uris` field to the `MediaItem` data model for storing source media of any type.
- Updating the Pixie Compositor to write to this new field.
- Modifying the library detail dialog to render a "Source Assets" section. This section uses the `media_tile` component to correctly display each source video or audio file.
- Removing the old, incorrect source image rendering logic from the `media_detail_viewer` web component.

Fixes #823


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
