### PR TITLE
Feat/media chooser refactor

### DIFF
--- a/common/metadata.py
+++ b/common/metadata.py
@@ -14,6 +14,7 @@
 """metadata implementation"""
 
 import datetime
+import json
 import uuid
 
 # from models.model_setup import ModelSetup
@@ -97,8 +98,8 @@ class MediaItem:
 
     # Music specific
     # duration is shared with Video
-    audio_analysis: Optional[Dict] = (
-        None  # Structured analysis from Gemini, stored as a map
+    audio_analysis: Optional[str] = (
+        None  # Structured analysis from Gemini, stored as a JSON string
     )
 
     # This field is for loading raw data from Firestore, not for writing.
@@ -129,6 +130,12 @@ class MediaItem:
     # R2V specific
     r2v_reference_images: List[str] = field(default_factory=list)
     r2v_style_image: Optional[str] = None
+
+    def __post_init__(self):
+        # Ensure audio_analysis is always a JSON string for state serialization.
+        # This handles cases where raw data from Firestore might be a dict.
+        if isinstance(self.audio_analysis, dict):
+            self.audio_analysis = json.dumps(self.audio_analysis)
 
 
 def add_media_item_to_firestore(item: MediaItem):
@@ -692,4 +699,69 @@ def get_media_for_page_optimized(
 
     except Exception as e:
         print(f"Error fetching media from Firestore (optimized): {e}")
+        return [], None
+
+def get_media_for_chooser(
+    media_type: str, page_size: int, start_after=None
+) -> tuple[list[MediaItem], Optional[firestore.DocumentSnapshot]]:
+    """Fetches media items for the chooser, using a hybrid query strategy."""
+    if not db:
+        return [], None
+
+    try:
+        # Query 1: For new data with the media_type field
+        query1 = (
+            db.collection(config.GENMEDIA_COLLECTION_NAME)
+            .where("media_type", "==", media_type)
+            .order_by("timestamp", direction=firestore.Query.DESCENDING)
+        )
+
+        # Query 2: For legacy data using mime_type
+        mime_prefix = f"{media_type}/"
+        mime_prefix_end = f"{media_type}0"
+        query2 = (
+            db.collection(config.GENMEDIA_COLLECTION_NAME)
+            .where("mime_type", ">=", mime_prefix)
+            .where("mime_type", "<", mime_prefix_end)
+            .order_by("timestamp", direction=firestore.Query.DESCENDING)
+        )
+
+        if start_after:
+            query1 = query1.start_after(start_after)
+            query2 = query2.start_after(start_after)
+
+        query1 = query1.limit(page_size)
+        query2 = query2.limit(page_size)
+
+        # Execute queries and merge results
+        docs1 = list(query1.stream())
+        docs2 = list(query2.stream())
+
+        merged_docs = {doc.id: doc for doc in docs1}
+        for doc in docs2:
+            if doc.id not in merged_docs:
+                merged_docs[doc.id] = doc
+
+        # Sort merged results by timestamp
+        sorted_docs = sorted(
+            merged_docs.values(),
+            key=lambda doc: doc.to_dict().get("timestamp"),
+            reverse=True,
+        )
+
+        # Paginate the final sorted list
+        paginated_docs = sorted_docs[:page_size]
+
+        media_items = [
+            _create_media_item_from_dict(doc.id, doc.to_dict())
+            for doc in paginated_docs
+        ]
+
+        # Determine the correct `last_doc` for pagination
+        last_doc = paginated_docs[-1] if paginated_docs else None
+
+        return media_items, last_doc
+
+    except Exception as e:
+        print(f"Error fetching media for chooser: {e}")
         return [], None

--- a/common/metadata.py
+++ b/common/metadata.py
@@ -723,6 +723,7 @@ def get_media_for_chooser(
             db.collection(config.GENMEDIA_COLLECTION_NAME)
             .where("mime_type", ">=", mime_prefix)
             .where("mime_type", "<", mime_prefix_end)
+            .order_by("mime_type", direction=firestore.Query.ASCENDING)
             .order_by("timestamp", direction=firestore.Query.DESCENDING)
         )
 

--- a/components/library/media_chooser_button.py
+++ b/components/library/media_chooser_button.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A generic, stateless media chooser button component."""
+
+from collections.abc import Callable
+from typing import Optional
+
+import mesop as me
+
+
+@me.component
+def media_chooser_button(
+    *,
+    on_click: Callable[[me.ClickEvent], None],
+    media_type: str,  # "video", "audio", or "image"
+    button_label: Optional[str] = None,
+    button_type: str = "stroked",
+    key: str,
+):
+    """
+    Renders a simple, stateless button for choosing media.
+    It emits an on_click event and does not manage its own state or dialog.
+    """
+    icon_name = "image"
+    if media_type == "video":
+        icon_name = "video_library"
+    elif media_type == "audio":
+        icon_name = "audio_file"
+
+    with me.content_button(on_click=on_click, type=button_type, key=key):
+        with me.box(
+            style=me.Style(
+                display="flex", flex_direction="row", gap=8, align_items="center"
+            )
+        ):
+            me.icon(icon_name)
+            if button_label:
+                me.text(button_label)

--- a/components/library/video_chooser_button.py
+++ b/components/library/video_chooser_button.py
@@ -12,24 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable, Optional
+from typing import Optional
 
 import mesop as me
 
-from common.metadata import MediaItem, get_media_for_page_optimized, db, config
+from common.metadata import MediaItem, config, db, get_media_for_page_optimized
 from components.dialog import dialog
 from components.library.events import LibrarySelectionChangeEvent
-from components.library.video_infinite_scroll_library import video_infinite_scroll_library
+from components.library.video_infinite_scroll_library import (
+    video_infinite_scroll_library,
+)
 
 
 @me.stateclass
 class State:
     """Local mesop state for the infinite scroll chooser button."""
+
     show_dialog: bool = False
     active_chooser_key: str = ""
     is_loading: bool = False
-    media_items: list[MediaItem] = field(default_factory=list)
+    media_items: list[MediaItem] = field(default_factory=list)  # pylint: disable=E3701:invalid-field-call
     has_more_items: bool = True
 
 
@@ -69,14 +73,16 @@ def video_chooser_button(
         yield
 
         last_item_id = state.media_items[-1].id
-        last_doc_ref = db.collection(config.GENMEDIA_COLLECTION_NAME).document(last_item_id).get()
+        last_doc_ref = (
+            db.collection(config.GENMEDIA_COLLECTION_NAME).document(last_item_id).get()
+        )
 
         new_items, last_doc = get_media_for_page_optimized(
             20, ["videos"], start_after=last_doc_ref
         )
         if new_items:
             state.media_items.extend(new_items)
-        
+
         if not last_doc:
             state.has_more_items = False
         state.is_loading = False
@@ -93,15 +99,23 @@ def video_chooser_button(
         yield
 
     with me.content_button(on_click=open_dialog, type=button_type, key=key):
-        with me.box(style=me.Style(display="flex", flex_direction="row", gap=8, align_items="center")):
+        with me.box(
+            style=me.Style(
+                display="flex", flex_direction="row", gap=8, align_items="center"
+            )
+        ):
             me.icon("video_library")
             if button_label:
                 me.text(button_label)
 
-    dialog_style = me.Style(width="95vw", height="80vh", display="flex", flex_direction="column")
+    dialog_style = me.Style(
+        width="95vw", height="80vh", display="flex", flex_direction="column"
+    )
 
-    with dialog(is_open=state.show_dialog, dialog_style=dialog_style):
-        with me.box(style=me.Style(display="flex", flex_direction="column", gap=16, flex_grow=1)):
+    with dialog(is_open=state.show_dialog, dialog_style=dialog_style):  # pylint: disable=E1129:not-context-manager
+        with me.box(
+            style=me.Style(display="flex", flex_direction="column", gap=16, flex_grow=1)
+        ):
             me.text("Select a Video from Library", type="headline-6")
             with me.box(style=me.Style(flex_grow=1, overflow_y="auto")):
                 if state.is_loading and not state.media_items:
@@ -130,7 +144,11 @@ def video_chooser_button(
                         on_load_more=handle_load_more,
                         on_image_selected=handle_image_selected,
                     )
-            with me.box(style=me.Style(display="flex", justify_content="flex-end", margin=me.Margin(top=24))):
+            with me.box(
+                style=me.Style(
+                    display="flex", justify_content="flex-end", margin=me.Margin(top=24)
+                )
+            ):
                 me.button(
                     "Cancel",
                     on_click=lambda e: setattr(state, "show_dialog", False),

--- a/config/default.py
+++ b/config/default.py
@@ -53,7 +53,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class"""
 
-    VERSION: str = "1.0.8" # Library fixes
+    VERSION: str = "1.0.9" # New media chooser
     APP_ENV: str = os.environ.get("APP_ENV", "")
 
     SERVICE_ACCOUNT_EMAIL: str = os.environ.get("SERVICE_ACCOUNT_EMAIL")

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -99,3 +99,76 @@ To work around this, you have two options:
     ```python
     timestamp = state.my_dataclass["timestamp"]
     ```
+
+## Using the Media Chooser Component
+
+The application provides a generic, high-performance component for selecting media (`video`, `audio`, or `image`) from the library. This component, `media_chooser_button`, uses a **parent-managed state** pattern. This means the page that uses the button is responsible for managing the state and rendering of the chooser dialog.
+
+This pattern is robust and avoids the complex state-collision bugs that can occur with self-contained components in Mesop. Here’s how to use it:
+
+### 1. Add State to Your Page
+
+First, add the necessary fields to your page's `@me.stateclass` to manage the dialog's visibility, content, and data loading.
+
+**Example:**
+```python
+from dataclasses import field
+from common.metadata import MediaItem
+
+@me.stateclass
+class PageState:
+    # ... your other page state fields ...
+
+    # State for the media chooser dialog
+    show_chooser_dialog: bool = False
+    chooser_dialog_media_type: str = ""
+    chooser_dialog_key: str = "" # To track which button opened the dialog
+    chooser_is_loading: bool = False
+    chooser_media_items: list[MediaItem] = field(default_factory=list)
+    chooser_last_doc_id: str = "" # For pagination
+    chooser_all_items_loaded: bool = False
+```
+
+### 2. Render the Button and Create an Event Handler
+
+Place the `media_chooser_button` in your UI. Its `on_click` event should trigger a handler that sets the dialog state and starts the data fetching process.
+
+**Example:**
+```python
+from components.library.media_chooser_button import media_chooser_button
+from common.metadata import get_media_for_chooser
+
+# In your page's layout function:
+media_chooser_button(
+    key="my_video_chooser", # A unique key for this button
+    on_click=open_chooser,
+    media_type="video",
+    button_label="Choose a Video"
+)
+
+# The event handler to open the dialog and load the first page of items:
+def open_chooser(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.show_chooser_dialog = True
+    state.chooser_dialog_media_type = "video" # Set the type of media to show
+    state.chooser_dialog_key = e.key
+    state.chooser_is_loading = True
+    state.chooser_media_items = []
+    state.chooser_all_items_loaded = False
+    state.chooser_last_doc_id = ""
+    yield
+
+    items, last_doc = get_media_for_chooser(media_type="video", page_size=20)
+    state.chooser_media_items = items
+    state.chooser_last_doc_id = last_doc.id if last_doc else ""
+    if not last_doc:
+        state.chooser_all_items_loaded = True
+    state.chooser_is_loading = False
+    yield
+```
+
+### 3. Render the Dialog
+
+Finally, add a component to your page that renders the dialog itself. This component will read the state you set in the previous step to show the dialog, display the items, and handle selection and infinite scrolling.
+
+For a complete, working example, see `pages/test_media_chooser.py`.

--- a/main.py
+++ b/main.py
@@ -61,6 +61,7 @@ from pages.test_uploader import test_uploader_page
 from pages.test_vto_prompt_generator import page as test_vto_prompt_generator_page
 from pages.test_worsfold_encoder import test_worsfold_encoder_page
 from pages.test_svg import test_svg_page
+from pages.test_media_chooser import page as test_media_chooser_page
 from pages import pixie_compositor as pixie_compositor_page
 from state.state import AppState
 import google.auth
@@ -188,6 +189,9 @@ me.page(path="/test_worsfold_encoder", title="Test Worsfold Encoder")(
 )
 me.page(path="/test_svg", title="Test SVG")(
     test_svg_page
+)
+me.page(path="/test_media_chooser", title="Test Media Chooser")(
+    test_media_chooser_page
 )
 
 

--- a/main.tf
+++ b/main.tf
@@ -304,11 +304,12 @@ resource "google_firestore_index" "genmedia_library_mime_type_timestamp" {
   query_scope = "COLLECTION"
 
   fields {
-    field_path = "timestamp"
-    order      = "DESCENDING"
-  }
-  fields {
     field_path = "mime_type"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "timestamp"
     order      = "DESCENDING"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -313,6 +313,22 @@ resource "google_firestore_index" "genmedia_library_mime_type_timestamp" {
   }
 }
 
+resource "google_firestore_index" "genmedia_chooser_media_type_timestamp" {
+  collection  = "genmedia"
+  database    = google_firestore_database.create_studio_asset_metadata.name
+  query_scope = "COLLECTION"
+
+  fields {
+    field_path = "media_type"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "timestamp"
+    order      = "DESCENDING"
+  }
+}
+
 resource "google_project_iam_member" "creative_studio_db_access" {
   project = var.project_id
   role    = "roles/datastore.user"

--- a/pages/library_v2.py
+++ b/pages/library_v2.py
@@ -100,11 +100,6 @@ def _load_media(pagestate: PageState, is_filter_change: bool = False):
         error_filter=pagestate.error_filter,
     )
 
-    # Sanitize items before adding to state to prevent deserialization errors.
-    for item in new_items:
-        if isinstance(item.audio_analysis, dict):
-            item.audio_analysis = json.dumps(item.audio_analysis)
-
     if not new_items:
         pagestate.all_items_loaded = True
     else:

--- a/pages/lyria.py
+++ b/pages/lyria.py
@@ -508,7 +508,7 @@ def on_click_lyria(e: me.ClickEvent):
             generation_time=execution_time,
             error_message=lyria_error_message_for_metadata if lyria_error_message_for_metadata else None,
             gcsuri=gcs_uri_for_analysis_and_metadata if generated_successfully and gcs_uri_for_analysis_and_metadata else None,
-            audio_analysis=analysis_dict_for_metadata if analysis_dict_for_metadata else None,
+            audio_analysis=json.dumps(analysis_dict_for_metadata) if analysis_dict_for_metadata else None,
             # duration might be available if analysis_dict_for_metadata contains it, or if Lyria API provides it
         )
         add_media_item_to_firestore(item)

--- a/pages/pixie_compositor.py
+++ b/pages/pixie_compositor.py
@@ -14,23 +14,27 @@
 
 """A test page for concatenating videos using moviepy."""
 
-from dataclasses import field
 import datetime
 import time
+from dataclasses import field
 
 import mesop as me
 
+from common.metadata import MediaItem, add_media_item_to_firestore
 from common.storage import store_to_gcs
 from common.utils import gcs_uri_to_https_url
-from common.metadata import MediaItem, add_media_item_to_firestore
-from components.header import header
-from components.library.events import LibrarySelectionChangeEvent
 from components.dialog import dialog
-from components.library.video_chooser_button import video_chooser_button
+from components.header import header
 from components.library.audio_chooser_button import audio_chooser_button
+from components.library.events import LibrarySelectionChangeEvent
+from components.library.video_chooser_button import video_chooser_button
 from components.page_scaffold import page_frame, page_scaffold
 from components.snackbar import snackbar
-from models.video_processing import process_videos, convert_mp4_to_gif, layer_audio_on_video
+from models.video_processing import (
+    convert_mp4_to_gif,
+    layer_audio_on_video,
+    process_videos,
+)
 from state.state import AppState
 
 

--- a/pages/pixie_compositor.py
+++ b/pages/pixie_compositor.py
@@ -16,19 +16,28 @@
 
 import datetime
 import time
-from dataclasses import field
+from dataclasses import field, dataclass
+from typing import Callable
 
 import mesop as me
 
-from common.metadata import MediaItem, add_media_item_to_firestore
+from common.metadata import (
+    MediaItem,
+    add_media_item_to_firestore,
+    get_media_for_chooser,
+    db,
+    config,
+)
 from common.storage import store_to_gcs
 from common.utils import gcs_uri_to_https_url
 from components.dialog import dialog
 from components.header import header
 from components.library.audio_chooser_button import audio_chooser_button
 from components.library.events import LibrarySelectionChangeEvent
-from components.library.video_chooser_button import video_chooser_button
+from components.library.media_chooser_button import media_chooser_button
+from components.media_tile.media_tile import media_tile, get_pills_for_item
 from components.page_scaffold import page_frame, page_scaffold
+from components.scroll_sentinel.scroll_sentinel import scroll_sentinel
 from components.snackbar import snackbar
 from models.video_processing import (
     convert_mp4_to_gif,
@@ -41,7 +50,7 @@ from state.state import AppState
 @me.stateclass
 class PageState:
     # Using a dict to store selected videos, keyed by chooser id (e.g., "video_1")
-    selected_videos: dict[str, str] = field(default_factory=dict) # pylint: disable=invalid-field-call
+    selected_videos: dict[str, str] = field(default_factory=dict)
     concatenated_video_url: str = ""
     gif_url: str = ""
     is_loading: bool = False
@@ -56,6 +65,15 @@ class PageState:
     active_tab: str = "video_video"
     selected_video_for_audio: str = ""
     selected_audio: str = ""
+
+    # State for the new media chooser dialog
+    show_chooser_dialog: bool = False
+    chooser_dialog_media_type: str = ""
+    chooser_dialog_key: str = ""
+    chooser_is_loading: bool = False
+    chooser_media_items: list[MediaItem] = field(default_factory=list)
+    chooser_last_doc_id: str = ""
+    chooser_all_items_loaded: bool = False
 
 
 VIDEO_PLACEHOLDER_STYLE = me.Style(
@@ -72,20 +90,17 @@ VIDEO_PLACEHOLDER_STYLE = me.Style(
     gap=8,
 )
 
+
 @me.page(
     path="/pixie_compositor",
     title="Pixie Compositor",
 )
 def pixie_compositor_page():
-    with page_scaffold(page_name="pixie_compositor"):  # pylint: disable=not-context-manager
-        with page_frame():  # pylint: disable=not-context-manager
+    with page_scaffold(page_name="pixie_compositor"):
+        with page_frame():
             header("Pixie Compositor", "auto_fix_high")
             page_content()
-
-
-
-from dataclasses import dataclass
-from typing import Callable
+            render_chooser_dialog()  # Add dialog to the page layout
 
 
 # Adapted from components/tab_nav.py
@@ -165,58 +180,103 @@ def page_content():
         render_video_video_tab()
     elif state.active_tab == "video_audio":
         render_video_audio_tab()
-    
+
     snackbar(is_visible=state.show_snackbar, label=state.snackbar_message)
+
+
+def open_video_chooser(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.show_chooser_dialog = True
+    state.chooser_dialog_media_type = "video"
+    state.chooser_dialog_key = e.key
+    state.chooser_is_loading = True
+    state.chooser_media_items = []
+    state.chooser_all_items_loaded = False
+    state.chooser_last_doc_id = ""
+    yield
+
+    items, last_doc = get_media_for_chooser(media_type="video", page_size=20)
+    state.chooser_media_items = items
+    state.chooser_last_doc_id = last_doc.id if last_doc else ""
+    if not last_doc:
+        state.chooser_all_items_loaded = True
+    state.chooser_is_loading = False
+    yield
 
 
 def render_video_video_tab():
     state = me.state(PageState)
-    with me.box(style=me.Style(display="flex", flex_direction="column", gap=20, margin=me.Margin(top=20))):
+    with me.box(
+        style=me.Style(
+            display="flex", flex_direction="column", gap=20, margin=me.Margin(top=20)
+        )
+    ):
         me.text("Select two videos from the library to process.")
 
         # Video Selection Area
-        with me.box(style=me.Style(display="flex", flex_direction="row", gap=20, justify_content="center")):
+        with me.box(
+            style=me.Style(
+                display="flex", flex_direction="row", gap=20, justify_content="center"
+            )
+        ):
             # Video 1 Selector
-            with me.box(style=me.Style(display="flex", flex_direction="column", gap=10)):
+            with me.box(
+                style=me.Style(display="flex", flex_direction="column", gap=10)
+            ):
                 me.text("Video 1")
-                with me.box(style=me.Style(display="flex", flex_direction="row", gap=8, align_items="center")):
+                with me.box(
+                    style=me.Style(
+                        display="flex", flex_direction="row", gap=8, align_items="center"
+                    )
+                ):
                     me.uploader(
                         label="Upload Video",
                         on_upload=on_upload_video_1,
                         accepted_file_types=["video/mp4", "video/quicktime"],
                         style=me.Style(width="100%"),
                     )
-                    video_chooser_button(
-                        key="video_1", on_library_select=on_video_select
+                    media_chooser_button(
+                        key="video_1", on_click=open_video_chooser, media_type="video"
                     )
                 with me.box(style=VIDEO_PLACEHOLDER_STYLE):
                     if "video_1" in state.selected_videos:
                         me.video(
-                            key=state.selected_videos["video_1"], # Add key to force re-render
+                            key=state.selected_videos["video_1"],  # Add key to force re-render
                             src=gcs_uri_to_https_url(state.selected_videos["video_1"]),
-                            style=me.Style(height="100%", width="100%", border_radius=8, object_fit="contain"),
+                            style=me.Style(
+                                height="100%",
+                                width="100%",
+                                border_radius=8,
+                                object_fit="contain",
+                            ),
                         )
                     else:
                         me.icon("movie")
                         me.text("Select Video 1")
 
             # Video 2 Selector
-            with me.box(style=me.Style(display="flex", flex_direction="column", gap=10)):
+            with me.box(
+                style=me.Style(display="flex", flex_direction="column", gap=10)
+            ):
                 me.text("Video 2")
-                with me.box(style=me.Style(display="flex", flex_direction="row", gap=8, align_items="center")):
+                with me.box(
+                    style=me.Style(
+                        display="flex", flex_direction="row", gap=8, align_items="center"
+                    )
+                ):
                     me.uploader(
                         label="Upload Video",
                         on_upload=on_upload_video_2,
                         accepted_file_types=["video/mp4", "video/quicktime"],
                         style=me.Style(width="100%"),
                     )
-                    video_chooser_button(
-                        key="video_2", on_library_select=on_video_select
+                    media_chooser_button(
+                        key="video_2", on_click=open_video_chooser, media_type="video"
                     )
                 with me.box(style=VIDEO_PLACEHOLDER_STYLE):
                     if "video_2" in state.selected_videos:
                         me.video(
-                            key=state.selected_videos["video_2"], # Add key to force re-render
+                            key=state.selected_videos["video_2"],  # Add key to force re-render
                             src=gcs_uri_to_https_url(state.selected_videos["video_2"]),
                             style=me.Style(height="100%", width="100%", border_radius=8),
                         )
@@ -227,7 +287,11 @@ def render_video_video_tab():
         # Controls
         with me.box(
             style=me.Style(
-                display="flex", gap=16, flex_direction="row",  align_items="center", justify_content="center"
+                display="flex",
+                gap=16,
+                flex_direction="row",
+                align_items="center",
+                justify_content="center",
             ),
         ):
             # Transition Selector
@@ -255,69 +319,112 @@ def render_video_video_tab():
         if state.is_loading:
             with me.box(style=me.Style(display="flex", justify_content="center")):
                 me.progress_spinner()
-        
+
         if state.error_message:
             me.text(state.error_message, style=me.Style(color="red"))
 
         # result video
         if state.concatenated_video_url:
-            with me.box(style=me.Style(display="flex", flex_direction="column", align_items="center", gap=10)):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="column",
+                    align_items="center",
+                    gap=10,
+                )
+            ):
                 me.video(
                     src=gcs_uri_to_https_url(state.concatenated_video_url),
                     style=me.Style(width="100%", max_width="720px", border_radius=8),
                 )
-                me.button("Convert to GIF", on_click=on_convert_to_gif_click, disabled=state.is_converting_gif)
+                me.button(
+                    "Convert to GIF",
+                    on_click=on_convert_to_gif_click,
+                    disabled=state.is_converting_gif,
+                )
 
         if state.is_converting_gif:
             with me.box(style=me.Style(display="flex", justify_content="center")):
                 me.progress_spinner()
 
         if state.gif_url:
-            with me.box(style=me.Style(display="flex", flex_direction="column", align_items="center", gap=10)):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="column",
+                    align_items="center",
+                    gap=10,
+                )
+            ):
                 me.text("Video as GIF:", type="headline-5")
                 me.image(
                     src=gcs_uri_to_https_url(state.gif_url),
                     style=me.Style(width="100%", max_width="480px", border_radius=8),
                 )
-        
-
 
 
 def render_video_audio_tab():
     state = me.state(PageState)
-    with me.box(style=me.Style(display="flex", flex_direction="column", gap=20, margin=me.Margin(top=20))):
+    with me.box(
+        style=me.Style(
+            display="flex", flex_direction="column", gap=20, margin=me.Margin(top=20)
+        )
+    ):
         me.text("Select a video and an audio file to layer.")
 
         # Media Selection Area
-        with me.box(style=me.Style(display="flex", flex_direction="row", gap=20, justify_content="center")):
+        with me.box(
+            style=me.Style(
+                display="flex", flex_direction="row", gap=20, justify_content="center"
+            )
+        ):
             # Video Selector
-            with me.box(style=me.Style(display="flex", flex_direction="column", gap=10)):
+            with me.box(
+                style=me.Style(display="flex", flex_direction="column", gap=10)
+            ):
                 me.text("Video")
-                with me.box(style=me.Style(display="flex", flex_direction="row", gap=8, align_items="center")):
+                with me.box(
+                    style=me.Style(
+                        display="flex", flex_direction="row", gap=8, align_items="center"
+                    )
+                ):
                     me.uploader(
                         label="Upload Video",
                         on_upload=on_upload_video_for_audio,
                         accepted_file_types=["video/mp4", "video/quicktime"],
                         style=me.Style(width="100%"),
                     )
-                    video_chooser_button(
-                        key="video_for_audio", on_library_select=on_video_select_for_audio
+                    media_chooser_button(
+                        key="video_for_audio",
+                        on_click=open_video_chooser,
+                        media_type="video",
                     )
                 with me.box(style=VIDEO_PLACEHOLDER_STYLE):
                     if state.selected_video_for_audio:
                         me.video(
-                            key=state.selected_video_for_audio, # Add key to force re-render
+                            key=state.selected_video_for_audio,  # Add key to force re-render
                             src=gcs_uri_to_https_url(state.selected_video_for_audio),
-                            style=me.Style(height="100%", width="100%", border_radius=8, object_fit="contain"),
+                            style=me.Style(
+                                height="100%",
+                                width="100%",
+                                border_radius=8,
+                                object_fit="contain",
+                            ),
                         )
                     else:
                         me.icon("movie")
                         me.text("Select a Video")
 
             # Audio Selector
-            with me.box(style=me.Style(display="flex", flex_direction="column", gap=10)):
+            with me.box(
+                style=me.Style(display="flex", flex_direction="column", gap=10)
+            ):
                 me.text("Audio")
-                with me.box(style=me.Style(display="flex", flex_direction="row", gap=8, align_items="center")):
+                with me.box(
+                    style=me.Style(
+                        display="flex", flex_direction="row", gap=8, align_items="center"
+                    )
+                ):
                     me.uploader(
                         label="Upload Audio",
                         on_upload=on_upload_audio,
@@ -340,13 +447,19 @@ def render_video_audio_tab():
         # Controls
         with me.box(
             style=me.Style(
-                display="flex", gap=16, flex_direction="row",  align_items="center", justify_content="center"
+                display="flex",
+                gap=16,
+                flex_direction="row",
+                align_items="center",
+                justify_content="center",
             ),
         ):
             me.button(
                 "Layer Audio on Video",
                 on_click=on_layer_audio_click,
-                disabled=not state.selected_video_for_audio or not state.selected_audio or state.is_loading,
+                disabled=not state.selected_video_for_audio
+                or not state.selected_audio
+                or state.is_loading,
                 type="raised",
             )
 
@@ -354,16 +467,151 @@ def render_video_audio_tab():
         if state.is_loading:
             with me.box(style=me.Style(display="flex", justify_content="center")):
                 me.progress_spinner()
-        
+
         if state.error_message:
             me.text(state.error_message, style=me.Style(color="red"))
 
         if state.concatenated_video_url:
-            with me.box(style=me.Style(display="flex", flex_direction="column", align_items="center", gap=10)):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="column",
+                    align_items="center",
+                    gap=10,
+                )
+            ):
                 me.video(
                     src=gcs_uri_to_https_url(state.concatenated_video_url),
                     style=me.Style(width="100%", max_width="720px", border_radius=8),
                 )
+
+
+@me.component
+def render_chooser_dialog():
+    """Renders the single, page-level dialog for choosing media."""
+    state = me.state(PageState)
+
+    def handle_item_selected(e: me.ClickEvent):
+        gcs_uri = e.key
+        # Based on which button opened the dialog, update the correct state variable.
+        if state.chooser_dialog_key == "video_1":
+            state.selected_videos["video_1"] = gcs_uri
+        elif state.chooser_dialog_key == "video_2":
+            state.selected_videos["video_2"] = gcs_uri
+        elif state.chooser_dialog_key == "video_for_audio":
+            state.selected_video_for_audio = gcs_uri
+
+        state.show_chooser_dialog = False
+        yield
+
+    def handle_load_more(e: me.WebEvent):
+        if state.chooser_is_loading or state.chooser_all_items_loaded:
+            return
+
+        state.chooser_is_loading = True
+        yield
+
+        last_doc_ref = (
+            db.collection(config.GENMEDIA_COLLECTION_NAME)
+            .document(state.chooser_last_doc_id)
+            .get()
+        )
+
+        new_items, last_doc = get_media_for_chooser(
+            media_type=state.chooser_dialog_media_type,
+            page_size=20,
+            start_after=last_doc_ref,
+        )
+        state.chooser_media_items.extend(new_items)
+        state.chooser_last_doc_id = last_doc.id if last_doc else ""
+        if not last_doc:
+            state.chooser_all_items_loaded = True
+        state.chooser_is_loading = False
+        yield
+
+    dialog_style = me.Style(
+        width="95vw", height="80vh", display="flex", flex_direction="column"
+    )
+
+    with dialog(is_open=state.show_chooser_dialog, dialog_style=dialog_style):
+        if state.show_chooser_dialog:
+            with me.box(
+                style=me.Style(
+                    display="flex", flex_direction="column", gap=16, flex_grow=1
+                )
+            ):
+                # Dialog header with title and close button
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_direction="row",
+                        justify_content="space-between",
+                        align_items="center",
+                        width="100%",
+                    )
+                ):
+                    me.text(
+                        f"Select a {state.chooser_dialog_media_type.capitalize()} from Library",
+                        type="headline-6",
+                    )
+                    with me.content_button(
+                        type="icon",
+                        on_click=lambda e: setattr(
+                            state, "show_chooser_dialog", False
+                        ),
+                    ):
+                        me.icon("close")
+
+                # Main content area with grid and scroller
+                with me.box(
+                    style=me.Style(
+                        flex_grow=1, overflow_y="auto", padding=me.Padding.all(10)
+                    )
+                ):
+                    if state.chooser_is_loading and not state.chooser_media_items:
+                        with me.box(
+                            style=me.Style(
+                                display="flex",
+                                justify_content="center",
+                                align_items="center",
+                                height="100%",
+                            )
+                        ):
+                            me.progress_spinner()
+                    else:
+                        with me.box(
+                            style=me.Style(
+                                display="grid",
+                                grid_template_columns="repeat(auto-fill, minmax(250px, 1fr))",
+                                gap="16px",
+                            )
+                        ):
+                            items_to_render = state.chooser_media_items
+                            if not items_to_render and not state.chooser_is_loading:
+                                me.text(
+                                    f"No items of type '{state.chooser_dialog_media_type}' found in your library."
+                                )
+                            else:
+                                for item in items_to_render:
+                                    https_url = gcs_uri_to_https_url(
+                                        item.gcsuri
+                                        or (item.gcs_uris[0] if item.gcs_uris else "")
+                                    )
+                                    media_tile(
+                                        key=item.gcsuri
+                                        or (item.gcs_uris[0] if item.gcs_uris else ""),
+                                        on_click=handle_item_selected,
+                                        media_type=item.media_type
+                                        or state.chooser_dialog_media_type,
+                                        https_url=https_url,
+                                        pills_json=get_pills_for_item(item, https_url),
+                                    )
+                        scroll_sentinel(
+                            on_visible=handle_load_more,
+                            is_loading=state.chooser_is_loading,
+                            all_items_loaded=state.chooser_all_items_loaded,
+                        )
+
 
 def on_upload_video_for_audio(e: me.UploadEvent):
     """Upload video handler for the audio tab."""
@@ -374,10 +622,12 @@ def on_upload_video_for_audio(e: me.UploadEvent):
     state.selected_video_for_audio = gcs_url
     yield
 
+
 def on_video_select_for_audio(e: LibrarySelectionChangeEvent):
     state = me.state(PageState)
     state.selected_video_for_audio = e.gcs_uri
     yield
+
 
 def on_upload_audio(e: me.UploadEvent):
     """Upload audio handler for the audio tab."""
@@ -388,10 +638,12 @@ def on_upload_audio(e: me.UploadEvent):
     state.selected_audio = gcs_url
     yield
 
+
 def on_audio_select_from_library(e: LibrarySelectionChangeEvent):
     state = me.state(PageState)
     state.selected_audio = e.gcs_uri
     yield
+
 
 def on_layer_audio_click(e: me.ClickEvent):
     state = me.state(PageState)
@@ -403,7 +655,9 @@ def on_layer_audio_click(e: me.ClickEvent):
     yield
 
     try:
-        processed_uri = layer_audio_on_video(state.selected_video_for_audio, state.selected_audio)
+        processed_uri = layer_audio_on_video(
+            state.selected_video_for_audio, state.selected_audio
+        )
         state.concatenated_video_url = processed_uri
 
         # Log to Firestore
@@ -424,8 +678,6 @@ def on_layer_audio_click(e: me.ClickEvent):
     finally:
         state.is_loading = False
         yield
-
-
 
 
 def show_snackbar(state: PageState, message: str):
@@ -450,6 +702,7 @@ def on_upload_video_1(e: me.UploadEvent):
     state.selected_videos["video_1"] = gcs_url
     yield
 
+
 def on_upload_video_2(e: me.UploadEvent):
     """Upload video 2 handler."""
     state = me.state(PageState)
@@ -459,16 +712,19 @@ def on_upload_video_2(e: me.UploadEvent):
     state.selected_videos["video_2"] = gcs_url
     yield
 
+
 def on_video_select(e: LibrarySelectionChangeEvent):
     state = me.state(PageState)
     # The key of the chooser button tells us which video slot to fill.
     state.selected_videos[e.chooser_id] = e.gcs_uri
     yield
 
+
 def on_transition_change(e: me.SelectSelectionChangeEvent):
     state = me.state(PageState)
     state.selected_transition = e.value
     yield
+
 
 def on_process_click(e: me.ClickEvent):
     state = me.state(PageState)
@@ -485,7 +741,9 @@ def on_process_click(e: me.ClickEvent):
             state.selected_videos["video_1"],
             state.selected_videos["video_2"],
         ]
-        processed_uri = process_videos(video_uris_to_process, state.selected_transition)
+        processed_uri = process_videos(
+            video_uris_to_process, state.selected_transition
+        )
         state.concatenated_video_url = processed_uri
 
         # Log to Firestore
@@ -513,6 +771,7 @@ def on_process_click(e: me.ClickEvent):
         state.is_loading = False
         yield
 
+
 def on_convert_to_gif_click(e: me.ClickEvent):
     state = me.state(PageState)
     app_state = me.state(AppState)
@@ -532,7 +791,9 @@ def on_convert_to_gif_click(e: me.ClickEvent):
                 user_email=app_state.user_email,
                 timestamp=datetime.datetime.now(datetime.timezone.utc),
                 mime_type="image/gif",
-                source_images_gcs=[state.concatenated_video_url], # Source is the concatenated video
+                source_images_gcs=[
+                    state.concatenated_video_url
+                ],  # Source is the concatenated video
                 comment="Produced by Pixie Compositor",
                 model="pixie-compositor-v1-gif",
             )
@@ -543,4 +804,3 @@ def on_convert_to_gif_click(e: me.ClickEvent):
     finally:
         state.is_converting_gif = False
         yield
-

--- a/pages/test_index.py
+++ b/pages/test_index.py
@@ -65,6 +65,11 @@ def page():
             "title": "Legacy Library",
             "description": "Legacy Library page",
             "route": "/legacy_library",
+        },
+        {
+            "title": "Media Chooser Test",
+            "description": "A test page for the generic, high-performance media chooser component.",
+            "route": "/test_media_chooser",
         }
     ]
 

--- a/pages/test_media_chooser.py
+++ b/pages/test_media_chooser.py
@@ -1,0 +1,217 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A temporary page to test the new media_chooser_button component."""
+
+from dataclasses import field
+
+import mesop as me
+
+from common.metadata import MediaItem, get_media_for_chooser, db, config
+from common.utils import gcs_uri_to_https_url
+from components.dialog import dialog
+from components.header import header
+from components.library.events import LibrarySelectionChangeEvent
+from components.library.media_chooser_button import media_chooser_button
+from components.media_tile.media_tile import get_pills_for_item, media_tile
+from components.page_scaffold import page_frame, page_scaffold
+from components.scroll_sentinel.scroll_sentinel import scroll_sentinel
+
+
+@me.stateclass
+class PageState:
+    # UI state
+    selected_video_uri: str = ""
+    selected_audio_uri: str = ""
+    selected_image_uri: str = ""
+
+    # Dialog state
+    show_dialog: bool = False
+    dialog_media_type: str = ""  # To control the dialog's content
+    dialog_chooser_id: str = ""  # To know which button opened the dialog
+    is_loading: bool = False
+    media_items: list[MediaItem] = field(default_factory=list)
+    last_doc_id: str = ""  # For pagination, store only the ID
+    all_items_loaded: bool = False
+
+
+@me.page(
+    path="/test_media_chooser",
+    title="Test Media Chooser",
+)
+def page():
+    """Main test page."""
+    with page_scaffold(page_name="test_media_chooser"):
+        with page_frame():
+            header("Test Media Chooser", "science")
+            page_content()
+            # The dialog is now part of the page, not the button.
+            render_chooser_dialog()
+
+
+def page_content():
+    """The main content of the test page."""
+    state = me.state(PageState)
+
+    def open_dialog_for(e: me.ClickEvent, media_type: str):
+        print(f"<-- LOGGER: Button with key '{e.key}' clicked. Opening dialog for media_type: '{media_type}' -->")
+        state.show_dialog = True
+        state.dialog_media_type = media_type
+        state.dialog_chooser_id = e.key
+        state.is_loading = True
+        state.media_items = []
+        state.all_items_loaded = False
+        state.last_doc_id = ""
+        yield
+
+        # Fetch real data
+        items, last_doc = get_media_for_chooser(media_type=media_type, page_size=20)
+        state.media_items = items
+        state.last_doc_id = last_doc.id if last_doc else ""
+        if not last_doc:
+            state.all_items_loaded = True
+        state.is_loading = False
+        print(f"<-- LOGGER: {len(items)} items loaded for dialog. -->")
+        yield
+
+    with me.box(style=me.Style(display="flex", flex_direction="column", gap=20)):
+        me.text(
+            "This page is for testing the new media_chooser_button component in isolation."
+        )
+
+        # Test the video chooser
+        with me.box(
+            style=me.Style(display="flex", flex_direction="row", gap=16, align_items="center")
+        ):
+            media_chooser_button(
+                key="video_chooser_1",
+                on_click=lambda e: open_dialog_for(e, "video"),
+                media_type="video",
+                button_label="Choose a Video",
+            )
+            me.text(f"Selected Video: {state.selected_video_uri or 'None'}")
+
+        # Test the audio chooser
+        with me.box(
+            style=me.Style(display="flex", flex_direction="row", gap=16, align_items="center")
+        ):
+            media_chooser_button(
+                key="audio_chooser_1",
+                on_click=lambda e: open_dialog_for(e, "audio"),
+                media_type="audio",
+                button_label="Choose Audio",
+            )
+            me.text(f"Selected Audio: {state.selected_audio_uri or 'None'}")
+
+        # Test the image chooser
+        with me.box(
+            style=me.Style(display="flex", flex_direction="row", gap=16, align_items="center")
+        ):
+            media_chooser_button(
+                key="image_chooser_1",
+                on_click=lambda e: open_dialog_for(e, "image"),
+                media_type="image",
+                button_label="Choose an Image",
+            )
+            me.text(f"Selected Image: {state.selected_image_uri or 'None'}")
+
+
+@me.component
+def render_chooser_dialog():
+    """Renders the single, page-level dialog for choosing media."""
+    state = me.state(PageState)
+
+    def handle_item_selected(e: me.ClickEvent):
+        gcs_uri = e.key
+        print(f"<-- LOGGER: Item selected. Chooser ID: '{state.dialog_chooser_id}'. GCS URI: {gcs_uri} -->")
+        
+        if state.dialog_chooser_id == "video_chooser_1":
+            state.selected_video_uri = gcs_uri
+        elif state.dialog_chooser_id == "audio_chooser_1":
+            state.selected_audio_uri = gcs_uri
+        elif state.dialog_chooser_id == "image_chooser_1":
+            state.selected_image_uri = gcs_uri
+        
+        state.show_dialog = False
+        yield
+
+    def handle_load_more(e: me.WebEvent):
+        if state.is_loading or state.all_items_loaded:
+            return
+
+        print(f"<-- LOGGER: Loading more items for {state.dialog_media_type} -->")
+        state.is_loading = True
+        yield
+
+        # Re-fetch the snapshot from the stored ID to use as a cursor
+        last_doc_ref = db.collection(config.GENMEDIA_COLLECTION_NAME).document(state.last_doc_id).get()
+
+        new_items, last_doc = get_media_for_chooser(
+            media_type=state.dialog_media_type, page_size=20, start_after=last_doc_ref
+        )
+        state.media_items.extend(new_items)
+        state.last_doc_id = last_doc.id if last_doc else ""
+        if not last_doc:
+            state.all_items_loaded = True
+        state.is_loading = False
+        yield
+
+    dialog_style = me.Style(
+        width="95vw", height="80vh", display="flex", flex_direction="column"
+    )
+
+    with dialog(is_open=state.show_dialog, dialog_style=dialog_style):
+        if state.show_dialog:
+            with me.box(
+                style=me.Style(display="flex", flex_direction="column", gap=16, flex_grow=1)
+            ):
+                me.text(f"Select a {state.dialog_media_type.capitalize()} from Library", type="headline-6")
+
+                with me.box(style=me.Style(flex_grow=1, overflow_y="auto", padding=me.Padding.all(10))):
+                    if state.is_loading and not state.media_items:
+                        with me.box(style=me.Style(display="flex", justify_content="center", align_items="center", height="100%")):
+                            me.progress_spinner()
+                    else:
+                        with me.box(
+                            style=me.Style(
+                                display="grid",
+                                grid_template_columns="repeat(auto-fill, minmax(250px, 1fr))",
+                                gap="16px",
+                            )
+                        ):
+                            items_to_render = state.media_items # No need to filter, query does it now
+                            if not items_to_render and not state.is_loading:
+                                me.text(f"No items of type '{state.dialog_media_type}' found in your library.")
+                            else:
+                                for item in items_to_render:
+                                    https_url = gcs_uri_to_https_url(item.gcsuri or (item.gcs_uris[0] if item.gcs_uris else ""))
+                                    media_tile(
+                                        key=item.gcsuri or (item.gcs_uris[0] if item.gcs_uris else ""),
+                                        on_click=handle_item_selected,
+                                        media_type=item.media_type or state.dialog_media_type,
+                                        https_url=https_url,
+                                        pills_json=get_pills_for_item(item, https_url),
+                                    )
+                        scroll_sentinel(
+                            on_visible=handle_load_more,
+                            is_loading=state.is_loading,
+                            all_items_loaded=state.all_items_loaded,
+                        )
+
+                with me.box(style=me.Style(display="flex", justify_content="flex-end", margin=me.Margin(top=24))):
+                    me.button(
+                        "Cancel",
+                        on_click=lambda e: setattr(state, "show_dialog", False),
+                        type="stroked",
+                    )

--- a/pages/test_media_chooser.py
+++ b/pages/test_media_chooser.py
@@ -18,7 +18,7 @@ from dataclasses import field
 
 import mesop as me
 
-from common.metadata import MediaItem, get_media_for_chooser, db, config
+from common.metadata import MediaItem, config, db, get_media_for_chooser
 from common.utils import gcs_uri_to_https_url
 from components.dialog import dialog
 from components.header import header
@@ -41,7 +41,7 @@ class PageState:
     dialog_media_type: str = ""  # To control the dialog's content
     dialog_chooser_id: str = ""  # To know which button opened the dialog
     is_loading: bool = False
-    media_items: list[MediaItem] = field(default_factory=list)
+    media_items: list[MediaItem] = field(default_factory=list)  # pylint: disable=E3701:invalid-field-call
     last_doc_id: str = ""  # For pagination, store only the ID
     all_items_loaded: bool = False
 
@@ -52,8 +52,8 @@ class PageState:
 )
 def page():
     """Main test page."""
-    with page_scaffold(page_name="test_media_chooser"):
-        with page_frame():
+    with page_scaffold(page_name="test_media_chooser"):  # pylint: disable=E1129:not-context-manager
+        with page_frame():  # pylint: disable=E1129:not-context-manager
             header("Test Media Chooser", "science")
             page_content()
             # The dialog is now part of the page, not the button.
@@ -65,7 +65,9 @@ def page_content():
     state = me.state(PageState)
 
     def open_dialog_for(e: me.ClickEvent, media_type: str):
-        print(f"<-- LOGGER: Button with key '{e.key}' clicked. Opening dialog for media_type: '{media_type}' -->")
+        print(
+            f"<-- LOGGER: Button with key '{e.key}' clicked. Opening dialog for media_type: '{media_type}' -->"
+        )
         state.show_dialog = True
         state.dialog_media_type = media_type
         state.dialog_chooser_id = e.key
@@ -92,7 +94,9 @@ def page_content():
 
         # Test the video chooser
         with me.box(
-            style=me.Style(display="flex", flex_direction="row", gap=16, align_items="center")
+            style=me.Style(
+                display="flex", flex_direction="row", gap=16, align_items="center"
+            )
         ):
             media_chooser_button(
                 key="video_chooser_1",
@@ -104,7 +108,9 @@ def page_content():
 
         # Test the audio chooser
         with me.box(
-            style=me.Style(display="flex", flex_direction="row", gap=16, align_items="center")
+            style=me.Style(
+                display="flex", flex_direction="row", gap=16, align_items="center",
+            )
         ):
             media_chooser_button(
                 key="audio_chooser_1",
@@ -116,7 +122,9 @@ def page_content():
 
         # Test the image chooser
         with me.box(
-            style=me.Style(display="flex", flex_direction="row", gap=16, align_items="center")
+            style=me.Style(
+                display="flex", flex_direction="row", gap=16, align_items="center"
+            )
         ):
             media_chooser_button(
                 key="image_chooser_1",
@@ -134,15 +142,17 @@ def render_chooser_dialog():
 
     def handle_item_selected(e: me.ClickEvent):
         gcs_uri = e.key
-        print(f"<-- LOGGER: Item selected. Chooser ID: '{state.dialog_chooser_id}'. GCS URI: {gcs_uri} -->")
-        
+        print(
+            f"<-- LOGGER: Item selected. Chooser ID: '{state.dialog_chooser_id}'. GCS URI: {gcs_uri} -->"
+        )
+
         if state.dialog_chooser_id == "video_chooser_1":
             state.selected_video_uri = gcs_uri
         elif state.dialog_chooser_id == "audio_chooser_1":
             state.selected_audio_uri = gcs_uri
         elif state.dialog_chooser_id == "image_chooser_1":
             state.selected_image_uri = gcs_uri
-        
+
         state.show_dialog = False
         yield
 
@@ -155,7 +165,11 @@ def render_chooser_dialog():
         yield
 
         # Re-fetch the snapshot from the stored ID to use as a cursor
-        last_doc_ref = db.collection(config.GENMEDIA_COLLECTION_NAME).document(state.last_doc_id).get()
+        last_doc_ref = (
+            db.collection(config.GENMEDIA_COLLECTION_NAME)
+            .document(state.last_doc_id)
+            .get()
+        )
 
         new_items, last_doc = get_media_for_chooser(
             media_type=state.dialog_media_type, page_size=20, start_after=last_doc_ref
@@ -171,10 +185,12 @@ def render_chooser_dialog():
         width="95vw", height="80vh", display="flex", flex_direction="column"
     )
 
-    with dialog(is_open=state.show_dialog, dialog_style=dialog_style):
+    with dialog(is_open=state.show_dialog, dialog_style=dialog_style):  # pylint: disable=E1129:not-context-manager
         if state.show_dialog:
             with me.box(
-                style=me.Style(display="flex", flex_direction="column", gap=16, flex_grow=1)
+                style=me.Style(
+                    display="flex", flex_direction="column", gap=16, flex_grow=1,
+                )
             ):
                 # Dialog header with title and close button
                 with me.box(
@@ -186,7 +202,10 @@ def render_chooser_dialog():
                         width="100%",
                     )
                 ):
-                    me.text(f"Select a {state.dialog_media_type.capitalize()} from Library", type="headline-6")
+                    me.text(
+                        f"Select a {state.dialog_media_type.capitalize()} from Library",
+                        type="headline-6",
+                    )
                     with me.content_button(
                         type="icon",
                         on_click=lambda e: setattr(state, "show_dialog", False),
@@ -194,9 +213,20 @@ def render_chooser_dialog():
                         me.icon("close")
 
                 # Main content area with grid and scroller
-                with me.box(style=me.Style(flex_grow=1, overflow_y="auto", padding=me.Padding.all(10))):
+                with me.box(
+                    style=me.Style(
+                        flex_grow=1, overflow_y="auto", padding=me.Padding.all(10)
+                    )
+                ):
                     if state.is_loading and not state.media_items:
-                        with me.box(style=me.Style(display="flex", justify_content="center", align_items="center", height="100%")):
+                        with me.box(
+                            style=me.Style(
+                                display="flex",
+                                justify_content="center",
+                                align_items="center",
+                                height="100%",
+                            )
+                        ):
                             me.progress_spinner()
                     else:
                         with me.box(
@@ -206,16 +236,25 @@ def render_chooser_dialog():
                                 gap="16px",
                             )
                         ):
-                            items_to_render = state.media_items # No need to filter, query does it now
+                            items_to_render = (
+                                state.media_items
+                            )  # No need to filter, query does it now
                             if not items_to_render and not state.is_loading:
-                                me.text(f"No items of type '{state.dialog_media_type}' found in your library.")
+                                me.text(
+                                    f"No items of type '{state.dialog_media_type}' found in your library."
+                                )
                             else:
                                 for item in items_to_render:
-                                    https_url = gcs_uri_to_https_url(item.gcsuri or (item.gcs_uris[0] if item.gcs_uris else ""))
+                                    https_url = gcs_uri_to_https_url(
+                                        item.gcsuri
+                                        or (item.gcs_uris[0] if item.gcs_uris else "")
+                                    )
                                     media_tile(
-                                        key=item.gcsuri or (item.gcs_uris[0] if item.gcs_uris else ""),
+                                        key=item.gcsuri
+                                        or (item.gcs_uris[0] if item.gcs_uris else ""),
                                         on_click=handle_item_selected,
-                                        media_type=item.media_type or state.dialog_media_type,
+                                        media_type=item.media_type
+                                        or state.dialog_media_type,
                                         https_url=https_url,
                                         pills_json=get_pills_for_item(item, https_url),
                                     )

--- a/pages/test_media_chooser.py
+++ b/pages/test_media_chooser.py
@@ -176,8 +176,24 @@ def render_chooser_dialog():
             with me.box(
                 style=me.Style(display="flex", flex_direction="column", gap=16, flex_grow=1)
             ):
-                me.text(f"Select a {state.dialog_media_type.capitalize()} from Library", type="headline-6")
+                # Dialog header with title and close button
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_direction="row",
+                        justify_content="space-between",
+                        align_items="center",
+                        width="100%",
+                    )
+                ):
+                    me.text(f"Select a {state.dialog_media_type.capitalize()} from Library", type="headline-6")
+                    with me.content_button(
+                        type="icon",
+                        on_click=lambda e: setattr(state, "show_dialog", False),
+                    ):
+                        me.icon("close")
 
+                # Main content area with grid and scroller
                 with me.box(style=me.Style(flex_grow=1, overflow_y="auto", padding=me.Padding.all(10))):
                     if state.is_loading and not state.media_items:
                         with me.box(style=me.Style(display="flex", justify_content="center", align_items="center", height="100%")):
@@ -208,10 +224,3 @@ def render_chooser_dialog():
                             is_loading=state.is_loading,
                             all_items_loaded=state.all_items_loaded,
                         )
-
-                with me.box(style=me.Style(display="flex", justify_content="flex-end", margin=me.Margin(top=24))):
-                    me.button(
-                        "Cancel",
-                        on_click=lambda e: setattr(state, "show_dialog", False),
-                        type="stroked",
-                    )


### PR DESCRIPTION
##Summary

  This PR introduces a new, generic, and high-performance media chooser component to replace the slow and buggy legacy choosers used   across the application. The primary motivation was to fix the significant performance bottleneck on pages like the Pixie Compositor,  where loading media from the library was unacceptably slow.

  Problem

  The old chooser components relied on an inefficient data fetching strategy that performed filtering on the client-side, leading to slow
   load times. They also suffered from state management bugs that would cause incorrect behavior when multiple choosers were present on
  the same page.

##  Solution

  A comprehensive refactor was performed, resulting in a new, robust architecture:

   - New Generic Component: A single, stateless media_chooser_button was created to be used for selecting any media type (video, audio,     image).
   - Parent-Managed State: The responsibility for managing the dialog's state and rendering has been moved to the parent page, following a     more robust and standard UI pattern that eliminates state-collision bugs.
   - Performant Backend Query: A new get_media_for_chooser function was implemented that uses an efficient, indexed, hybrid query strategy     against Firestore. This ensures fast load times by fetching only the necessary data, while maintaining backward compatibility with     older data schemas.
   - Infrastructure as Code: The required composite Firestore indexes have been added to the project's Terraform configuration.

##  Bug Fixes

  During this refactoring, several latent bugs were discovered and fixed:
   - A critical data model deserialization error was resolved by ensuring complex dictionary fields are always handled as JSON strings,     which also fixed a bug that was causing the main Library page to fail silently.
   - A subtle rendering bug on the Pixie Compositor page was fixed by replacing an indirect lambda event handler with a direct one,     ensuring Mesop's render cycle is correctly triggered.

##  Testing

  A new test page, /test_media_chooser, was created to develop and verify the new component in isolation. This page has been added to  the main Labs index for future reference. The Pixie Compositor page has been successfully upgraded to use the new component.

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
