### PR TITLE
fix(gemini): Add aspect_ratio to image generation calls

### DIFF
--- a/models/character_consistency.py
+++ b/models/character_consistency.py
@@ -146,6 +146,7 @@ def generate_character_video(
             generate_image_from_prompt_and_images,
             final_prompt,
             reference_image_gcs_uris,
+            aspect_ratio="1:1",
             gcs_folder="character_consistency_candidates",
             file_prefix="candidate",
         )

--- a/models/starter_pack.py
+++ b/models/starter_pack.py
@@ -28,6 +28,7 @@ def generate_starter_pack_from_look(look_image_uri: str) -> str:
     generated_images, _ = gemini.generate_image_from_prompt_and_images(
         prompt=prompt,
         images=[look_image_uri],
+        aspect_ratio="1:1",
         gcs_folder="starter_pack_generations",
         file_prefix="starter_pack_from_look",
     )
@@ -43,6 +44,7 @@ def generate_look_from_starter_pack(
     generated_images, _ = gemini.generate_image_from_prompt_and_images(
         prompt=prompt,
         images=[starter_pack_uri, model_image_uri],
+        aspect_ratio="1:1",
         gcs_folder="starter_pack_generations",
         file_prefix="look_from_starter_pack",
     )

--- a/pages/interior_design_v2.py
+++ b/pages/interior_design_v2.py
@@ -303,6 +303,7 @@ def on_generate_3d_view_click(e: me.ClickEvent):
         gcs_uris, _ = generate_image_from_prompt_and_images(
             prompt=prompt,
             images=[state.storyboard["original_floor_plan_uri"]],
+            aspect_ratio="16:9",
             gcs_folder="interior_design_generations",
         )
 
@@ -352,6 +353,7 @@ def on_room_button_click(e: me.ClickEvent):
         gcs_uris, _ = generate_image_from_prompt_and_images(
             prompt=prompt,
             images=[state.storyboard["generated_3d_view_uri"]],
+            aspect_ratio="16:9",
             gcs_folder="interior_design_zoomed_views",
         )
 
@@ -427,6 +429,7 @@ def on_design_click(e: me.ClickEvent):
         gcs_uris, _ = generate_image_from_prompt_and_images(
             prompt=state.design_prompt,
             images=images,
+            aspect_ratio="16:9",
             gcs_folder="interior_design_iterations",
         )
 


### PR DESCRIPTION
Updates all calls to the `generate_image_from_prompt_and_images` function to include the newly required `aspect_ratio` parameter.

A previous change to the function signature in `models/gemini.py` was not propagated to all call sites, causing a `TypeError` in features like the Starter Pack page.

This change adds the `aspect_ratio` argument with a sensible default ("1:1" or "16:9" depending on the context) to the function calls in:
- `models/starter_pack.py`
- `pages/interior_design_v2.py`
- `models/character_consistency.py`

Fixes #834


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
