### PR TITLE
Add Check for Issues Feature Enablement to Gemini Scheduled Issue Triage Workflow

### DIFF
--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -69,6 +69,7 @@ jobs:
 
           if [[ "$HAS_ISSUES" == "false" ]]; then
             echo '📝 GitHub repo does not have Issues enabled. Skipping issue triage.'
+            echo "issues_to_triage=[]" >> "${GITHUB_OUTPUT}"
             exit
           fi
 


### PR DESCRIPTION
# Pull-Request Template

Thank you for your contribution! Please provide a brief description of your changes and ensure you've completed the checklist below.

## Description

What does this PR do? 

Adds check to the Gemini Scheduled Issue Triage workflow to see if repo has Issues feature enabled. If not, it sets the issues_to_triage output to an empty array so that workflow completes without error.

Call to gh api repos/ has been added to look for the has_issues property. Docs for that REST call can be found [here](https://docs.github.com/en/rest/repos/repos).

Why is it necessary?

Forks that are used by contributors typically do not have Issues enabled, as they are not meant to be long term repos and are typically spun up to address an issue in the upstream. Right now, a fork will have a failure every hour because the workflow assumes the Issues feature is enabled. These failures cause an email to the fork's owner every hour, which can be a source of friction.

**Fixes #<Issue Number>** (if applicable)

## Checklist

- [X] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [X] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [X] **Authorship:** I am listed as the author (if applicable).
- [X] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [X] **Code Format:** I have run `nox -s format` to format the code.
- [X] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [X] **Sync:** My Fork is synced with the upstream.
- [X] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [X] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
