### PR TITLE
feat: Add Gemini Writers Workshop page

### DIFF
--- a/components/copy_button/copy_button.js
+++ b/components/copy_button/copy_button.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, css, html } from "https://esm.sh/lit";
+import { SvgIcon } from "../svg_icon/svg_icon.js";
+
+class CopyButton extends LitElement {
+  static styles = css`
+    .copy-button {
+      cursor: pointer;
+      padding: 4px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background-color 0.2s ease-in-out;
+    }
+    .copy-button:hover {
+      background-color: var(--mesop-surface-container-hover-color);
+    }
+    svg-icon {
+      width: 20px;
+      height: 20px;
+      color: var(--mesop-on-surface-variant-color);
+    }
+  `;
+
+  static get properties() {
+    return {
+      textToCopy: { type: String },
+      _copied: { state: true },
+    };
+  }
+
+  constructor() {
+    super();
+    this.textToCopy = "";
+    this._copied = false;
+  }
+
+  handleClick() {
+    if (!navigator.clipboard) {
+      console.warn("Copy to clipboard is not supported in this browser.");
+      return;
+    }
+    navigator.clipboard.writeText(this.textToCopy).then(() => {
+      this._copied = true;
+      setTimeout(() => {
+        this._copied = false;
+      }, 2000); // Revert back after 2 seconds
+    });
+  }
+
+  render() {
+    return html`
+      <div class="copy-button" @click=${this.handleClick}>
+        <svg-icon .iconName=${this._copied ? "task_alt" : "content_copy"}></svg-icon>
+      </div>
+    `;
+  }
+}
+
+customElements.define("copy-button", CopyButton);

--- a/components/copy_button/copy_button.py
+++ b/components/copy_button/copy_button.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python wrapper for the Copy Button Lit component."""
+
+import mesop as me
+
+@me.web_component(path="./copy_button.js")
+def copy_button(
+    *,
+    text_to_copy: str,
+    key: str | None = None,
+):
+    """A button that copies the provided text to the clipboard."""
+    return me.insert_web_component(
+        key=key,
+        name="copy-button",
+        properties={
+            "textToCopy": text_to_copy,
+        },
+    )

--- a/components/svg_icon/svg_icon.js
+++ b/components/svg_icon/svg_icon.js
@@ -75,6 +75,10 @@ export class SvgIcon extends LitElement {
         return html`<svg style=${iconStyle} xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>`;
       case 'science':
         return html`<svg style=${iconStyle} xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#5f6368"><g><rect fill="none" height="24" width="24"/></g><g><path d="M13,11.33L18,18H6l5-6.67V6h2 M15.96,4H8.04C7.62,4,7.39,4.48,7.65,4.81L9,6.5v4.17L3.2,18.4C2.71,19.06,3.18,20,4,20h16 c0.82,0,1.29-0.94,0.8-1.6L15,10.67V6.5l1.35-1.69C16.61,4.48,16.38,4,15.96,4L15.96,4z"/></g></svg>`;
+      case 'content_copy':
+        return html`<svg style=${iconStyle} xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>`;
+      case 'task_alt':
+        return html`<svg style=${iconStyle} xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>`;
       default:
         return html`<span class="material-symbols-outlined">${this.iconName}</span>`;
     }

--- a/config/default.py
+++ b/config/default.py
@@ -53,7 +53,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class"""
 
-    VERSION: str = "1.1.1" # media proxies, veo 3.1
+    VERSION: str = "1.1.2" # gemini writer's workshop
     APP_ENV: str = os.environ.get("APP_ENV", "")
 
     SERVICE_ACCOUNT_EMAIL: str = os.environ.get("SERVICE_ACCOUNT_EMAIL")

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.middleware.wsgi import WSGIMiddleware
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from google.auth import impersonated_credentials
 from google.cloud import storage
@@ -42,6 +42,7 @@ from pages import chirp_3hd as chirp_3hd_page
 from pages import config as config_page
 from pages import gemini_image_generation as gemini_image_generation_page
 from pages import gemini_tts as gemini_tts_page
+from pages import gemini_writers_workshop as gemini_writers_workshop_page
 from pages import home as home_page
 from pages import imagen as imagen_page
 from pages import interior_design_v2 as interior_design_page
@@ -203,8 +204,7 @@ me.page(path="/test_svg", title="Test SVG")(test_svg_page)
 me.page(path="/test_media_chooser", title="Test Media Chooser")(test_media_chooser_page)
 
 
-from fastapi.responses import StreamingResponse
-from google.cloud import storage
+
 
 
 # Add a new endpoint to proxy GCS media for better caching.

--- a/models/gemini.py
+++ b/models/gemini.py
@@ -963,11 +963,17 @@ def generate_text(prompt: str, images: list[str]) -> tuple[str, float]:
 
     parts = [types.Part.from_text(text=prompt)]
     for image_uri in images:
-        # Simple check for video based on common extensions
-        if any(ext in image_uri for ext in [".mp4", ".mov", ".avi", ".mkv"]):
-            mime_type = "video/mp4"
+        # More robust mime type detection
+        if any(image_uri.lower().endswith(ext) for ext in [".mp4", ".mov", ".avi", ".mkv", ".webm"]):
+            mime_type = "video/mp4" # General video type
+        elif any(image_uri.lower().endswith(ext) for ext in [".wav", ".mp3", ".flac"]):
+            mime_type = "audio/wav" # General audio type
+        elif any(image_uri.lower().endswith(ext) for ext in [".png", ".jpg", ".jpeg", ".webp", ".gif"]):
+            mime_type = "image/png" # General image type
         else:
-            mime_type = "image/png"
+            # Fallback for unknown types, though this may still cause errors
+            mime_type = "application/octet-stream"
+        
         parts.append(types.Part.from_uri(file_uri=image_uri, mime_type=mime_type))
     
     print(f"Constructed parts for Gemini API: {parts}")

--- a/pages/gemini_writers_workshop.py
+++ b/pages/gemini_writers_workshop.py
@@ -1,0 +1,526 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gemini Writers Workshop - an experimental page for text generation."""
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import mesop as me
+from google.cloud import firestore
+
+from common.analytics import track_model_call
+from common.metadata import (
+    MediaItem,
+    _create_media_item_from_dict,
+    config,
+    db,
+)
+from common.storage import store_to_gcs
+from common.utils import create_display_url
+from components.dialog import dialog
+from components.header import header
+from components.image_thumbnail import image_thumbnail
+from components.media_tile.media_tile import get_pills_for_item, media_tile
+from components.page_scaffold import page_frame, page_scaffold
+from components.scroll_sentinel.scroll_sentinel import scroll_sentinel
+from components.snackbar import snackbar
+from components.svg_icon.svg_icon import svg_icon
+from components.video_thumbnail.video_thumbnail import video_thumbnail
+from config.default import Default as cfg
+from models.gemini import generate_text
+from state.state import AppState
+
+MAX_MEDIA_ASSETS = 3
+
+
+@me.stateclass
+class PageState:
+    """Gemini Writers Workshop Page State"""
+
+    uploaded_media_gcs_uris: list[str] = field(default_factory=list) # pylint: disable=E3701:invalid-field-call
+    uploaded_media_display_urls: list[str] = field(default_factory=list) # pylint: disable=E3701:invalid-field-call
+    prompt: str = ""
+    generated_text: str = ""
+    is_generating: bool = False
+    generation_complete: bool = False
+    generation_time: float = 0.0
+    show_snackbar: bool = False
+    snackbar_message: str = ""
+    previous_media_item_id: str | None = None
+
+    # For the new chooser dialog
+    show_chooser_dialog: bool = False
+    chooser_is_loading: bool = False
+    chooser_media_items: list[MediaItem] = field(default_factory=list) # pylint: disable=E3701:invalid-field-call
+    chooser_last_doc_id: str = ""
+    chooser_all_items_loaded: bool = False
+
+    info_dialog_open: bool = False
+    show_error_dialog: bool = False
+    error_message: str = ""
+
+
+def get_all_media_for_chooser(
+    page_size: int, start_after=None
+) -> tuple[list[MediaItem], Optional[firestore.DocumentSnapshot]]:
+    """
+    Page-local function to fetch all media types, avoiding regressions
+    in the shared `get_media_for_chooser`.
+    """
+    if not db:
+        return [], None
+    try:
+        query = db.collection(config.GENMEDIA_COLLECTION_NAME).order_by(
+            "timestamp", direction=firestore.Query.DESCENDING
+        )
+        if start_after:
+            query = query.start_after(start_after)
+        query = query.limit(page_size)
+        docs = list(query.stream())
+
+        media_items = [
+            _create_media_item_from_dict(doc.id, doc.to_dict())
+            for doc in docs
+            if doc.to_dict() is not None
+        ]
+        last_doc = docs[-1] if docs else None
+        return media_items, last_doc
+    except Exception as e:
+        print(f"Error fetching all media for chooser: {e}")
+        return [], None
+
+
+@me.page(
+    path="/gemini-writers-workshop",
+    title="Gemini Writers Workshop - GenMedia Creative Studio",
+)
+def page():
+    """Define the Mesop page route for Gemini Writers Workshop."""
+    with page_scaffold(page_name="gemini-writers-workshop"): # pylint: disable=E1129:not-context-manager
+        gemini_writers_workshop_page_content()
+
+
+def gemini_writers_workshop_page_content():
+    """Renders the main UI for the Gemini Writers Studio page."""
+    state = me.state(PageState)
+    render_chooser_dialog()
+
+    with dialog(is_open=state.show_error_dialog):
+        me.text("Generation Error", type="headline-6", style=me.Style(color=me.theme_var("error")))
+        me.text(state.error_message, style=me.Style(margin=me.Margin(top=16)))
+        with me.box(style=me.Style(display="flex", justify_content="flex-end", margin=me.Margin(top=24))):
+            me.button("Close", on_click=on_close_error_dialog, type="flat")
+
+    with page_frame():  # pylint: disable=E1129:not-context-manager
+        header(
+            "Gemini Writers Workshop",
+            "spark",
+        )
+        with me.box(style=me.Style(display="flex", flex_direction="row", gap=16)):
+            # Left column (controls)
+            with me.box(
+                style=me.Style(
+                    width=400,
+                    background=me.theme_var("surface-container-lowest"),
+                    padding=me.Padding.all(16),
+                    border_radius=12,
+                )
+            ):
+                me.text(
+                    "Type a prompt and optionally add media assets",
+                    style=me.Style(margin=me.Margin(bottom=16)),
+                )
+                me.textarea(
+                    label="Prompt",
+                    rows=5,
+                    max_rows=20,
+                    autosize=True,
+                    on_blur=on_prompt_blur,
+                    value=me.state(PageState).prompt,
+                    style=me.Style(width="100%", margin=me.Margin(bottom=2)),
+                )
+                _media_upload_slots()
+                with me.box(
+                    style=me.Style(
+                        display="flex",
+                        flex_direction="row",
+                        align_items="center",
+                        gap=16,
+                        margin=me.Margin(top=16),
+                    )
+                ):
+                    _generate_text_button()
+                    with me.content_button(on_click=on_clear_click, type="icon"):
+                        me.icon("delete_sweep")
+
+                if me.state(PageState).generation_complete and me.state(PageState).generation_time > 0:
+                    me.text(
+                        f"{me.state(PageState).generation_time:.2f} seconds",
+                        style=me.Style(font_size=12),
+                    )
+
+            # Right column (generated text)
+            with me.box(
+                style=me.Style(
+                    flex_grow=1,
+                    border_radius=12,
+                    padding=me.Padding.all(16),
+                    min_height=400,
+                )
+            ):
+                if me.state(PageState).generated_text:
+                    me.markdown(me.state(PageState).generated_text)
+                else:
+                    with me.box(
+                        style=me.Style(
+                            display="flex",
+                            flex_direction="column",
+                            align_items="center",
+                            justify_content="center",
+                            height="100%",
+                        )
+                    ):
+                        with me.box(
+                            style=me.Style(
+                                opacity=0.2,
+                                width=128,
+                                height=128,
+                                color=me.theme_var("on-surface-variant"),
+                            )
+                        ):
+                            svg_icon(icon_name="edit_document")
+
+
+@me.component
+def _media_upload_slots():
+    """The media upload UI with 3 slots."""
+    state = me.state(PageState)
+    with me.box(
+        style=me.Style(
+            display="flex",
+            flex_direction="row",
+            gap=10,
+            margin=me.Margin(bottom=16),
+            justify_content="center",
+        )
+    ):
+        for i in range(MAX_MEDIA_ASSETS):
+            if i < len(state.uploaded_media_display_urls):
+                display_url = state.uploaded_media_display_urls[i]
+                gcs_uri = state.uploaded_media_gcs_uris[i]
+
+                with me.box(style=me.Style(position="relative", width=100, height=100)):
+                    if any(gcs_uri.lower().endswith(ext) for ext in [".png", ".jpg", ".jpeg", ".webp", ".gif"]):
+                        me.image(src=display_url, style=me.Style(width="100%", height="100%", border_radius=8, object_fit="cover"))
+                    elif any(gcs_uri.lower().endswith(ext) for ext in [".mp4", ".mov", ".avi", ".webm"]):
+                        video_thumbnail(video_src=display_url)
+                    else:
+                        with me.box(style=me.Style(width=100, height=100, border=me.Border.all(me.BorderSide(style="dashed")), display="flex", align_items="center", justify_content="center")):
+                            me.icon("article")
+                    
+                    with me.box(
+                        on_click=on_remove_media,
+                        key=str(i),
+                        style=me.Style(
+                            background="rgba(0, 0, 0, 0.5)",
+                            color="white",
+                            position="absolute",
+                            top=4,
+                            right=4,
+                            border_radius="50%",
+                            cursor="pointer",
+                            display="flex",
+                            align_items="center",
+                            justify_content="center",
+                            width=26,
+                            height=26,
+                        ),
+                    ):
+                        me.icon("close", style=me.Style(font_size=18))
+
+            elif i == len(state.uploaded_media_gcs_uris):
+                _uploader_placeholder(key_prefix=f"media_slot_{i}")
+            else:
+                _empty_placeholder()
+
+
+@me.component
+def _uploader_placeholder(key_prefix: str):
+    """A placeholder box with uploader and library chooser buttons."""
+    with me.box(
+        style=me.Style(
+            height=100,
+            width=100,
+            border=me.Border.all(
+                me.BorderSide(
+                    width=1,
+                    style="dashed",
+                    color=me.theme_var("outline"),
+                )
+            ),
+            border_radius=8,
+            display="flex",
+            flex_direction="column",
+            align_items="center",
+            justify_content="center",
+            gap=8,
+        )
+    ):
+        me.uploader(
+            label="Upload Media",
+            on_upload=on_upload,
+            accepted_file_types=["image/jpeg", "image/png", "image/webp", "video/mp4"],
+            key=f"{key_prefix}_uploader",
+            multiple=True,
+        )
+        with me.content_button(
+            on_click=open_chooser_dialog, type="icon", key=f"{key_prefix}_library_chooser"
+        ):
+            me.icon("photo_library")
+
+
+@me.component
+def _empty_placeholder():
+    """An empty, non-interactive placeholder box."""
+    me.box(
+        style=me.Style(
+            height=100,
+            width=100,
+            border=me.Border.all(
+                me.BorderSide(width=1, style="dashed", color=me.theme_var("outline"))
+            ),
+            border_radius=8,
+            opacity=0.5,
+        )
+    )
+
+
+@me.component
+def _generate_text_button():
+    """Renders the main generate button and its loading state."""
+    state = me.state(PageState)
+    if state.is_generating:
+        with me.content_button(type="raised", disabled=True):
+            with me.box(
+                style=me.Style(
+                    display="flex",
+                    flex_direction="row",
+                    align_items="center",
+                    gap=8,
+                )
+            ):
+                me.progress_spinner(diameter=20, stroke_width=3)
+                me.text("Generating Text...")
+    else:
+        me.button(
+            "Generate Text",
+            on_click=on_generate_text_click,
+            type="raised",
+        )
+
+
+@me.component
+def render_chooser_dialog():
+    """Renders the single, page-level dialog for choosing media."""
+    state = me.state(PageState)
+
+    def handle_item_selected(e: me.WebEvent):
+        gcs_uri = e.key
+        if len(state.uploaded_media_gcs_uris) < MAX_MEDIA_ASSETS:
+            state.uploaded_media_gcs_uris.append(gcs_uri)
+            state.uploaded_media_display_urls.append(create_display_url(gcs_uri))
+        else:
+            show_snackbar(f"You can add a maximum of {MAX_MEDIA_ASSETS} media assets.")
+        state.show_chooser_dialog = False
+        yield
+
+    def handle_load_more(e: me.WebEvent):
+        if state.chooser_is_loading or state.chooser_all_items_loaded:
+            return
+
+        state.chooser_is_loading = True
+        yield
+
+        # Get document object using stored ID
+        last_doc_ref = (
+            db.collection(config.GENMEDIA_COLLECTION_NAME)
+            .document(state.chooser_last_doc_id)
+            .get()
+        )
+        # Use that object for query
+        new_items, last_doc = get_all_media_for_chooser(
+            page_size=20, start_after=last_doc_ref,
+        )
+
+        for item in new_items:
+            gcs_uri = item.gcsuri or (item.gcs_uris[0] if item.gcs_uris else None)
+            item.signed_url = create_display_url(gcs_uri) if gcs_uri else ""
+
+        state.chooser_media_items.extend(new_items)
+        state.chooser_last_doc_id = last_doc.id if last_doc else ""
+        state.chooser_is_loading = False
+        yield
+
+    dialog_style = me.Style(width="95vw", height="80vh", display="flex", flex_direction="column")
+
+    with dialog(is_open=state.show_chooser_dialog, dialog_style=dialog_style):  # pylint: disable=E1129:not-context-manager
+        if state.show_chooser_dialog:
+            with me.box(style=me.Style(display="flex", flex_direction="column", gap=16, flex_grow=1)):
+                with me.box(style=me.Style(display="flex", flex_direction="row", justify_content="space-between", align_items="center", width="100%")):
+                    me.text("Select a Media Asset from Library", type="headline-6")
+                    with me.content_button(type="icon", on_click=lambda e: setattr(state, "show_chooser_dialog", False)):
+                        me.icon("close")
+
+                with me.box(style=me.Style(flex_grow=1, overflow_y="auto", padding=me.Padding.all(10))):
+                    if state.chooser_is_loading and not state.chooser_media_items:
+                        with me.box(style=me.Style(display="flex", justify_content="center", align_items="center", height="100%")):
+                            me.progress_spinner()
+                    else:
+                        with me.box(style=me.Style(display="grid", grid_template_columns="repeat(auto-fill, minmax(250px, 1fr))", gap="16px")):
+                            items_to_render = state.chooser_media_items
+                            if not items_to_render and not state.chooser_is_loading:
+                                me.text("No items found in your library.")
+                            else:
+                                for item in items_to_render:
+                                    https_url = item.signed_url if hasattr(item, "signed_url") else ""
+                                    
+                                    # Explicitly determine render type for the tile
+                                    render_type = "image" # Default
+                                    if item.mime_type:
+                                        if item.mime_type.startswith("video/"):
+                                            render_type = "video"
+                                        elif item.mime_type.startswith("audio/"):
+                                            render_type = "audio"
+                                    elif https_url:
+                                        if ".mp4" in https_url or ".webm" in https_url:
+                                            render_type = "video"
+                                        elif ".wav" in https_url or ".mp3" in https_url:
+                                            render_type = "audio"
+
+                                    media_tile(
+                                        key=item.gcsuri
+                                        or (item.gcs_uris[0] if item.gcs_uris else ""),
+                                        on_click=handle_item_selected,
+                                        media_type=render_type,
+                                        https_url=https_url,
+                                        pills_json=get_pills_for_item(item, https_url),
+                                    )
+                        scroll_sentinel(
+                            on_visible=handle_load_more,
+                            is_loading=state.chooser_is_loading,
+                            all_items_loaded=state.chooser_all_items_loaded,
+                        )
+
+def open_chooser_dialog(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.show_chooser_dialog = True
+    state.chooser_is_loading = True
+    state.chooser_media_items = []
+    state.chooser_all_items_loaded = False
+    state.chooser_last_doc_id = ""
+    yield
+
+    items, last_doc = get_all_media_for_chooser(page_size=20)
+
+    for item in items:
+        gcs_uri = item.gcsuri or (item.gcs_uris[0] if item.gcs_uris else None)
+        item.signed_url = create_display_url(gcs_uri) if gcs_uri else ""
+
+    state.chooser_media_items = items
+    state.chooser_last_doc_id = last_doc.id if last_doc else ""
+    if not last_doc:
+        state.chooser_all_items_loaded = True
+    state.chooser_is_loading = False
+    yield
+
+# Other event handlers
+def on_upload(e: me.UploadEvent):
+    state = me.state(PageState)
+    if len(state.uploaded_media_gcs_uris) < MAX_MEDIA_ASSETS:
+        file = e.files[0]
+        gcs_url = store_to_gcs("gemini_writers_studio_references", file.name, file.mime_type, file.getvalue())
+        state.uploaded_media_gcs_uris.append(gcs_url)
+        state.uploaded_media_display_urls.append(create_display_url(gcs_url))
+    else:
+        show_snackbar(f"You can add a maximum of {MAX_MEDIA_ASSETS} media assets.")
+    yield
+
+def on_remove_media(e: me.ClickEvent):
+    state = me.state(PageState)
+    index_to_remove = int(e.key)
+    if 0 <= index_to_remove < len(state.uploaded_media_gcs_uris):
+        del state.uploaded_media_gcs_uris[index_to_remove]
+        del state.uploaded_media_display_urls[index_to_remove]
+    yield
+
+def on_prompt_blur(e: me.InputEvent):
+    me.state(PageState).prompt = e.value
+
+def on_clear_click(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.generated_text = ""
+    state.prompt = ""
+    state.uploaded_media_gcs_uris = []
+    state.uploaded_media_display_urls = []
+    state.generation_time = 0.0
+    state.generation_complete = False
+    state.previous_media_item_id = None
+    yield
+
+def show_snackbar(message: str):
+    state = me.state(PageState)
+    state.snackbar_message = message
+    state.show_snackbar = True
+    yield
+    time.sleep(3)
+    state.show_snackbar = False
+    yield
+
+def on_generate_text_click(e: me.ClickEvent):
+    state = me.state(PageState)
+    if not state.prompt:
+        yield from show_snackbar("Please enter a prompt.")
+        return
+    yield from _generate_text_and_save(
+        base_prompt=state.prompt,
+        input_gcs_uris=state.uploaded_media_gcs_uris,
+    )
+
+def on_close_error_dialog(e: me.ClickEvent):
+    state = me.state(PageState)
+    state.show_error_dialog = False
+    yield
+
+def _generate_text_and_save(base_prompt: str, input_gcs_uris: list[str]):
+    state = me.state(PageState)
+    app_state = me.state(AppState)
+    state.is_generating = True
+    state.generation_complete = False
+    yield
+
+    try:
+        with track_model_call(model_name=cfg().MODEL_ID, prompt_length=len(base_prompt)):
+            text_result, execution_time = generate_text(prompt=base_prompt, images=input_gcs_uris)
+        state.generation_time = execution_time
+        state.generated_text = text_result
+    except Exception as ex:
+        print(f"ERROR: Failed to generate text. Details: {ex}")
+        state.error_message = f"An error occurred: {ex}"
+        state.show_error_dialog = True
+    finally:
+        state.is_generating = False
+        state.generation_complete = True
+        yield

--- a/pages/gemini_writers_workshop.py
+++ b/pages/gemini_writers_workshop.py
@@ -21,7 +21,7 @@ from typing import List, Optional
 import mesop as me
 from google.cloud import firestore
 
-from common.analytics import track_model_call
+from common.analytics import track_model_call, track_click
 from common.metadata import (
     MediaItem,
     _create_media_item_from_dict,
@@ -588,6 +588,7 @@ def on_prompt_blur(e: me.InputEvent):
     me.state(PageState).prompt = e.value
 
 
+@track_click(element_id="writers_workshop_clear_button")
 def on_clear_click(e: me.ClickEvent):
     state = me.state(PageState)
     state.generated_text = ""
@@ -610,6 +611,7 @@ def show_snackbar(message: str):
     yield
 
 
+@track_click(element_id="writers_workshop_generate_button")
 def on_generate_text_click(e: me.ClickEvent):
     state = me.state(PageState)
     if not state.prompt:

--- a/pages/test_index.py
+++ b/pages/test_index.py
@@ -37,6 +37,11 @@ def page():
             "route": "/banana-studio",
         },
         {
+            "title": "Gemini Writers Workshop",
+            "description": "A place to generate text content from prompts and optional media assets.",
+            "route": "/gemini-writers-workshop",
+        },
+        {
             "title": "VTO Model Composite Card Generator",
             "description": "A tool to generate a matrix of virtual models with different attributes.",
             "route": "/test_vto_prompt_generator",


### PR DESCRIPTION
This commit introduces the "Gemini Writers Workshop," a new experimental page for multimodal text generation using Gemini.

The core feature allows users to provide a text prompt along with up to three optional media assets (images or videos) to generate rich text content.

Key changes include:
- **New Page:** Created `pages/gemini_writers_workshop.py` to house the new UI and its logic.
- **Backend Model:** Added a `generate_text` function to `models/gemini.py` to handle multimodal requests to the Gemini API.
- **UI Components:**
    - Implemented a page-local, asynchronous media chooser dialog that displays all media types from the library.
    - Added logic to conditionally render different thumbnails for images, videos, and other media types.
    - Implemented a modal dialog for displaying critical model generation errors, improving user feedback.
- **State Management:** Refactored the page's state management for pagination to be JSON serializable, resolving a critical bug by storing document IDs as strings instead of complex `DocumentSnapshot` objects.
- **Routing:** Registered the new page and added a link from the main labs index.

This feature was developed through an iterative debugging process that involved identifying and resolving architectural inconsistencies, fixing data-fetching and rendering bugs in the UI, and aligning the new page with the project's established component and state management patterns.

Begins to address #868


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
