### PR TITLE
fix: fixes #880 adds webp image for upload

### DIFF
--- a/components/veo/veo_modes.py
+++ b/components/veo/veo_modes.py
@@ -196,7 +196,7 @@ def _uploader_placeholder(on_upload, on_library_select, key_prefix: str, disable
         me.uploader(
             label="Upload Image",
             on_upload=on_upload,
-            accepted_file_types=["image/jpeg", "image/png"],
+            accepted_file_types=["image/jpeg", "image/png", "image/webp"],
             key=f"{key_prefix}_uploader",
             disabled=disabled,
         )


### PR DESCRIPTION
Veo upload chooser for i2v/r2v doesn't allow image/webp

Fixes #880



## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
