### PR TITLE
feat(veo): Add generate_audio support and refactor model capabilities

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/go.work.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/go.work.sum
@@ -1150,6 +1150,7 @@ google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojt
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 google.golang.org/protobuf v1.36.7/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
@@ -30,8 +30,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.53.0/go.mod h1:jUZ5LYlw40WMd07qxcQJD5M40aUxrfwqQX1g7zxYnrQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251007003430-7f3a9d00b298 h1:GOcjBARwze/Cb5lvQYIMjY/TzDbgw1IzQ76UrnA+5Ew=
-github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251007003430-7f3a9d00b298/go.mod h1:WoFxuaQNUwkp/1D6EcIhv5I55AP1tZjJ0fy9/LV05OY=
 github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251008031531-ca221c476ed6 h1:N5VpX+qjsrMzF6j45LTYpGtOI2BRTJy7RbLRI21ISy8=
 github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20251008031531-ca221c476ed6/go.mod h1:WoFxuaQNUwkp/1D6EcIhv5I55AP1tZjJ0fy9/LV05OY=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -130,11 +130,11 @@ func BuildImagenModelDescription() string {
 type VeoModelInfo struct {
 	CanonicalName         string
 	Aliases               []string
-	MinDuration           int32
-	MaxDuration           int32
 	DefaultDuration       int32
+	SupportedDurations    []int32
 	MaxVideos             int32
 	SupportedAspectRatios []string
+	SupportsGenerateAudio bool
 }
 
 // SupportedVeoModels is the single source of truth for all supported Veo models.
@@ -142,29 +142,83 @@ var SupportedVeoModels = map[string]VeoModelInfo{
 	"veo-2.0-generate-001": {
 		CanonicalName:         "veo-2.0-generate-001",
 		Aliases:               []string{"Veo 2"},
-		MinDuration:           5,
-		MaxDuration:           8,
-		DefaultDuration:       5,
+		DefaultDuration:       8,
+		SupportedDurations:    []int32{5, 6, 7, 8},
 		MaxVideos:             4,
 		SupportedAspectRatios: []string{"16:9", "9:16"},
+		SupportsGenerateAudio: false,
+	},
+	"veo-2.0-generate-exp": {
+		CanonicalName:         "veo-2.0-generate-exp",
+		Aliases:               []string{"Veo 2.0 Exp"},
+		DefaultDuration:       8,
+		SupportedDurations:    []int32{5, 6, 7, 8},
+		MaxVideos:             4,
+		SupportedAspectRatios: []string{"16:9", "9:16"},
+		SupportsGenerateAudio: false,
+	},
+	"veo-2.0-generate-preview": {
+		CanonicalName:         "veo-2.0-generate-preview",
+		Aliases:               []string{"Veo 2.0 Preview"},
+		DefaultDuration:       8,
+		SupportedDurations:    []int32{5, 6, 7, 8},
+		MaxVideos:             4,
+		SupportedAspectRatios: []string{"16:9", "9:16"},
+		SupportsGenerateAudio: false,
+	},
+	"veo-3.0-generate-001": {
+		CanonicalName:         "veo-3.0-generate-001",
+		Aliases:               []string{"Veo 3.0"},
+		DefaultDuration:       8,
+		SupportedDurations:    []int32{4, 6, 8},
+		MaxVideos:             2,
+		SupportedAspectRatios: []string{"16:9"},
+		SupportsGenerateAudio: true,
+	},
+	"veo-3.0-fast-generate-001": {
+		CanonicalName:         "veo-3.0-fast-generate-001",
+		Aliases:               []string{"Veo 3.0 Fast"},
+		DefaultDuration:       8,
+		SupportedDurations:    []int32{4, 6, 8},
+		MaxVideos:             2,
+		SupportedAspectRatios: []string{"16:9"},
+		SupportsGenerateAudio: true,
 	},
 	"veo-3.0-generate-preview": {
 		CanonicalName:         "veo-3.0-generate-preview",
 		Aliases:               []string{"Veo 3"},
-		MinDuration:           8,
-		MaxDuration:           8,
 		DefaultDuration:       8,
+		SupportedDurations:    []int32{4, 6, 8},
 		MaxVideos:             2,
 		SupportedAspectRatios: []string{"16:9"},
+		SupportsGenerateAudio: true,
 	},
 	"veo-3.0-fast-generate-preview": {
 		CanonicalName:         "veo-3.0-fast-generate-preview",
 		Aliases:               []string{"Veo 3 Fast"},
-		MinDuration:           8,
-		MaxDuration:           8,
 		DefaultDuration:       8,
+		SupportedDurations:    []int32{4, 6, 8},
 		MaxVideos:             2,
 		SupportedAspectRatios: []string{"16:9"},
+		SupportsGenerateAudio: true,
+	},
+	"veo-3.1-generate-preview": {
+		CanonicalName:         "veo-3.1-generate-preview",
+		Aliases:               []string{"Veo 3.1"},
+		DefaultDuration:       8,
+		SupportedDurations:    []int32{4, 6, 8},
+		MaxVideos:             2,
+		SupportedAspectRatios: []string{"16:9", "9:16"},
+		SupportsGenerateAudio: true,
+	},
+	"veo-3.1-fast-generate-preview": {
+		CanonicalName:         "veo-3.1-fast-generate-preview",
+		Aliases:               []string{"Veo 3.1 Fast"},
+		DefaultDuration:       8,
+		SupportedDurations:    []int32{4, 6, 8},
+		MaxVideos:             2,
+		SupportedAspectRatios: []string{"16:9", "9:16"},
+		SupportsGenerateAudio: true,
 	},
 }
 
@@ -197,8 +251,12 @@ func BuildVeoModelDescription() string {
 
 	for _, name := range sortedNames {
 		info := SupportedVeoModels[name]
-		sb.WriteString(fmt.Sprintf("- *%s* (Duration: %d-%ds, Max Videos: %d, Ratios: %s)",
-			info.CanonicalName, info.MinDuration, info.MaxDuration, info.MaxVideos, strings.Join(info.SupportedAspectRatios, ", ")))
+		durationsStr := make([]string, len(info.SupportedDurations))
+		for i, d := range info.SupportedDurations {
+			durationsStr[i] = fmt.Sprintf("%d", d)
+		}
+		sb.WriteString(fmt.Sprintf("- *%s* (Durations: [%s]s, Max Videos: %d, Ratios: %s)",
+			info.CanonicalName, strings.Join(durationsStr, ", "), info.MaxVideos, strings.Join(info.SupportedAspectRatios, ", ")))
 		if len(info.Aliases) > 0 {
 			sb.WriteString(fmt.Sprintf(" Aliases: *%s*", strings.Join(info.Aliases, "*, *")))
 		}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.sum
@@ -166,8 +166,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250908214217-97024824d090 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250908214217-97024824d090/go.mod h1:GmFNa4BdJZ2a8G+wCe9Bg3wwThLrJun751XstdJt5Og=
 google.golang.org/grpc v1.75.1 h1:/ODCNEuf9VghjgO3rqLcfg8fiOP0nSluljWFlDxELLI=
 google.golang.org/grpc v1.75.1/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
-google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
-google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This commit introduces two major enhancements to the Veo MCP server: support for the `generate_audio` parameter and a more flexible system for defining model capabilities.

The `generate_audio` boolean parameter has been added to the `veo_t2v` and `veo_i2v` tools. This is conditionally applied based on a new `SupportsGenerateAudio` flag in the model definition, ensuring it is only sent for compatible models like Veo 3.

To accommodate discontinuous duration values (e.g., 4, 6, 8s for Veo 3.x models), the `VeoModelInfo` struct has been refactored. The `MinDuration` and `MaxDuration` fields have been replaced with a `SupportedDurations` slice of integers. The server's validation logic and help text generation have been updated accordingly.

Finally, the list of supported Veo models has been expanded and updated:
- Added new Veo 2.x, 3.x, and 3.1 models.
- Veo 3.1 models now support both 16:9 and 9:16 aspect ratios.
- All Veo 3.x models now correctly define their supported durations as [4, 6, 8].

Fixes: #882


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
