### PR TITLE
feat(veo): Improve UI clarity and documentation

### DIFF
--- a/components/veo/veo_modes.py
+++ b/components/veo/veo_modes.py
@@ -44,10 +44,10 @@ def veo_modes(
         return
 
     # Dynamically create the buttons based on the supported modes for the selected model.
-    veo_mode_buttons = [
-        me.ButtonToggleButton(label=mode, value=mode)
-        for mode in selected_config.supported_modes
-    ]
+    veo_mode_buttons = []
+    for mode in selected_config.supported_modes:
+        label = "first/last" if mode == "interpolation" else mode
+        veo_mode_buttons.append(me.ButtonToggleButton(label=label, value=mode))
 
     me.button_toggle(
         value=state.veo_mode,
@@ -257,7 +257,7 @@ def _image_uploader(
                     disabled=False,
                 )
 
-        # Last Frame (for interpolation)
+        # Last Frame (for interpolation, also known as first/last frame)
         if last_image:
             with me.box(style=me.Style(display="flex", flex_direction="column", gap=2)):
                 me.text("Last Frame", style=me.Style(font_size="10pt"))

--- a/pages/veo.py
+++ b/pages/veo.py
@@ -192,7 +192,22 @@ def veo_content(app_state: me.state):
             me.text(f"Negative Prompt: {state.negative_prompt}")
             me.text(f"Model: {state.veo_model}")
             me.text(f"Duration: {state.video_length}s")
-            me.text(f"Input Image: {state.reference_image_gcs}")
+
+            # Mode-specific settings display
+            if state.veo_mode == "i2v":
+                if state.reference_image_gcs:
+                    me.text(f"Input Image: {state.reference_image_gcs}")
+            elif state.veo_mode == "interpolation":
+                if state.reference_image_gcs:
+                    me.text(f"First Frame: {state.reference_image_gcs}")
+                if state.last_reference_image_gcs:
+                    me.text(f"Last Frame: {state.last_reference_image_gcs}")
+            elif state.veo_mode == "r2v":
+                if state.r2v_reference_images:
+                    me.text(f"Asset Images: {len(state.r2v_reference_images)} selected")
+                if state.r2v_style_image:
+                    me.text(f"Style Image: {state.r2v_style_image}")
+
             with dialog_actions():  # pylint: disable=E1129:not-context-manager
                 me.button("Close", on_click=close_info_dialog, type="flat")
 


### PR DESCRIPTION
This commit includes several updates to the Veo page to improve user experience, clarity, and the accuracy of displayed information.

Key Changes:
- **Mode Relabeling:** The 'interpolation' mode has been relabeled to 'first/last' in the UI to be more descriptive for users. The underlying value remains the same to ensure logic compatibility.
- **Updated 'About' Dialog:** The description in the main 'About Veo' dialog has been updated to accurately list all supported generation modes (t2v, i2v, first/last, and r2v).
- **Dynamic Settings Display:** The 'Current Settings' panel within the info dialog is now mode-aware. It dynamically displays the correct input image information based on the currently selected generation mode, removing confusion.

Fixes: internal/455140690

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
