### PR TITLE
feat(vto): Migrate VTO to new Python GenAI SDK

### DIFF
--- a/common/metadata.py
+++ b/common/metadata.py
@@ -136,6 +136,10 @@ class MediaItem:
     r2v_reference_images: List[str] = field(default_factory=list)
     r2v_style_image: Optional[str] = None
 
+    # VTO specific
+    person_image_gcs: Optional[str] = None
+    product_image_gcs: Optional[str] = None
+
     def __post_init__(self):
         # Ensure audio_analysis is always a JSON string for state serialization.
         # This handles cases where raw data from Firestore might be a dict.
@@ -331,6 +335,8 @@ def _create_media_item_from_dict(doc_id: str, raw_item_data: dict) -> MediaItem:
         related_media_item_id=raw_item_data.get("related_media_item_id"),
         r2v_reference_images=raw_item_data.get("r2v_reference_images", []),
         r2v_style_image=raw_item_data.get("r2v_style_image"),
+        person_image_gcs=raw_item_data.get("person_image_gcs"),
+        product_image_gcs=raw_item_data.get("product_image_gcs"),
         raw_data=raw_item_data,
     )
     return media_item

--- a/components/media_tile/media_tile.py
+++ b/components/media_tile/media_tile.py
@@ -34,6 +34,8 @@ def get_pills_for_item(item: MediaItem, https_url: str) -> str:
             pills.append({"label": f"{item.duration} sec"})
     elif effective_media_type == "image":
         pills.append({"label": "Image"})
+        if item.model and ("vto" in item.model.lower() or "virtual-try-on" in item.model.lower()):
+            pills.append({"label": "vto"})
         if item.aspect:
             pills.append({"label": item.aspect})
         if len(item.gcs_uris) > 1:

--- a/config/about_content.json
+++ b/config/about_content.json
@@ -14,7 +14,7 @@
     {
       "id": "veo",
       "title": "Veo",
-      "description": "The **Veo** page is for video generation. You can create videos from a text prompt (text-to-video) or animate an existing image (image-to-video).\n\n**Available Models:**\n*   Veo 2\n*   Veo 3\n*   Veo 3 Fast\n\n[Learn more about Veo on Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/video/overview)",
+      "description": "The **Veo** page is for advanced video generation. You can create videos using several modes:\n*   **Text-to-Video**: Create a video from a descriptive text prompt.\n*   **Image-to-Video**: Animate a single static image.\n*   **First/Last Frame**: Generate the video motion between a starting image and an ending image.\n*   **Reference-to-Video**: Generate a video based on multiple asset images and an optional style reference image.\n\n**Available Models:**\n*   Veo 2\n*   Veo 3 & Veo 3 Fast\n*   Veo 3.1 & Veo 3.1 Fast\n\n[Learn more about Veo on Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/video/overview)",
       "image": null,
       "video": null
     },

--- a/config/default.py
+++ b/config/default.py
@@ -53,7 +53,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class"""
 
-    VERSION: str = "1.2.0" # prompt templates
+    VERSION: str = "1.2.2" # vto / stl refactor
     APP_ENV: str = os.environ.get("APP_ENV", "")
 
     SERVICE_ACCOUNT_EMAIL: str = os.environ.get("SERVICE_ACCOUNT_EMAIL")

--- a/models/shop_the_look_handlers.py
+++ b/models/shop_the_look_handlers.py
@@ -34,7 +34,7 @@ from models.gemini import (
 )
 from models.shop_the_look_models import ProgressionImage, ProgressionImages
 from models.veo import image_to_video
-from models.vto import call_virtual_try_on
+from models.vto import generate_vto_image
 from common.utils import create_display_url
 from state.shop_the_look_state import PageState
 from state.state import AppState
@@ -305,13 +305,12 @@ def on_click_vto_look(e: me.ClickEvent):  # pylint: disable=unused-argument
                 state.current_status = f"{status_prefix}Trying on {row.article_type}..."
                 yield
 
-                op = call_virtual_try_on(
-                    person_image_uri=state.reference_image_gcs_model,
-                    product_image_uri=row.clothing_image,
+                potential_images = generate_vto_image(
+                    person_gcs_uri=state.reference_image_gcs_model,
+                    product_gcs_uri=row.clothing_image,
                     sample_count=int(state.vto_sample_count),
                 )
 
-                potential_images = [p["gcsUri"] for p in op.predictions]
                 temp_progressions = [
                     ProgressionImage(image_path=p, best_image=False, reasoning="")
                     for p in potential_images

--- a/pages/library_v2.py
+++ b/pages/library_v2.py
@@ -519,6 +519,10 @@ def render_default_detail_dialog(item: MediaItem):
         all_source_uris.append(item.r2v_style_image)
     if item.reference_image:
         all_source_uris.append(item.reference_image)
+    if item.person_image_gcs:
+        all_source_uris.append(item.person_image_gcs)
+    if item.product_image_gcs:
+        all_source_uris.append(item.product_image_gcs)
 
     # Handle case where timestamp might be a string from Firestore
     timestamp_display = "N/A"


### PR DESCRIPTION
Migrates the Virtual Try-On (VTO) feature to use the new `google-genai` Python SDK, replacing the legacy `aiplatform` GAPIC client.

Changes:
- Created `models/vto.py` using `google-genai` SDK with direct GCS output for improved efficiency.
- Updated `pages/vto.py` to use the new service and added UI controls for `person_generation` and `safety_filter_level`.
- Refactored `models/shop_the_look_handlers.py` to use the new VTO service.
- Updated `common/metadata.py` to include VTO-specific fields (`person_image_gcs`, `product_image_gcs`) in `MediaItem`.
- Enhanced `pages/library_v2.py` to display VTO source images in the details view.
- Updated `components/media_tile/media_tile.py` to display a "vto" pill for VTO media items.


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
