### PR TITLE
feat(mcp-gemini): add support for gemini-3-pro-image-preview and lite tts

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-11-23
+
+*   **Feat:** Added support for `gemini-3-pro-image-preview` (alias: "Nano Banana Pro") and `gemini-2.5-flash-image` (alias: "Nano Banana") to the `gemini_image_generation` tool in `mcp-gemini-go`.
+*   **Feat:** Added `gemini-2.5-flash-lite-preview-tts` to the supported models in the `gemini_audio_tts` tool in `mcp-gemini-go`.
+*   **Refactor:** Centralized Gemini Image model definitions in `mcp-common/models.go`, matching the architectural pattern used for Imagen and Veo.
+*   **Chore:** Incremented `mcp-gemini-go` version to 0.5.1.
+
 ## 2025-10-09
 
 *   **Feat:** Standardized network port configuration across all MCP servers (`avtool`, `chirp3`, `imagen`, `lyria`, `veo`, `gemini`). All servers now follow a consistent precedence: `--port` flag, `PORT` environment variable, and then transport-specific defaults (`8080` for `http`, `8081` for `sse`).

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -124,6 +124,70 @@ func BuildImagenModelDescription() string {
 }
 
 
+// --- Gemini Image Model Configuration ---
+
+// GeminiImageModelInfo holds the details for a specific Gemini Image model.
+type GeminiImageModelInfo struct {
+	CanonicalName string
+	Aliases       []string
+	Description   string
+}
+
+// SupportedGeminiImageModels is the single source of truth for all supported Gemini Image models.
+var SupportedGeminiImageModels = map[string]GeminiImageModelInfo{
+	"gemini-3-pro-image-preview": {
+		CanonicalName: "gemini-3-pro-image-preview",
+		Aliases:       []string{"Nano Banana Pro"},
+		Description:   "High quality, preferred alternative to gemini-2.5-flash-image.",
+	},
+	"gemini-2.5-flash-image": {
+		CanonicalName: "gemini-2.5-flash-image",
+		Aliases:       []string{"Nano Banana", "nano-banana"},
+		Description:   "Fast, cost-efficient image generation.",
+	},
+}
+
+var geminiImageAliasMap = make(map[string]string)
+
+func init() {
+	for canonicalName, info := range SupportedGeminiImageModels {
+		geminiImageAliasMap[strings.ToLower(canonicalName)] = canonicalName
+		for _, alias := range info.Aliases {
+			geminiImageAliasMap[strings.ToLower(alias)] = canonicalName
+		}
+	}
+}
+
+// ResolveGeminiImageModel finds the canonical model name from a user-provided name or alias.
+func ResolveGeminiImageModel(modelInput string) (string, bool) {
+	canonicalName, found := geminiImageAliasMap[strings.ToLower(modelInput)]
+	return canonicalName, found
+}
+
+// BuildGeminiImageModelDescription generates a formatted string for the tool description.
+func BuildGeminiImageModelDescription() string {
+	var sb strings.Builder
+	sb.WriteString("Model for image generation. Can be a full model ID or a common name. Supported models:\n")
+	var sortedNames []string
+	for name := range SupportedGeminiImageModels {
+		sortedNames = append(sortedNames, name)
+	}
+	sort.Strings(sortedNames)
+
+	for _, name := range sortedNames {
+		info := SupportedGeminiImageModels[name]
+		sb.WriteString(fmt.Sprintf("- *%s*", info.CanonicalName))
+		if len(info.Aliases) > 0 {
+			sb.WriteString(fmt.Sprintf(" Aliases: *%s*", strings.Join(info.Aliases, "*, *")))
+		}
+		if info.Description != "" {
+			sb.WriteString(fmt.Sprintf(" - %s", info.Description))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
 // --- Veo Model Configuration ---
 
 // VeoModelInfo holds the details for a specific Veo model.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -1,5 +1,3 @@
-
-
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -123,7 +121,6 @@ func BuildImagenModelDescription() string {
 	return sb.String()
 }
 
-
 // --- Gemini Image Model Configuration ---
 
 // GeminiImageModelInfo holds the details for a specific Gemini Image model.
@@ -137,13 +134,13 @@ type GeminiImageModelInfo struct {
 var SupportedGeminiImageModels = map[string]GeminiImageModelInfo{
 	"gemini-3-pro-image-preview": {
 		CanonicalName: "gemini-3-pro-image-preview",
-		Aliases:       []string{"Nano Banana Pro"},
-		Description:   "High quality, preferred alternative to gemini-2.5-flash-image.",
+		Aliases:       []string{"Nano Banana Pro", "Gemini 3 Pro Image"},
+		Description:   "Gemini 3 Pro Image, or Gemini 3 Pro (with Nano Banana), is designed to tackle the most challenging image generation by incorporating state-of-the-art reasoning capabilities. It's the best model for complex and multi-turn image generation and editing, having improved accuracy and enhanced image quality.",
 	},
 	"gemini-2.5-flash-image": {
 		CanonicalName: "gemini-2.5-flash-image",
 		Aliases:       []string{"Nano Banana", "nano-banana"},
-		Description:   "Fast, cost-efficient image generation.",
+		Description:   "Gemini 2.5 Flash Image, or Nano Banana, is optimized for image understanding and generation and offers a balance of price and performance.",
 	},
 }
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
@@ -29,6 +29,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/genai"
+
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
 )
 
 func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -42,12 +44,14 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 		return mcp.NewToolResultError("prompt must be a non-empty string and is required"), nil
 	}
 
-	model, _ := request.GetArguments()["model"].(string)
-	if model == "nano-banana" || model == "nano banana" {
-		model = "gemini-2.5-flash-image"
-	}
-	if model == "" { // default
-		model = "gemini-2.5-flash-image"
+	modelArg, _ := request.GetArguments()["model"].(string)
+	model := "gemini-2.5-flash-image"
+	if modelArg != "" {
+		if resolved, found := common.ResolveGeminiImageModel(modelArg); found {
+			model = resolved
+		} else {
+			model = modelArg
+		}
 	}
 
 	outputDir := ""

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-gemini-go"
-	version     = "0.5.0" // Add http support
+	version     = "0.5.1" // Add new Gemini models
 )
 
 func init() {
@@ -97,9 +97,9 @@ func main() {
 	s := server.NewMCPServer("Gemini", version, server.WithResourceCapabilities(true, false))
 
 	tool := mcp.NewTool("gemini_image_generation",
-		mcp.WithDescription("Generates content (text and/or images) based on a multimodal prompt using Gemini 2.5 Flash Image generation. This model is also called nano-banana."),
+		mcp.WithDescription("Generates content (text and/or images) based on a multimodal prompt using Gemini Image generation models."),
 		mcp.WithString("prompt", mcp.Required(), mcp.Description("The text prompt for content generation.")),
-		mcp.WithString("model", mcp.DefaultString("gemini-2.5-flash-image"), mcp.Description("The specific Gemini model to use.")),
+		mcp.WithString("model", mcp.DefaultString("gemini-2.5-flash-image"), mcp.Description(common.BuildGeminiImageModelDescription())),
 		mcp.WithArray("images", mcp.Description("Optional. A list of local file paths or GCS URIs for input images.")),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save generated image(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated images (e.g., your-bucket/outputs/).")),
@@ -133,7 +133,7 @@ func main() {
 		mcp.WithString("model_name",
 			mcp.DefaultString(defaultGeminiTTSModel),
 			mcp.Description("The model to use."),
-			mcp.Enum("gemini-2.5-flash-tts", "gemini-2.5-pro-tts"),
+			mcp.Enum("gemini-2.5-flash-tts", "gemini-2.5-pro-tts", "gemini-2.5-flash-lite-preview-tts"),
 		),
 		mcp.WithString("language_code",
 			mcp.DefaultString("en-US"),


### PR DESCRIPTION
feat(mcp-gemini): add support for gemini-3-pro-image-preview and lite tts

- Refactored mcp-common/models.go to include configuration for Gemini Image models, including aliases for Nano Banana Pro.
- Updated mcp-gemini-go to resolve image models using the central configuration.
- Added gemini-2.5-flash-lite-preview-tts to the gemini_audio_tts tool.
- Incremented server version to 0.5.1.


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [ ] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
