### PR TITLE
fix(gemini-image): update callers to handle grounding info return value

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -53,7 +53,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class"""
 
-    VERSION: str = "1.3.4" # prompt templates in nano banana
+    VERSION: str = "1.3.5" # fix banana returns
     APP_ENV: str = os.environ.get("APP_ENV", "")
     API_BASE_URL: str = os.environ.get(
         "API_BASE_URL", f"http://localhost:{os.environ.get('PORT', '8080')}"

--- a/models/character_consistency.py
+++ b/models/character_consistency.py
@@ -152,7 +152,7 @@ def generate_character_video(
         )
 
         imagen_candidate_gcs_uris, imagen_candidate_image_bytes_list = imagen_future.result()
-        gemini_candidate_gcs_uris, _, _ = gemini_future.result()
+        gemini_candidate_gcs_uris, _, _, _ = gemini_future.result()
 
     candidate_image_gcs_uris = imagen_candidate_gcs_uris + gemini_candidate_gcs_uris
     candidate_image_bytes_list = imagen_candidate_image_bytes_list  # We don't have bytes from Gemini yet

--- a/models/object_rotation.py
+++ b/models/object_rotation.py
@@ -45,7 +45,7 @@ from models.gemini import generate_image_from_prompt_and_images
 
 async def _generate_single_view(prompt: str, image_uri: str) -> str:
     """Helper to generate one view and return the URI."""
-    gcs_uris, _, _ = await asyncio.to_thread(
+    gcs_uris, _, _, _ = await asyncio.to_thread(
         generate_image_from_prompt_and_images,
         prompt=prompt,
         images=[image_uri],

--- a/models/starter_pack.py
+++ b/models/starter_pack.py
@@ -25,7 +25,7 @@ from models.virtual_model_generator import VirtualModelGenerator, DEFAULT_PROMPT
 def generate_starter_pack_from_look(look_image_uri: str) -> str:
     """Generates a starter pack from a look image."""
     prompt = "Analyze the image to extract the featured products for a mood board. Lay out only the articles / items, and not the person."
-    generated_images, _, _ = gemini.generate_image_from_prompt_and_images(
+    generated_images, _, _, _ = gemini.generate_image_from_prompt_and_images(
         prompt=prompt,
         images=[look_image_uri],
         aspect_ratio="1:1",
@@ -41,7 +41,7 @@ def generate_look_from_starter_pack(
 ) -> str:
     """Generates a look from a starter pack and model image."""
     prompt = "Try this ensemble on the given model."
-    generated_images, _, _ = gemini.generate_image_from_prompt_and_images(
+    generated_images, _, _, _ = gemini.generate_image_from_prompt_and_images(
         prompt=prompt,
         images=[starter_pack_uri, model_image_uri],
         aspect_ratio="1:1",

--- a/workflows/retro_games_backend.py
+++ b/workflows/retro_games_backend.py
@@ -75,7 +75,7 @@ def step_1_generate_8bit(state: RetroGameWorkflowState) -> RetroGameWorkflowStat
     for attempt in range(max_retries):
         logger.info(f"Workflow {state.workflow_id}: Step 1 (8-bit generation) attempt {attempt + 1}/{max_retries}")
         try:
-            gcs_uris, _, _ = generate_image_from_prompt_and_images(
+            gcs_uris, _, _, _ = generate_image_from_prompt_and_images(
                 prompt=full_prompt,
                 images=[state.input_image_uri],
                 aspect_ratio="1:1", # Assuming 1:1 for now, could be made dynamic
@@ -111,7 +111,7 @@ def step_2_generate_character_sheet(state: RetroGameWorkflowState) -> RetroGameW
     prompt = "Create a retro game character sheet for this character. Include front, side, and back views, and a few action poses (idle, walk, jump). Pixel art style matching the input."
     
     try:
-        gcs_uris, _, _ = generate_image_from_prompt_and_images(
+        gcs_uris, _, _, _ = generate_image_from_prompt_and_images(
             prompt=prompt,
             images=[state.eight_bit_image_uri],
             aspect_ratio="1:1", # Character sheets are often square-ish


### PR DESCRIPTION
- Updated `models/starter_pack.py`, `models/object_rotation.py`, `models/character_consistency.py`, and `workflows/retro_games_backend.py` to correctly unpack the 4 return values from `generate_image_from_prompt_and_images` (now including `grounding_info`).
- This resolves "too many values to unpack" runtime errors in the Starter Pack, Object Rotation, Character Consistency, and Retro Games workflows.


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
