### PR TITLE
Refactoring Conditional OpenTelemetry Initialization in mcp-veo-go/veo.go

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -65,19 +65,18 @@ func main() {
 	appConfig = common.LoadConfig()
 
 	// Initialize OpenTelemetry
-	if otel_enabled {
-		tp, err := common.InitTracerProvider(serviceName, version)
-		if err != nil {
-			log.Fatalf("failed to initialize tracer provider: %v", err)
-		}
-		if tp != nil {
-			defer func() {
-				if err := tp.Shutdown(context.Background()); err != nil {
-					log.Printf("Error shutting down tracer provider: %v", err)
-				}
-			}()
-		}
+	tp, err := common.InitTracerProvider(serviceName, version)
+	if err != nil {
+		log.Fatalf("failed to initialize tracer provider: %v", err)
 	}
+	if tp != nil {
+		defer func() {
+			if err := tp.Shutdown(context.Background()); err != nil {
+				log.Printf("Error shutting down tracer provider: %v", err)
+			}
+		}()
+	}
+	
 
 	log.Printf("Initializing global GenAI client...")
 	clientCtx, clientCancel := context.WithTimeout(context.Background(), 1*time.Minute)


### PR DESCRIPTION
# Pull-Request Template

Thank you for your contribution! Please provide a brief description of your changes and ensure you've completed the checklist below.

## Description

What does this PR do? 

This pull request removes the conditional check surrounding the OpenTelemetry (OTel) initialization logic in mcp-veo-go/veo.go.

The variable otel_enabled was previously controllable via a build argument, but since that argument was removed, the variable has been permanently false. This resulted in the opentelemetrytracer initialization being skipped and the OTel instrumentation being disabled (dead code).

As the expected behavior is to have opentelemetrytracer alwasy instantiated, this PR makes the initialization steps run unconditionally. To allow enabling the opentelemetry traces

Why is it necessary?

**Fixes #935** 

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [ ] **Authorship:** I am listed as the author (if applicable).
- [ ] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [ ] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
