### PR TITLE
fix(storyboarder): add missing mime_type to MediaItem

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -53,7 +53,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class"""
 
-    VERSION: str = "1.3.9" # character consistency issues
+    VERSION: str = "1.3.10" # storyboarder fix
     APP_ENV: str = os.environ.get("APP_ENV", "")
     API_BASE_URL: str = os.environ.get(
         "API_BASE_URL", f"http://localhost:{os.environ.get('PORT', '8080')}"

--- a/pages/storyboarder.py
+++ b/pages/storyboarder.py
@@ -226,6 +226,7 @@ def on_generate_video_click(e: me.ClickEvent):
                 user_email=app_state.user_email,
                 timestamp=datetime.datetime.now(datetime.UTC).isoformat(),
                 media_type="video",
+                mime_type="video/mp4",
                 mode="Storyboarder",
                 gcs_uris=[final_uri],
                 thumbnail_uri=final_uri,


### PR DESCRIPTION
The Storyboarder workflow was saving generated videos without a `mime_type` field in the MediaItem metadata. This prevented these videos from appearing in the library chooser, which filters by `mime_type` (e.g., starting with "video/").

This commit explicitly sets `mime_type="video/mp4"` when saving the final concatenated video to Firestore.

Fixes #948

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
