### PR TITLE
fix: Address syntax errors in install-online.sh

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
@@ -36,7 +36,7 @@ else
     RELEASE_DATA=$(wget -qO- "$LATEST_URL")
 fi
 
-TAG=$(echo "$RELEASE_DATA" | grep '"tag_name": "mcp-v' | head -n 1 | cut -d '"'"' -f 4)
+TAG=$(echo "$RELEASE_DATA" | grep '"tag_name": "mcp-v' | head -n 1 | cut -d '"' -f 4)
 
 if [ -z "$TAG" ]; then
     echo_err "Could not find a valid mcp-v* release tag on GitHub."


### PR DESCRIPTION
# Pull-Request Template

Thank you for your contribution! Please provide a brief description of your changes and ensure you've completed the checklist below.

## Description

What does this PR do? 
Currently the install-online.sh script errors out on MacOS with the following error message: `unexpected EOF while looking for matching `"'`

Why is it necessary?

**Fixes #<Issue Number>** (if applicable)

## Checklist

- [ X] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [ X] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [ X] **Authorship:** I am listed as the author (if applicable).
- [ X] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ X] **Code Format:** I have run `nox -s format` to format the code.
- [ X] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [ X] **Sync:** My Fork is synced with the upstream.
- [X ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ X] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ X] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
