### PR TITLE
feat: add support for Lyria 3 preview models via the Interactions API

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-03-25
+
+*   **Feat:** Added support for `lyria-3-clip-preview` (30s) and `lyria-3-pro-preview` (2:30s) music generation models to `mcp-lyria-go`.
+*   **Feat:** Implemented a new, lightweight Go port of the Vertex AI Interactions API to support the Lyria 3 backends.
+*   **Feat:** Set `lyria-3-clip-preview` as the new default model for the `lyria_generate_music` tool.
+*   **Config:** Added the Lyria model registry to `mcp-common/models.go` to provide self-describing model options to the LLM agent via the MCP tool description.
+
 ## 2026-03-24
 
 *   **Feat:** Added a new `mcp-nanobanana-go` server dedicated to Google Gemini Image models.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -299,3 +299,59 @@ func BuildVeoModelDescription() string {
 	}
 	return sb.String()
 }
+
+
+// --- Lyria Model Configuration ---
+
+// LyriaModelInfo holds the details for a specific Lyria model.
+type LyriaModelInfo struct {
+	CanonicalName string
+	Aliases       []string
+	Description   string
+	EndpointType  string // "prediction" or "interactions"
+}
+
+// SupportedLyriaModels is the single source of truth for all supported Lyria models.
+var SupportedLyriaModels = map[string]LyriaModelInfo{
+	"lyria-002": {
+		CanonicalName: "lyria-002",
+		Aliases:       []string{"Lyria 2"},
+		Description:   "The original Lyria 2 model (using standard Vertex AI Prediction API).",
+		EndpointType:  "prediction",
+	},
+	"lyria-3-clip-preview": {
+		CanonicalName: "lyria-3-clip-preview",
+		Aliases:       []string{"Lyria 3 Clip"},
+		Description:   "Lyria 3 Clip model for 30-second audio generation (using Interactions API).",
+		EndpointType:  "interactions",
+	},
+	"lyria-3-pro-preview": {
+		CanonicalName: "lyria-3-pro-preview",
+		Aliases:       []string{"Lyria 3 Pro"},
+		Description:   "Lyria 3 Pro model for 2:30 audio generation (using Interactions API).",
+		EndpointType:  "interactions",
+	},
+}
+
+// BuildLyriaModelDescription returns a markdown-formatted string listing all supported Lyria models
+// and their aliases, suitable for use in an MCP tool description.
+func BuildLyriaModelDescription() string {
+	var sb strings.Builder
+	sb.WriteString("The specific Lyria model ID to use. Supported models:\n")
+
+	keys := make([]string, 0, len(SupportedLyriaModels))
+	for k := range SupportedLyriaModels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		info := SupportedLyriaModels[k]
+		fmt.Fprintf(&sb, "- *%s*", info.CanonicalName)
+		if len(info.Aliases) > 0 {
+			fmt.Fprintf(&sb, " Aliases: *%s*", strings.Join(info.Aliases, "*, *"))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/README.md
@@ -22,7 +22,7 @@ The following tool is exposed by this server:
     *   `file_name` (string, optional): Desired file name (e.g., "my_song.wav"). Used for GCS object and local file. If omitted, a unique name like "lyria_output_&lt;uid&gt;.wav" is generated.
     *   `local_path` (string, optional): Local directory path. If provided, audio is saved locally.
     *   `model_id` (string, optional): Specific Lyria model ID to use for the Vertex AI endpoint.
-        *   Defaults to the value of the `DEFAULT_LYRIA_MODEL_ID` environment variable, or `"lyria-002"` if the variable is not set.
+        *   Defaults to the value of the `DEFAULT_LYRIA_MODEL_ID (Deprecated)` environment variable, or `"lyria-3-clip-preview"` if the variable is not set.
 
 ## Environment Variable Configuration
 
@@ -31,13 +31,13 @@ The tool utilizes the following environment variables:
 *   `PROJECT_ID` (string): **Required**. Your Google Cloud Project ID. The application will terminate if this is not set.
 *   `LOCATION` (string): The primary Google Cloud location for services.
     *   Default: `"us-central1"`
-    *   Also used as the default for `LYRIA_LOCATION` if `LYRIA_LOCATION` is not set.
-*   `LYRIA_LOCATION` (string): The specific Google Cloud location for the Lyria model endpoint.
+    *   Also used as the default for `LYRIA_LOCATION (Deprecated for V3)` if `LYRIA_LOCATION (Deprecated for V3)` is not set.
+*   `LYRIA_LOCATION (Deprecated for V3)` (string): The specific Google Cloud location for the Lyria model endpoint.
     *   Default: Value of `LOCATION` environment variable (e.g., `"us-central1"`).
-*   `LYRIA_MODEL_PUBLISHER` (string): The publisher of the Lyria model in Vertex AI.
+*   `LYRIA_MODEL_PUBLISHER (Deprecated)` (string): The publisher of the Lyria model in Vertex AI.
     *   Default: `"google"`
-*   `DEFAULT_LYRIA_MODEL_ID` (string): The default Lyria model ID to be used if not specified in the request.
-    *   Default: `"lyria-002"` (fallback if the environment variable is not set).
+*   `DEFAULT_LYRIA_MODEL_ID (Deprecated)` (string): The default Lyria model ID to be used if not specified in the request.
+    *   Default: `"lyria-3-clip-preview"` (fallback if the environment variable is not set).
 *   `GENMEDIA_BUCKET` (string): An optional default Google Cloud Storage bucket to use for GCS outputs if `output_gcs_bucket` is not specified in the tool request. The object name will be `lyria_outputs/<generated_filename>.wav` within this bucket.
     *   Default: `""` (empty string, meaning no default GCS output path is formed from this variable unless `output_gcs_bucket` is also absent).
 *   `PORT` (string, for HTTP transport): The port for the HTTP server to listen on.
@@ -84,7 +84,7 @@ Build the tool using `go build` or `go install`.
     "name": "lyria_generate_music",
     "arguments": {
       "prompt": "An upbeat electronic track with a catchy melody, suitable for a retro video game.",
-      "model_id": "lyria-002",
+      "model_id": "lyria-3-clip-preview",
       "sample_count": 1,
       "local_path": "./lyria_output",
       "file_name": "my_retro_tune.wav"

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// generateAudioWithInteractions uses the experimental Interactions API to generate audio
+// for newer Lyria models like lyria-3-pro-preview and lyria-3-clip-preview.
+func generateAudioWithInteractions(ctx context.Context, modelID string, prompt string) ([]byte, error) {
+	log.Printf("Using Interactions API for model: %s", modelID)
+
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default credentials: %w", err)
+	}
+	oauthClient := oauth2.NewClient(ctx, creds.TokenSource)
+
+	endpoint := "aiplatform.googleapis.com"
+	if appConfig.ApiEndpoint != "" {
+		endpoint = appConfig.ApiEndpoint
+	}
+
+	url := fmt.Sprintf("https://%s/v1beta1/projects/%s/locations/%s/interactions",
+		endpoint, appConfig.ProjectID, appConfig.Location)
+
+	payload := map[string]interface{}{
+		"model": modelID,
+		"input": []map[string]string{
+			{
+				"type": "text",
+				"text": prompt,
+			},
+		},
+		"store": false,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-user-project", appConfig.ProjectID)
+
+	resp, err := oauthClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	outputs, ok := raw["outputs"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("no \"outputs\" array found in response")
+	}
+
+	for _, out := range outputs {
+		outMap, ok := out.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if outMap["type"] == "audio" {
+			data, ok := outMap["data"].(string)
+			if !ok {
+				continue
+			}
+			// Decode the base64 string directly
+			decodedBytes, err := base64.StdEncoding.DecodeString(data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode base64 audio data: %w", err)
+			}
+			return decodedBytes, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no audio output found in response")
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -58,7 +58,7 @@ const (
 	serviceName         = "mcp-lyria-go"
 	version     = "3.0.0" // Standardize port handling
 	defaultPublisher    = "google"
-	defaultLyriaModelID = "lyria-002"
+	defaultLyriaModelID = "lyria-3-clip-preview"
 	defaultSampleCount  = 1
 	audioMIMEType       = "audio/wav" // Define MIME type for audio
 )

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -133,7 +133,8 @@ func main() {
 			mcp.Description("Optional. Local directory path. If provided, audio is saved locally and direct audio data is NOT returned (unless GCS is also not specified)."),
 		),
 		mcp.WithString("model_id",
-			mcp.Description(fmt.Sprintf("Optional. Specific Lyria model ID to use for the Vertex AI endpoint. Defaults to '%s'.", defaultLyriaModelID)),
+			mcp.DefaultString(defaultLyriaModelID),
+			mcp.Description(common.BuildLyriaModelDescription()),
 		),
 	}
 

--- a/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia/commands/producer/soundtrack.toml
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia/commands/producer/soundtrack.toml
@@ -1,0 +1,4 @@
+prompt = """
+Please act as an expert GenMedia Producer and generate a full 2-minute-and-30-second soundtrack for: `{{args}}`.
+Use the `lyria_generate_music` tool and explicitly set the `model_id` to `lyria-3-pro-preview`.
+"""

--- a/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia/skills/producer/SKILL.md
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia/skills/producer/SKILL.md
@@ -9,7 +9,7 @@ You are a highly capable media production assistant. Use this skill when asked t
 3. **Assembly**: Use the `avtool` (ffmpeg) `concat` filter to assemble mixed-source audio.
    - Example: `ffmpeg -y -i file1.wav -i file2.wav -filter_complex "[0:0][1:0]concat=n=2:v=0:a=1[out]" -map "[out]" final_audio.wav`
    - NEVER use `-c copy` or concat demuxer for mixed sources.
-4. **Bumpers**: Create 5-second intro/outro music using `lyria_generate_music`, trim it, and apply a 1-second `afade`.
+4. **Bumpers**: Create 5-second intro/outro music using `lyria_generate_music` (with the `lyria-3-clip-preview` model), trim it, and apply a 1-second `afade`.
 
 ## Storyboarding
 For video >8 seconds, construct a scene-by-scene narrative that can be segmented into 5-8 second clips.


### PR DESCRIPTION

### **Description**

This PR brings the `mcp-lyria-go` server up to date with the latest music generation models!

**New Features**
* **feat**: Added full support for the  Lyria 3`lyria-3-clip-preview` (30s) and Lyria 3 Pro `lyria-3-pro-preview` (2:30s) models.
* **feat**: Implemented a lightweight, native Go port of the new Vertex AI Interactions API to support the Lyria 3 backends. The server dynamically routes requests at runtime - using the Prediction API for `lyria-002` and the new Interactions API for `lyria-3-*`.
* **feat**: Updated the default tool model to use the fast `lyria-3-clip-preview` model.

**Under the Hood**
* **config**: Added the Lyria model registry to `mcp-common/models.go` to provide self-describing model options to the LLM agent via the MCP tool definition.
* **auth**: The Interactions client seamlessly leverages the user's Application Default Credentials (ADC) and automatically injects the `x-goog-user-project` header to satisfy the production router's quota tracking.


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [x] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [ ] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
