### PR TITLE
fix: force global location for lyria-3 interactions api calls

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions.go
@@ -30,8 +30,10 @@ func generateAudioWithInteractions(ctx context.Context, modelID string, prompt s
 		endpoint = appConfig.ApiEndpoint
 	}
 
-	url := fmt.Sprintf("https://%s/v1beta1/projects/%s/locations/%s/interactions",
-		endpoint, appConfig.ProjectID, appConfig.Location)
+	// Lyria 3 preview models via the Interactions API currently only support the global location ("Cardolan").
+	// We hardcode "global" here instead of using appConfig.Location (which defaults to "us-central1").
+	url := fmt.Sprintf("https://%s/v1beta1/projects/%s/locations/global/interactions",
+		endpoint, appConfig.ProjectID)
 
 	payload := map[string]interface{}{
 		"model": modelID,


### PR DESCRIPTION
fix: force global location for lyria-3 interactions api calls

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
