### PR TITLE
fix: resolve bash syntax error caused by fragile quote escaping in install-online.sh

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
@@ -36,7 +36,7 @@ else
     RELEASE_DATA=$(wget -qO- "$LATEST_URL")
 fi
 
-TAG=$(echo "$RELEASE_DATA" | grep '"tag_name": "mcp-v' | head -n 1 | cut -d '"'"' -f 4)
+TAG=$(echo "$RELEASE_DATA" | grep '"tag_name": "mcp-v' | head -n 1 | awk -F'"' '{print $4}')
 
 if [ -z "$TAG" ]; then
     echo_err "Could not find a valid mcp-v* release tag on GitHub."


### PR DESCRIPTION
fix: resolve bash syntax error caused by fragile quote escaping in install-online.sh



**Fixes #1119 **

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
