### PR TITLE
fix: correct capitalization and tag prefixes in install-online.sh download URLs

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
@@ -45,8 +45,10 @@ if [ -z "$TAG" ]; then
 fi
 echo_info "Found version: ${TAG}"
 
-TARBALL="${ARCHIVE_PREFIX}_${OS_TITLE}_${ARCH_MAP}.tar.gz"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${TARBALL}"
+TARBALL="${ARCHIVE_PREFIX}_${OS}_${ARCH_MAP}.tar.gz"
+# GoReleaser uses the stripped semantic version for the actual release assets if we stripped it in CI
+CLEAN_TAG=${TAG#mcp-}
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${CLEAN_TAG#v}/${TARBALL}"
 
 echo_info "Downloading ${TARBALL}..."
 TMP_DIR=$(mktemp -d)


### PR DESCRIPTION
fix: correct capitalization and tag prefixes in install-online.sh download URLs



**Fixes ##1119**

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
