### PR TITLE
fix: correct architecture string in install-online.sh to match goreleaser output

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
@@ -25,7 +25,6 @@ case "$ARCH" in
 esac
 
 OS_TITLE="$(tr '[:lower:]' '[:upper:]' <<< ${OS:0:1})${OS:1}"
-if [ "$ARCH" = "amd64" ]; then ARCH_MAP="x86_64"; else ARCH_MAP="$ARCH"; fi
 
 LATEST_URL="https://api.github.com/repos/${REPO}/releases"
 echo_info "Checking GitHub for the latest MCP release..."
@@ -45,7 +44,7 @@ if [ -z "$TAG" ]; then
 fi
 echo_info "Found version: ${TAG}"
 
-TARBALL="${ARCHIVE_PREFIX}_${OS}_${ARCH_MAP}.tar.gz"
+TARBALL="${ARCHIVE_PREFIX}_${OS}_${ARCH}.tar.gz"
 # GoReleaser uses the stripped semantic version for the actual release assets if we stripped it in CI
 CLEAN_TAG=${TAG#mcp-}
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${CLEAN_TAG#v}/${TARBALL}"


### PR DESCRIPTION
fix: correct architecture string in install-online.sh to match goreleaser output


**Fixes #1122 **


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
