### PR TITLE
refactor: use native GenAI SDK ImageConfig for aspect ratio instead of prompt injection in NanoBanana

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
@@ -44,8 +44,9 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 		return mcp.NewToolResultError("prompt must be a non-empty string and is required"), nil
 	}
 
-	if aspectRatio, ok := request.GetArguments()["aspect_ratio"].(string); ok && strings.TrimSpace(aspectRatio) != "" {
-		prompt += fmt.Sprintf(" Aspect ratio: %s.", aspectRatio)
+	aspectRatio := "1:1"
+	if ar, ok := request.GetArguments()["aspect_ratio"].(string); ok && strings.TrimSpace(ar) != "" {
+		aspectRatio = strings.TrimSpace(ar)
 	}
 
 	modelArg, _ := request.GetArguments()["model"].(string)
@@ -93,8 +94,12 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 	log.Printf("Calling GenerateContent with Model: %s, Prompt: \"%s\"", model, prompt)
 	startTime := time.Now()
 
-	config := &genai.GenerateContentConfig{}
-	config.ResponseModalities = []string{"IMAGE", "TEXT"}
+	config := &genai.GenerateContentConfig{
+		ResponseModalities: []string{"IMAGE", "TEXT"},
+		ImageConfig: &genai.ImageConfig{
+			AspectRatio: aspectRatio,
+		},
+	}
 	contents := &genai.Content{Parts: parts, Role: "USER"}
 
 	resp, err := client.Models.GenerateContent(ctx, model, []*genai.Content{contents}, config)

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -44,8 +44,9 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		return mcp.NewToolResultError("prompt must be a non-empty string and is required"), nil
 	}
 
-	if aspectRatio, ok := request.GetArguments()["aspect_ratio"].(string); ok && strings.TrimSpace(aspectRatio) != "" {
-		prompt += fmt.Sprintf(" Aspect ratio: %s.", aspectRatio)
+	aspectRatio := "1:1"
+	if ar, ok := request.GetArguments()["aspect_ratio"].(string); ok && strings.TrimSpace(ar) != "" {
+		aspectRatio = strings.TrimSpace(ar)
 	}
 
 	modelArg, _ := request.GetArguments()["model"].(string)
@@ -93,8 +94,12 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 	log.Printf("Calling GenerateContent with Model: %s, Prompt: \"%s\"", model, prompt)
 	startTime := time.Now()
 
-	config := &genai.GenerateContentConfig{}
-	config.ResponseModalities = []string{"IMAGE", "TEXT"}
+	config := &genai.GenerateContentConfig{
+		ResponseModalities: []string{"IMAGE", "TEXT"},
+		ImageConfig: &genai.ImageConfig{
+			AspectRatio: aspectRatio,
+		},
+	}
 	contents := &genai.Content{Parts: parts, Role: "USER"}
 
 	resp, err := client.Models.GenerateContent(ctx, model, []*genai.Content{contents}, config)


### PR DESCRIPTION
refactor: use native GenAI SDK ImageConfig for aspect ratio instead of prompt injection in NanoBanana

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [ ] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
