### PR TITLE
fix(config): add default=str to json.dumps to handle DatetimeWithNanoseconds serialization

### DIFF
--- a/pages/config.py
+++ b/pages/config.py
@@ -114,7 +114,7 @@ def on_load(e: me.LoadEvent):
         [t.model_dump() for t in all_templates],
         key=lambda x: (x["category"], x["label"]),
     )
-    state.templates_json = json.dumps(templates)
+    state.templates_json = json.dumps(templates, default=str)
     state.is_loading = False
     yield
 
@@ -146,7 +146,7 @@ def on_update_template(template_id: str, updates: dict):
             [t.model_dump() for t in all_templates],
             key=lambda x: (x["category"], x["label"]),
         )
-        state.templates_json = json.dumps(templates)
+        state.templates_json = json.dumps(templates, default=str)
         # Close the dialog
         state.show_template_dialog = False
         state.selected_template_key = None


### PR DESCRIPTION
fix(config): add default=str to json.dumps to handle DatetimeWithNanoseconds serialization

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [x] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
