### PR TITLE
chore(ci): update go-version to 1.26 in release workflow

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Strip Tag Prefix
         id: strip-tag


### PR DESCRIPTION
The goreleaser job in the release workflow was failing because it was using Go 1.24 while the project's go.work and go.mod files require Go 1.26.0. This PR updates the workflow to use the correct Go version.