### PR TITLE
 docs(skills): teach agents to use new Veo capabilities and 3.1 Lite model

### DIFF
--- a/experiments/mcp-genmedia/skills/genmedia-producer/SKILL.md
+++ b/experiments/mcp-genmedia/skills/genmedia-producer/SKILL.md
@@ -23,7 +23,7 @@ For video >8 seconds, construct a scene-by-scene narrative that can be segmented
 ## Veo Video Generation (Veo 3.1)
 - Use the **Five-Part Formula** for prompts: Cinematography, Subject, Action, Context, and Style.
 - **Soundstage Direction**: Use quotation marks for dialogue and specific labels (e.g., `[loud thunder]`) for sound effects.
-- **Advanced Modalities**: Use `veo_first_last_to_video` for transitions and `veo_ingredients_to_video` for character/style consistency across scenes.
+- **Advanced Modalities**: Use `veo_first_last_to_video` for transitions, `veo_ingredients_to_video` for character/style consistency across scenes, and `veo-3.1-lite-generate-001` for faster, 720p/1080p generation.
 - If a request times out, retry once. If it fails again, reduce the `duration` parameter and inform the user.
 - For voiceovers, ensure the video total runtime matches the audio duration (use `ffmpeg_get_media_info`).
 - The `bucket` parameter must be a full GCS URI (`gs://...`).

--- a/experiments/mcp-genmedia/skills/genmedia-video-editor/SKILL.md
+++ b/experiments/mcp-genmedia/skills/genmedia-video-editor/SKILL.md
@@ -20,6 +20,7 @@ When generating video, use the [Veo 3.1 Prompting Guide](https://cloud.google.co
 - **Advanced Modalities**:
     - Use `veo_first_last_to_video` for precise control over transitions between two key frames.
     - Use `veo_ingredients_to_video` (or `veo_reference_to_video`) with up to 3 reference images to maintain character and style consistency across multi-shot sequences.
+    - Use the `veo-3.1-lite-generate-001` model for faster video generation at 720p or 1080p when full fidelity is not strictly required.
 
 ### Image-on-Video Overlay
 When placing logos, watermarks, or static elements on a video:


### PR DESCRIPTION


  This PR updates the GenMedia Agent Skills to reflect recent backend additions to the Veo MCP server (mcp-veo-go), empowering AI agents to take full advantage of new video modalities and the high-speed Lite model.

  Changes:
   - genmedia-video-editor: Added guidance for agents to leverage the veo-3.1-lite-generate-001 model for faster rendering when full cinematic fidelity is not strictly required.
   - genmedia-producer: Updated the Veo Generation strategy to include the veo-3.1-lite-generate-001 model alongside the new veo_first_last_to_video and veo_ingredients_to_video tools, ensuring the high-level orchestration agent understands when to apply these capabilities.

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [x] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
