### PR TITLE
Feat/gemini tts timeouts

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-04-08 (v3.5.1)
+
+*   **Fix:** Corrected the `SupportedAspectRatios` for `veo-3.1-lite-generate-001` in `mcp-veo-go` to use standard `"16:9"` and `"9:16"` instead of `"720p"` and `"1080p"` (which were rejected by the API).
+*   **Fix:** Removed hardcoded defaults for `duration` and `aspect_ratio` in `mcp-veo-go` tool schemas, allowing model-specific fallbacks (like the strict 4/6/8 second constraints of Veo 3.1 Lite) to function correctly.
+*   **Fix:** Added an explicit 120-second timeout context for the `gemini_audio_tts` API call in `mcp-gemini-go` to prevent long-running generative prompts from hanging indefinitely.
+*   **Docs:** Updated Gemini CLI integration documentation to explicitly call out the necessity of increasing the global `toolExecutionTimeout` for long-running media generation tools (like Veo and TTS).
+*   **Chore:** Incremented versions for all `mcp-*` servers to `3.5.1` to synchronize the release.
+
 ## 2026-04-02 (v3.5.0)
 
 *   **Feat:** Add support for the `veo-3.1-lite-generate-001` model.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	serviceName = "mcp-avtool-go"
-	version     = "3.5.0" // Synchronize release version
+	version     = "3.5.1" // Synchronize release version
 )
 
 var (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
@@ -34,7 +34,7 @@ var (
 	availableVoices []*texttospeechpb.Voice
 	transport       string
 	port            int
-	version         = "3.5.0" // Synchronize release version
+	version         = "3.5.1" // Synchronize release version
 )
 
 const (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -343,7 +343,7 @@ var SupportedVeoModels = map[string]VeoModelInfo{
 		DefaultDuration:        8,
 		SupportedDurations:     []int32{4, 6, 8},
 		MaxVideos:              4,
-		SupportedAspectRatios:  []string{"720p", "1080p"},
+		SupportedAspectRatios:  []string{"16:9", "9:16"},
 		SupportsGenerateAudio:  true,
 		SupportsFirstLast:      true,
 		SupportsReferenceImage: false,

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-gemini-go"
-	version     = "3.5.0" // Synchronize release version
+	version     = "3.5.1" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
@@ -261,7 +261,7 @@ func geminiAudioTTSHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 	}
 
 	// --- 2. Call the TTS API ---
-	audioBytes, err := callGeminiTTSAPIWithSDK(ctx, text, prompt, voiceName, modelName, audioEncoding, languageCode)
+	audioBytes, err := callGeminiTTSAPI(ctx, text, prompt, voiceName, modelName, audioEncoding, languageCode)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("error calling Gemini TTS API: %v", err)), nil
 	}
@@ -313,7 +313,10 @@ func geminiAudioTTSHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 
 // --- API Helper Function ---
 
-func callGeminiTTSAPIWithSDK(ctx context.Context, text, prompt, voiceName, modelName, audioEncoding, languageCode string) ([]byte, error) {
+func callGeminiTTSAPI(ctx context.Context, text, stylePrompt, voiceName, modelName, audioEncoding, languageCode string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
 	client, err := texttospeech.NewClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create texttospeech client: %w", err)
@@ -334,8 +337,8 @@ func callGeminiTTSAPIWithSDK(ctx context.Context, text, prompt, voiceName, model
 		},
 	}
 
-	if prompt != "" {
-		req.Input.Prompt = &prompt
+	if stylePrompt != "" {
+		req.Input.Prompt = &stylePrompt
 	}
 
 	resp, err := client.SynthesizeSpeech(ctx, req)

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -49,7 +49,7 @@ var (
 
 const (
 	serviceName = "mcp-imagen-go"
-	version     = "3.5.0" // Synchronize release version
+	version     = "3.5.1" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -56,7 +56,7 @@ var (
 
 const (
 	serviceName         = "mcp-lyria-go"
-	version     = "3.5.0" // Synchronize release version
+	version     = "3.5.1" // Synchronize release version
 	defaultPublisher    = "google"
 	defaultLyriaModelID = "lyria-3-clip-preview"
 	defaultSampleCount  = 1

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-nanobanana-go"
-	version     = "3.5.0" // Synchronize release version
+	version     = "3.5.1" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -42,7 +42,7 @@ var (
 
 const (
 	serviceName = "mcp-veo-go"
-	version     = "3.5.0" // Synchronize release version
+	version     = "3.5.1" // Synchronize release version
 )
 
 // init handles command-line flags and initial logging setup.
@@ -110,11 +110,9 @@ func main() {
 			mcp.Description("Number of videos to generate. Note: the maximum is model-dependent."),
 		),
 		mcp.WithString("aspect_ratio",
-			mcp.DefaultString("16:9"),
 			mcp.Description("Aspect ratio of the generated videos. Note: supported aspect ratios are model-dependent."),
 		),
 		mcp.WithNumber("duration",
-			mcp.DefaultNumber(5),
 			mcp.Description("Duration of the generated video in seconds. Note: the supported duration range is model-dependent."),
 		),
 		mcp.WithBoolean("generate_audio",

--- a/experiments/mcp-genmedia/sample-agents/geminicli/README.md
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/README.md
@@ -14,6 +14,23 @@ To configure these servers for gemini cli, you can either add these to your ~/.g
 
 > **Existing Users:** If you have previously installed the GenMedia extension using the older JSON format, please see the [Migration Guide](MIGRATION.md) for quick instructions on upgrading to the new interactive setup.
 
+## .gemini/settings.json: Global Tool Timeout
+
+If you intend to use long-running tools like **Veo** (which takes minutes to generate video) or complex **Gemini TTS** prompts, you **MUST** increase the global tool execution timeout in your `~/.gemini/settings.json` file. 
+
+The `MCP_REQUEST_MAX_TOTAL_TIMEOUT` environment variable controls the wait time for a specific server, but the Gemini CLI itself has a hard global timeout that will kill the connection if not adjusted.
+
+Add the `toolExecutionTimeout` (in milliseconds) to the `experimental` or `general` block:
+
+```json
+{
+  "experimental": {
+    "enableAgents": true,
+    "toolExecutionTimeout": 240000 
+  }
+}
+```
+
 ## .gemini/settings.json: mcpServers
 
 Add the following to your .gemini/settings.json `mcpServers` - you can do this at your ~/.gemini or per project directory.

--- a/experiments/mcp-genmedia/sample-agents/geminicli/sample_settings.json
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/sample_settings.json
@@ -48,5 +48,9 @@
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
     }
+  },
+  "experimental": {
+    "enableAgents": true,
+    "toolExecutionTimeout": 240000
   }
 }


### PR DESCRIPTION
 v3.5.1


  This release addresses critical timeouts for long-running generative tasks and fixes strict validation constraints for the Veo 3.1 Lite model.


  Bug Fixes
   * Veo 3.1 Lite Validation: Corrected the SupportedAspectRatios for the veo-3.1-lite-generate-001 model to use standard "16:9" and "9:16" strings. The previous configuration incorrectly passed "720p" and "1080p", which were rejected by the Vertex AI backend.
   * Veo Tool Defaults: Removed hardcoded global defaults for duration and aspect_ratio in the mcp-veo-go tool schemas. This ensures the tools properly fallback to the model-specific constraints defined in the registry (such as the strict 4, 6, or 8-second requirements for Veo 3.1 Lite).
   * Gemini TTS Timeouts: Added an explicit 120-second timeout context for the gemini_audio_tts API call in mcp-gemini-go to preventcomplex or long-running generative voice prompts from hanging indefinitely.


  Documentation
   * Gemini CLI Integration: Updated the Gemini CLI integration documentation (sample-agents/geminicli/README.md) to explicitly call out the necessity of increasing the global toolExecutionTimeout in settings.json when using long-running media generation tools like Veo and TTS.
   * 
## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
