### PR TITLE
feat(avtool): mix audio streams and add volume control (#1270)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-14 (v3.6.0)
+
+*   **Feat:** Updated `ffmpeg_combine_audio_and_video` in `mcp-avtool-go` to check if the input video already contains an audio stream. If it does, the tool now uses the `amix` filter to mix the tracks properly instead of appending a secondary audio track.
+*   **Feat:** Added optional `input_video_volume_db_change` and `input_audio_volume_db_change` parameters to `ffmpeg_combine_audio_and_video` to allow for independent volume control during mixing.
+
 ## 2026-04-08 (v3.5.2)
 
 *   **Fix:** Corrected the `SupportedAspectRatios` for `veo-3.1-lite-generate-001` in `mcp-veo-go` to use standard `"16:9"` and `"9:16"` instead of `"720p"` and `"1080p"` (which were rejected by the API).

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
@@ -27,8 +27,8 @@ The `avtool` provides the following functionalities, exposed as MCP tools:
     *   Output: GIF image file. Can be saved locally and/or to a GCS bucket.
 
 *   **`ffmpeg_combine_audio_and_video`**:
-    *   Combines a separate video file and an audio file into a single video file with the new audio track.
-    *   Inputs: URI of the input video file, URI of the input audio file.
+    *   Combines a separate video file and an audio file into a single video file. If the video already has an audio track, it mixes the new audio with the existing audio.
+    *   Inputs: URI of the input video file, URI of the input audio file, optional `input_video_volume_db_change`, optional `input_audio_volume_db_change`.
     *   Output: Combined video file (e.g., MP4). Can be saved locally and/or to a GCS bucket.
 
 *   **`ffmpeg_overlay_image_on_video`**:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	serviceName = "mcp-avtool-go"
-	version     = "3.5.2" // Synchronize release version
+	version     = "3.6.0" // Feature: Added volume control and amix for video+audio
 )
 
 var (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
@@ -351,6 +351,8 @@ func addCombineAudioVideoTool(s *server.MCPServer, cfg *common.Config) {
 		mcp.WithDescription("Combines separate audio and video files into a single video file."),
 		mcp.WithString("input_video_uri", mcp.Required(), mcp.Description("URI of the input video file (local path or gs://).")),
 		mcp.WithString("input_audio_uri", mcp.Required(), mcp.Description("URI of the input audio file (local path or gs://).")),
+		mcp.WithNumber("input_video_volume_db_change", mcp.Description("Optional. Volume change in dB for the input video's audio track (e.g., -10).")),
+		mcp.WithNumber("input_audio_volume_db_change", mcp.Description("Optional. Volume change in dB for the input audio track (e.g., +5).")),
 		mcp.WithString("output_file_name", mcp.Description("Optional. Desired name for the output video file (e.g., 'combined.mp4').")),
 		mcp.WithString("output_local_dir", mcp.Description("Optional. Local directory to save the output video file.")),
 		mcp.WithString("output_gcs_bucket", mcp.Description("Optional. GCS bucket to upload the output video file to.")),
@@ -382,6 +384,9 @@ func ffmpegCombineAudioVideoHandler(ctx context.Context, request mcp.CallToolReq
 	outputLocalDir, _ := argsMap["output_local_dir"].(string)
 	outputGCSBucket, _ := argsMap["output_gcs_bucket"].(string)
 	outputGCSBucket = strings.TrimSpace(outputGCSBucket)
+
+	inputVideoVolume, hasVideoVol := argsMap["input_video_volume_db_change"].(float64)
+	inputAudioVolume, hasAudioVol := argsMap["input_audio_volume_db_change"].(float64)
 
 	if outputGCSBucket == "" && cfg.GenmediaBucket != "" {
 		outputGCSBucket = cfg.GenmediaBucket
@@ -423,7 +428,56 @@ func ffmpegCombineAudioVideoHandler(ctx context.Context, request mcp.CallToolReq
 	}
 	defer outputCleanup()
 
-	_, ffmpegErr := runFFmpegCommand(ctx, "-y", "-i", localInputVideo, "-i", localInputAudio, "-map", "0", "-map", "1:a", "-c:v", "copy", "-shortest", tempOutputFile)
+	// Check if video has audio
+	mediaInfoJSON, err := executeGetMediaInfo(ctx, localInputVideo)
+	hasAudio := false
+	if err == nil {
+		var info struct {
+			Streams []struct {
+				CodecType string `json:"codec_type"`
+			} `json:"streams"`
+		}
+		if json.Unmarshal([]byte(mediaInfoJSON), &info) == nil {
+			for _, s := range info.Streams {
+				if s.CodecType == "audio" {
+					hasAudio = true
+					break
+				}
+			}
+		}
+	}
+
+	var ffmpegErr error
+	if hasAudio {
+		// Mix audio tracks using amix filter
+		var filterParts []string
+		
+		if hasVideoVol {
+			filterParts = append(filterParts, fmt.Sprintf("[0:a]volume=%.2fdB[v_a]", inputVideoVolume))
+		} else {
+			filterParts = append(filterParts, "[0:a]anull[v_a]")
+		}
+		
+		if hasAudioVol {
+			filterParts = append(filterParts, fmt.Sprintf("[1:a]volume=%.2fdB[a_a]", inputAudioVolume))
+		} else {
+			filterParts = append(filterParts, "[1:a]anull[a_a]")
+		}
+		
+		filterParts = append(filterParts, "[v_a][a_a]amix=inputs=2:duration=longest[a]")
+		filterComplex := strings.Join(filterParts, "; ")
+
+		_, ffmpegErr = runFFmpegCommand(ctx, "-y", "-i", localInputVideo, "-i", localInputAudio, "-filter_complex", filterComplex, "-map", "0:v", "-map", "[a]", "-c:v", "copy", "-c:a", "aac", tempOutputFile)
+	} else {
+		// Just add the audio track directly if video has no audio
+		if hasAudioVol {
+			filterComplex := fmt.Sprintf("[1:a]volume=%.2fdB[a]", inputAudioVolume)
+			_, ffmpegErr = runFFmpegCommand(ctx, "-y", "-i", localInputVideo, "-i", localInputAudio, "-filter_complex", filterComplex, "-map", "0:v", "-map", "[a]", "-c:v", "copy", "-c:a", "aac", tempOutputFile)
+		} else {
+			_, ffmpegErr = runFFmpegCommand(ctx, "-y", "-i", localInputVideo, "-i", localInputAudio, "-map", "0:v", "-map", "1:a", "-c:v", "copy", "-c:a", "aac", tempOutputFile)
+		}
+	}
+
 	if ffmpegErr != nil {
 		span.RecordError(ffmpegErr)
 		return mcp.NewToolResultError(fmt.Sprintf("FFMpeg combine audio/video failed: %v", ffmpegErr)), nil

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
@@ -34,7 +34,7 @@ var (
 	availableVoices []*texttospeechpb.Voice
 	transport       string
 	port            int
-	version         = "3.5.2" // Synchronize release version
+	version         = "3.6.0" // Synchronize release version
 )
 
 const (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-gemini-go"
-	version     = "3.5.2" // Synchronize release version
+	version     = "3.6.0" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -49,7 +49,7 @@ var (
 
 const (
 	serviceName = "mcp-imagen-go"
-	version     = "3.5.2" // Synchronize release version
+	version     = "3.6.0" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -56,7 +56,7 @@ var (
 
 const (
 	serviceName         = "mcp-lyria-go"
-	version     = "3.5.2" // Synchronize release version
+	version     = "3.6.0" // Synchronize release version
 	defaultPublisher    = "google"
 	defaultLyriaModelID = "lyria-3-clip-preview"
 	defaultSampleCount  = 1

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-nanobanana-go"
-	version     = "3.5.2" // Synchronize release version
+	version     = "3.6.0" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -42,7 +42,7 @@ var (
 
 const (
 	serviceName = "mcp-veo-go"
-	version     = "3.5.2" // Synchronize release version
+	version     = "3.6.0" // Synchronize release version
 )
 
 // init handles command-line flags and initial logging setup.

--- a/experiments/mcp-genmedia/skills/genmedia-video-editor/SKILL.md
+++ b/experiments/mcp-genmedia/skills/genmedia-video-editor/SKILL.md
@@ -41,9 +41,8 @@ When merging multiple clips:
 ### Audio-Video Sync
 When adding a soundtrack or voiceover:
 1. Check the audio duration using `ffmpeg_get_media_info`.
-2. Ensure the video matches this duration. 
-3. Use `ffmpeg_combine_audio_and_video`.
-
+2. Ensure the video matches this duration.
+3. Use `ffmpeg_combine_audio_and_video`. Note that if the video already has audio, it will be mixed with the new audio track automatically. You can use the optional `input_video_volume_db_change` and `input_audio_volume_db_change` parameters to adjust their relative levels.
 ## Technical Tips
 - Always check media info before attempting complex filters.
 - Prefer `.mp4` (H.264) for output compatibility unless otherwise specified.


### PR DESCRIPTION

* Update `ffmpeg_combine_audio_and_video` in `avtool` to use the `amix` filter if the input video already contains audio, layering the tracks instead of appending them as separate streams.
* Add optional `input_video_volume_db_change` and `input_audio_volume_db_change` parameters to `ffmpeg_combine_audio_and_video` for independent volume adjustments.
* Bump version of all MCP servers to 3.6.0.
* Update related tool descriptions, `README.md`, and `genmedia-video-editor` skill documentation.


**Fixes #1270**

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
