### PR TITLE
Fix/veo extend validation

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-14 (v3.7.1)
+
+*   **Fix:** Corrected parameter parsing in `mcp-veo-go`'s `veo_extend_video` tool to correctly bypass standard duration validation and supply the required 7-second duration to the Vertex AI API.
+*   **Chore:** Bumped minor versions for all MCP servers to synchronize the release.
+
 ## 2026-04-14 (v3.7.0)
 
 *   **Feat:** Upgraded `google.golang.org/genai` SDK to `v1.54.0` across all MCP servers.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/GEMINI.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/GEMINI.md
@@ -47,6 +47,20 @@ When you need to add a new model or change the parameters of an existing one, fo
 
 This pattern ensures that our tools are robust, self-describing, and easy to maintain.
 
+### Veo API Usage (GenerateVideos vs GenerateVideosFromSource)
+
+When working with Veo in the `google.golang.org/genai` SDK, **always** use the `GenerateVideosFromSource` method instead of `GenerateVideos`. The older `GenerateVideos` method is kept for backward compatibility and does not support newer features like video extension.
+
+**Correct Pattern:**
+```go
+source := &genai.GenerateVideosSource{
+    Prompt: "your prompt", // Optional
+    Image:  inputImage,   // Optional
+    Video:  inputVideo,   // Optional (for extension)
+}
+operation, err := client.Models.GenerateVideosFromSource(ctx, modelName, source, config)
+```
+
 ### Enabling Server Capabilities
 
 The MCP Server is modular. Features like `tools`, `prompts`, and `resources` must be explicitly enabled during server initialization. If you encounter errors like 'resources not supported', ensure you are passing the correct `server.With...Capabilities()` option to the `server.NewMCPServer()` constructor in the `main.go` file for the relevant server.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	serviceName = "mcp-avtool-go"
-	version     = "3.7.0" // Feature: Veo Video Extend
+	version     = "3.7.1" // Fix: Veo Video Extend validation
 )
 
 var (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
@@ -34,7 +34,7 @@ var (
 	availableVoices []*texttospeechpb.Voice
 	transport       string
 	port            int
-	version         = "3.7.0" // Synchronize release version
+	version         = "3.7.1" // Synchronize release version
 )
 
 const (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-gemini-go"
-	version     = "3.7.0" // Synchronize release version
+	version     = "3.7.1" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -49,7 +49,7 @@ var (
 
 const (
 	serviceName = "mcp-imagen-go"
-	version     = "3.7.0" // Synchronize release version
+	version     = "3.7.1" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -56,7 +56,7 @@ var (
 
 const (
 	serviceName         = "mcp-lyria-go"
-	version     = "3.7.0" // Synchronize release version
+	version     = "3.7.1" // Synchronize release version
 	defaultPublisher    = "google"
 	defaultLyriaModelID = "lyria-3-clip-preview"
 	defaultSampleCount  = 1

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-nanobanana-go"
-	version     = "3.7.0" // Synchronize release version
+	version     = "3.7.1" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
@@ -40,7 +40,7 @@ func veoTextToVideoHandler(client *genai.Client, ctx context.Context, request mc
 		return mcp.NewToolResultError("prompt must be a non-empty string and is required for text-to-video"), nil
 	}
 
-	gcsBucket, outputDir, model, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig)
+	gcsBucket, outputDir, model, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig, false)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -125,7 +125,7 @@ func veoImageToVideoHandler(client *genai.Client, ctx context.Context, request m
 		prompt = strings.TrimSpace(promptArg)
 	}
 
-	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig)
+	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig, false)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers_extended.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers_extended.go
@@ -49,7 +49,7 @@ func veoFirstLastToVideoHandler(client *genai.Client, ctx context.Context, reque
 		prompt = strings.TrimSpace(promptArg)
 	}
 
-	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig)
+	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig, false)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -202,7 +202,7 @@ func veoReferenceToVideoHandler(client *genai.Client, ctx context.Context, reque
 		})
 	}
 
-	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig)
+	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig, false)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -277,7 +277,7 @@ func veoExtendVideoHandler(client *genai.Client, ctx context.Context, request mc
 		prompt = strings.TrimSpace(promptArg)
 	}
 
-	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig)
+	gcsBucket, outputDir, modelName, finalAspectRatio, numberOfVideos, durationSecs, generateAudio, personGeneration, err := parseCommonVideoParams(request.GetArguments(), appConfig, true)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/utils.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/utils.go
@@ -39,7 +39,7 @@ func inferMimeTypeFromURI(uri string) string {
 }
 
 // parseCommonVideoParams extracts and validates video generation parameters from the request arguments.
-func parseCommonVideoParams(args map[string]interface{}, appConfig *common.Config) (string, string, string, string, int32, int32, bool, string, error) {
+func parseCommonVideoParams(args map[string]interface{}, appConfig *common.Config, isExtend bool) (string, string, string, string, int32, int32, bool, string, error) {
 	// Model
 	modelInput, ok := args["model"].(string)
 	if !ok || modelInput == "" {
@@ -78,24 +78,29 @@ func parseCommonVideoParams(args map[string]interface{}, appConfig *common.Confi
 	}
 
 	// Duration
-	durationSecs := modelDetails.DefaultDuration
-	if durationArg, ok := args["duration"].(float64); ok {
-		durationSecs = int32(durationArg)
-	}
-	validDuration := false
-	for _, d := range modelDetails.SupportedDurations {
-		if d == durationSecs {
-			validDuration = true
-			break
+	var durationSecs int32
+	if isExtend {
+		durationSecs = 7
+	} else {
+		durationSecs = modelDetails.DefaultDuration
+		if durationArg, ok := args["duration"].(float64); ok {
+			durationSecs = int32(durationArg)
 		}
-	}
-	if !validDuration {
-		// Create a string representation of the supported durations for the error message
-		durationsStr := make([]string, len(modelDetails.SupportedDurations))
-		for i, d := range modelDetails.SupportedDurations {
-			durationsStr[i] = fmt.Sprintf("%d", d)
+		validDuration := false
+		for _, d := range modelDetails.SupportedDurations {
+			if d == durationSecs {
+				validDuration = true
+				break
+			}
 		}
-		return "", "", "", "", 0, 0, false, "", fmt.Errorf("duration '%d' is not supported by model %s. Supported durations are: [%s]", durationSecs, model, strings.Join(durationsStr, ", "))
+		if !validDuration {
+			// Create a string representation of the supported durations for the error message
+			durationsStr := make([]string, len(modelDetails.SupportedDurations))
+			for i, d := range modelDetails.SupportedDurations {
+				durationsStr[i] = fmt.Sprintf("%d", d)
+			}
+			return "", "", "", "", 0, 0, false, "", fmt.Errorf("duration '%d' is not supported by model %s. Supported durations are: [%s]", durationSecs, model, strings.Join(durationsStr, ", "))
+		}
 	}
 
 	// Aspect Ratio

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -42,7 +42,7 @@ var (
 
 const (
 	serviceName = "mcp-veo-go"
-	version     = "3.7.0" // Synchronize release version
+	version     = "3.7.1" // Synchronize release version
 )
 
 // init handles command-line flags and initial logging setup.


### PR DESCRIPTION

*   **Fix:** Corrected parameter parsing in `mcp-veo-go`'s `veo_extend_video` tool to correctly bypass standard duration validation and supply the required 7-second duration to the Vertex AI API.
*   **Chore:** Bumped minor versions for all MCP servers to synchronize the release.

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
