### PR TITLE
fix(mcp-veo-go): remove duration from veo_extend_video schema

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-04-14 (v3.7.2)
+
+*   **Fix:** Removed `duration` from the `veo_extend_video` tool schema in `mcp-veo-go`. Because the extension duration is strictly hardcoded to 7 seconds by the backend API, exposing it as an optional parameter confused LLM agents, leading them to falsely assume a conflict between the API requirements and the model's standard limits.
+
 ## 2026-04-14 (v3.7.1)
 
 *   **Fix:** Corrected parameter parsing in `mcp-veo-go`'s `veo_extend_video` tool to correctly bypass standard duration validation and supply the required 7-second duration to the Vertex AI API.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	serviceName = "mcp-avtool-go"
-	version     = "3.7.1" // Fix: Veo Video Extend validation
+	version     = "3.7.2" // Fix: Removed duration param from extend schema
 )
 
 var (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
@@ -34,7 +34,7 @@ var (
 	availableVoices []*texttospeechpb.Voice
 	transport       string
 	port            int
-	version         = "3.7.1" // Synchronize release version
+	version         = "3.7.2" // Synchronize release version
 )
 
 const (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-gemini-go"
-	version     = "3.7.1" // Synchronize release version
+	version     = "3.7.2" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -49,7 +49,7 @@ var (
 
 const (
 	serviceName = "mcp-imagen-go"
-	version     = "3.7.1" // Synchronize release version
+	version     = "3.7.2" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -56,7 +56,7 @@ var (
 
 const (
 	serviceName         = "mcp-lyria-go"
-	version     = "3.7.1" // Synchronize release version
+	version     = "3.7.2" // Synchronize release version
 	defaultPublisher    = "google"
 	defaultLyriaModelID = "lyria-3-clip-preview"
 	defaultSampleCount  = 1

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-nanobanana-go"
-	version     = "3.7.1" // Synchronize release version
+	version     = "3.7.2" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -42,7 +42,7 @@ var (
 
 const (
 	serviceName = "mcp-veo-go"
-	version     = "3.7.1" // Synchronize release version
+	version     = "3.7.2" // Synchronize release version
 )
 
 // init handles command-line flags and initial logging setup.
@@ -242,8 +242,32 @@ func main() {
 		mcp.WithString("prompt",
 			mcp.Description("Optional text prompt to guide video extension."),
 		),
+		mcp.WithString("bucket",
+			mcp.Description("Google Cloud Storage bucket where the API will save the generated video(s) (e.g., your-bucket/output-folder or gs://your-bucket/output-folder). If not provided, GENMEDIA_BUCKET env var will be used. One of them is required."),
+		),
+		mcp.WithString("output_directory",
+			mcp.Description("Optional. If provided, specifies a local directory to download the generated video(s) to. Filenames will be generated automatically."),
+		),
+		mcp.WithString("model",
+			mcp.DefaultString("veo-3.1-fast-generate-001"),
+			mcp.Description(common.BuildVeoModelDescription()),
+		),
+		mcp.WithNumber("num_videos",
+			mcp.DefaultNumber(1),
+			mcp.Description("Number of videos to generate. Note: the maximum is model-dependent."),
+		),
+		mcp.WithString("aspect_ratio",
+			mcp.Description("Aspect ratio of the generated videos. Note: supported aspect ratios are model-dependent."),
+		),
+		mcp.WithBoolean("generate_audio",
+			mcp.DefaultBool(true),
+			mcp.Description("Optional. Generate audio for the video. Only supported by Veo 3 models. Defaults to true."),
+		),
+		mcp.WithString("person_generation",
+			mcp.DefaultString("allow_adult"),
+			mcp.Description("Whether to allow generating videos with people. Supported values: 'dont_allow', 'allow_adult'."),
+		),
 	)
-	extendVideoToolParams = append(extendVideoToolParams, commonVideoParams...)
 
 	extendVideoTool := mcp.NewTool("veo_extend_video",
 		extendVideoToolParams...,


### PR DESCRIPTION
- Removed `duration` parameter from `veo_extend_video` tool schema as it confused LLM agents trying to satisfy the model's standard duration limits and the backend API's strict 7s extension requirement.
- Bumped minor version to 3.7.2 across all servers.



## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
