### PR TITLE
feat(mcp-gemini-go): add gemini-3.1-flash-tts-preview support

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-15 (v3.8.0)
+
+*   **Feat:** Added support for `gemini-3.1-flash-tts-preview` to the `gemini_audio_tts` tool in `mcp-gemini-go` and set it as the default model.
+*   **Chore:** Bumped minor versions for all MCP servers to synchronize the release.
+
 ## 2026-04-14 (v3.7.2)
 
 *   **Fix:** Removed `duration` from the `veo_extend_video` tool schema in `mcp-veo-go`. Because the extension duration is strictly hardcoded to 7 seconds by the backend API, exposing it as an optional parameter confused LLM agents, leading them to falsely assume a conflict between the API requirements and the model's standard limits.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	serviceName = "mcp-avtool-go"
-	version     = "3.7.2" // Fix: Removed duration param from extend schema
+	version     = "3.8.0" // Fix: Removed duration param from extend schema
 )
 
 var (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
@@ -34,7 +34,7 @@ var (
 	availableVoices []*texttospeechpb.Voice
 	transport       string
 	port            int
-	version         = "3.7.2" // Synchronize release version
+	version         = "3.8.0" // Synchronize release version
 )
 
 const (

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
@@ -25,7 +25,7 @@ Synthesizes speech from text using Gemini models, allowing for granular control 
 - `text` (string, required): The text to synthesize (up to 800 characters).
 - `prompt` (string, optional): Stylistic instructions on how to synthesize the content.
 - `voice_name` (string, optional): The voice to use. Defaults to `Callirrhoe`. Use the `list_gemini_voices` tool to see all options.
-- `model_name` (string, optional): The model to use. Defaults to `gemini-2.5-flash-preview-tts`.
+- `model_name` (string, optional): The model to use. Defaults to `gemini-3.1-flash-tts-preview`.
 - `output_directory` (string, optional): Local directory to save the generated audio file to.
 - `output_filename_prefix` (string, optional): A prefix for the output WAV filename.
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-gemini-go"
-	version     = "3.7.2" // Synchronize release version
+	version     = "3.8.0" // Synchronize release version
 )
 
 func init() {
@@ -131,7 +131,7 @@ func main() {
 		mcp.WithString("model_name",
 			mcp.DefaultString(defaultGeminiTTSModel),
 			mcp.Description("The model to use."),
-			mcp.Enum("gemini-2.5-flash-tts", "gemini-2.5-pro-tts", "gemini-2.5-flash-lite-preview-tts"),
+			mcp.Enum("gemini-3.1-flash-tts-preview", "gemini-2.5-flash-tts", "gemini-2.5-pro-tts", "gemini-2.5-flash-lite-preview-tts"),
 		),
 		mcp.WithString("language_code",
 			mcp.DefaultString("en-US"),

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	geminiTTSAPIEndpoint     = "https://texttospeech.googleapis.com/v1/text:synthesize"
-	defaultGeminiTTSModel    = "gemini-2.5-flash-tts"
+	defaultGeminiTTSModel    = "gemini-3.1-flash-tts-preview"
 	defaultGeminiTTSVoice    = "Callirrhoe"
 	timeFormatForTTSFilename = "20060102-150405"
 )
@@ -314,7 +314,8 @@ func geminiAudioTTSHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 // --- API Helper Function ---
 
 func callGeminiTTSAPI(ctx context.Context, text, stylePrompt, voiceName, modelName, audioEncoding, languageCode string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	// Detach from parent context to avoid inherited short timeouts from the server/client
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	client, err := texttospeech.NewClient(ctx)

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -49,7 +49,7 @@ var (
 
 const (
 	serviceName = "mcp-imagen-go"
-	version     = "3.7.2" // Synchronize release version
+	version     = "3.8.0" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -56,7 +56,7 @@ var (
 
 const (
 	serviceName         = "mcp-lyria-go"
-	version     = "3.7.2" // Synchronize release version
+	version     = "3.8.0" // Synchronize release version
 	defaultPublisher    = "google"
 	defaultLyriaModelID = "lyria-3-clip-preview"
 	defaultSampleCount  = 1

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	serviceName = "mcp-nanobanana-go"
-	version     = "3.7.2" // Synchronize release version
+	version     = "3.8.0" // Synchronize release version
 )
 
 func init() {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -42,7 +42,7 @@ var (
 
 const (
 	serviceName = "mcp-veo-go"
-	version     = "3.7.2" // Synchronize release version
+	version     = "3.8.0" // Synchronize release version
 )
 
 // init handles command-line flags and initial logging setup.

--- a/experiments/mcp-genmedia/skills/genmedia-voice-director/SKILL.md
+++ b/experiments/mcp-genmedia/skills/genmedia-voice-director/SKILL.md
@@ -22,7 +22,7 @@ Your goal is to treat the Gemini TTS model like a virtual voice talent, setting 
 ## Tools
 When instructed to generate audio, you should use the `gemini_audio_tts` tool (available via the `gemini-multimodal` MCP server). 
 
-* **Model:** Prefer `gemini-2.5-flash-tts` or `gemini-2.5-pro-tts`.
+* **Model:** Prefer `gemini-3.1-flash-tts-preview` (default) or `gemini-2.5-pro-tts`.
 * **Voice Name:** Select an appropriate voice from the available list (e.g., *Kore* for firm, *Puck* for upbeat, *Enceladus* for breathy). See available voices via the `list_gemini_voices` tool.
 * **Prompt:** This is where your expertise lies. The prompt must be structured using the framework below.
 


### PR DESCRIPTION


- Added `gemini-3.1-flash-tts-preview` to the supported models enum in `mcp-gemini-go` and set it as the default TTS model.
- Bumped version to 3.8.0 across all MCP servers to synchronize the release.
- Updated CHANGELOG.md to reflect the new feature and version bump.
- Updated `genmedia-voice-director` SKILL.md to recommend the new default model.

## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [x] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
