### PR TITLE
fix(docs): Update Node.js version to 22 in GitHub Actions workflow to support Astro 5

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: docs-site/package-lock.json
           


### PR DESCRIPTION
fix(docs): Update Node.js version to 22 in GitHub Actions workflow to support Astro 5


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
