### PR TITLE
chore(deps): replace app-id with client-id for create-github-app-token action

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -95,7 +95,7 @@ jobs:
           ${{ vars.APP_ID }}
         uses: 'actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3' # v3
         with:
-          app-id: '${{ vars.APP_ID }}'
+          client-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
           permission-contents: 'read'
           permission-issues: 'write'
@@ -217,7 +217,7 @@ jobs:
           ${{ vars.APP_ID }}
         uses: 'actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3' # v3
         with:
-          app-id: '${{ vars.APP_ID }}'
+          client-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
           permission-contents: 'read'
           permission-issues: 'write'

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -38,7 +38,7 @@ jobs:
           ${{ vars.APP_ID }}
         uses: 'actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3' # v3
         with:
-          app-id: '${{ vars.APP_ID }}'
+          client-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
           permission-contents: 'read'
           permission-issues: 'write'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -39,7 +39,7 @@ jobs:
           ${{ vars.APP_ID }}
         uses: 'actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3' # v3
         with:
-          app-id: '${{ vars.APP_ID }}'
+          client-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
           permission-contents: 'read'
           permission-issues: 'write'

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -202,7 +202,7 @@ jobs:
           ${{ vars.APP_ID }}
         uses: 'actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3' # v3
         with:
-          app-id: '${{ vars.APP_ID }}'
+          client-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
           permission-contents: 'read'
           permission-issues: 'write'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -137,7 +137,7 @@ jobs:
           ${{ vars.APP_ID }}
         uses: 'actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3' # v3
         with:
-          app-id: '${{ vars.APP_ID }}'
+          client-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
           permission-contents: 'read'
           permission-issues: 'write'


### PR DESCRIPTION
Updates the inputs for the `actions/create-github-app-token` action in all workflow files to use the `client-id` parameter instead of the deprecated `app-id` parameter as introduced in v3 of the action.