### PR TITLE
feat: Enable PDF and multimodal file uploads for Gemini Image Generation

### DIFF
--- a/components/gemini_image/upload_ui.py
+++ b/components/gemini_image/upload_ui.py
@@ -24,10 +24,10 @@ def gemini_image_upload_ui(
         ),
     ):
         me.uploader(
-            label="Upload Images",
+            label="Upload Media",
             on_upload=on_upload,
             multiple=True,
-            accepted_file_types=["image/jpeg", "image/png", "image/webp"],
+            accepted_file_types=["image/jpeg", "image/png", "image/webp", "application/pdf"],
             style=me.Style(width="100%"),
             disabled=upload_disabled,
         )

--- a/components/image_thumbnail.py
+++ b/components/image_thumbnail.py
@@ -22,7 +22,23 @@ def image_thumbnail(image_uri: str, index: int, on_remove: Callable, icon_size: 
     box_dimension = icon_size + 8
     
     with me.box(style=me.Style(position="relative", width=100, height=100)):
-        me.image(src=image_uri, style=me.Style(width="100%", height="100%", border_radius=8, object_fit="cover"))
+        
+        if image_uri.lower().endswith(".pdf"):
+            with me.box(
+                style=me.Style(
+                    width="100%",
+                    height="100%",
+                    border=me.Border.all(me.BorderSide(style="dashed", color=me.theme_var("outline"))),
+                    border_radius=8,
+                    display="flex",
+                    align_items="center",
+                    justify_content="center",
+                )
+            ):
+                me.icon("article")
+        else:
+            me.image(src=image_uri, style=me.Style(width="100%", height="100%", border_radius=8, object_fit="cover"))
+
         with me.box(
             on_click=on_remove,
             key=str(index),

--- a/config/default.py
+++ b/config/default.py
@@ -53,7 +53,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class"""
 
-    VERSION: str = "1.8.3"  # Fallback if package metadata is missing
+    VERSION: str = "1.8.4"  # Fallback if package metadata is missing
     BUILD_COMMIT: str = ""
     BUILD_DATE: str = ""
 

--- a/models/gemini.py
+++ b/models/gemini.py
@@ -114,7 +114,25 @@ def generate_image_from_prompt_and_images(
 
     parts = [types.Part.from_text(text=prompt)]
     for image_uri in images:
-        parts.append(types.Part.from_uri(file_uri=image_uri, mime_type="image/png"))
+        # More robust mime type detection
+        if any(
+            image_uri.lower().endswith(ext)
+            for ext in [".mp4", ".mov", ".avi", ".mkv", ".webm"]
+        ):
+            mime_type = "video/mp4"  # General video type
+        elif any(image_uri.lower().endswith(ext) for ext in [".wav", ".mp3", ".flac"]):
+            mime_type = "audio/wav"  # General audio type
+        elif any(
+            image_uri.lower().endswith(ext)
+            for ext in [".png", ".jpg", ".jpeg", ".webp", ".gif"]
+        ):
+            mime_type = "image/png"  # General image type
+        elif image_uri.lower().endswith(".pdf"):
+            mime_type = "application/pdf"
+        else:
+            # Fallback for unknown types
+            mime_type = "image/png"
+        parts.append(types.Part.from_uri(file_uri=image_uri, mime_type=mime_type))
 
     contents = [types.Content(role="user", parts=parts)]
 
@@ -983,12 +1001,19 @@ def generate_transformation_prompts(image_uris: list[str]) -> list[Transformatio
     reraise=True,
 )
 def describe_image(image_uri: str) -> str:
-    """Generates a two-sentence description for a given image."""
+    """Generates a two-sentence description for a given media file."""
     model_name = cfg.MODEL_ID
     config = types.GenerateContentConfig(temperature=0.2)
+    
+    mime_type = "image/png"
+    if image_uri.lower().endswith(".pdf"):
+        mime_type = "application/pdf"
+    elif any(image_uri.lower().endswith(ext) for ext in [".mp4", ".mov", ".avi", ".mkv", ".webm"]):
+        mime_type = "video/mp4"
+
     prompt_parts = [
-        "Describe this image in two sentences.",
-        types.Part.from_uri(file_uri=image_uri, mime_type="image/png"),
+        "Describe this media file in two sentences.",
+        types.Part.from_uri(file_uri=image_uri, mime_type=mime_type),
     ]
     with track_model_call(model_name=model_name, task="describe_image"):
         response = client.models.generate_content(

--- a/pages/gemini_image_generation.py
+++ b/pages/gemini_image_generation.py
@@ -290,10 +290,10 @@ def gemini_image_gen_page_content():
                     ),
                 ):
                     me.uploader(
-                        label="Upload Images",
+                        label="Upload Media",
                         on_upload=on_upload,
                         multiple=True,
-                        accepted_file_types=["image/jpeg", "image/png", "image/webp"],
+                        accepted_file_types=["image/jpeg", "image/png", "image/webp", "application/pdf"],
                         style=me.Style(width="100%"),
                         disabled=upload_disabled,
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vertex-ai-genmedia-creative-studio"
-version = "1.8.3"
+version = "1.8.4"
 description = "GenMedia Creative Studio - Veo, Lyria, Nano Banana, Imagen, Gemini, Gemini TTS"
 readme = "README.md"
 requires-python = ">=3.14, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -2195,7 +2195,7 @@ wheels = [
 
 [[package]]
 name = "vertex-ai-genmedia-creative-studio"
-version = "1.8.3"
+version = "1.8.4"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
- models/gemini.py: Updated `generate_image_from_prompt_and_images` and `describe_image` to dynamically infer MIME types from file extensions (supporting .pdf, .mp4, .wav, etc.) instead of hardcoding image/png.
- components/gemini_image/upload_ui.py & pages/gemini_image_generation.py: Added application/pdf to accepted_file_types and relabeled upload buttons to "Upload Media".
- components/image_thumbnail.py: Added fallback rendering to display an icon placeholder for PDF files instead of a broken image tag.
- versioning: Bumped application patch version to 1.8.4.


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [x] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [ ] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
