### PR TITLE
Expose Veo location in Terraform

### DIFF
--- a/environment_variables.md
+++ b/environment_variables.md
@@ -144,6 +144,7 @@ These variables are exposed in `variables.tf` and directly map to environment va
 | `gemini_critique_model_id` | `GEMINI_CRITIQUE_MODEL_ID` | `gemini-3-flash-preview` |
 | `gemini_critique_location` | `GEMINI_CRITIQUE_LOCATION` | `global` |
 | `character_consistency_gemini_location` | `CHARACTER_CONSISTENCY_GEMINI_LOCATION` | `global` |
+| `veo_location` | `VEO_LOCATION` | `us-central1` |
 | `veo_model_id` | `VEO_MODEL_ID` | `veo-3.1-fast-generate-001` |
 | `veo_exp_model_id` | `VEO_EXP_MODEL_ID` | `veo-3.1-generate-001` |
 | `lyria_model_id` | `LYRIA_MODEL_VERSION` | `lyria-002` |
@@ -167,7 +168,7 @@ These variables are computed within `main.tf` based on the resources Terraform c
 The following variables are **not** explicitly set in the `main.tf` configuration. This means the application will use the **default values defined in `config/default.py`** when deployed via Terraform.
 
 *   **Gemini Models:** `GEMINI_IMAGE_GEN_MODEL`, `GEMINI_IMAGE_GEN_LOCATION`, `GEMINI_AUDIO_ANALYSIS_MODEL_ID`
-*   **Veo:** `DEFAULT_VEO_MODEL_NAME`, `VEO_LOCATION`, `PREVIEW_LOCATION`, `VEO_PROJECT_ID`, `VEO_EXP_FAST_MODEL_ID`, `VEO_EXP_PROJECT_ID`
+*   **Veo:** `DEFAULT_VEO_MODEL_NAME`, `PREVIEW_LOCATION`, `VEO_PROJECT_ID`, `VEO_EXP_FAST_MODEL_ID`, `VEO_EXP_PROJECT_ID`
 *   **VTO (Virtual Try-On):** `VTO_LOCATION`, `VTO_MODEL_ID`, `GENMEDIA_VTO_*` collection names.
 *   **Imagen:** `MODEL_IMAGEN_PRODUCT_RECONTEXT`, `IMAGEN_GENERATED_SUBFOLDER`, `IMAGEN_EDITED_SUBFOLDER`
 *   **Interior Design:** `INTERIOR_DESIGN_VIDEO_MODEL`, `INTERIOR_DESIGN_IMAGE_MODEL`, `INTERIOR_DESIGN_VIDEO_DURATION`

--- a/main.tf
+++ b/main.tf
@@ -151,25 +151,26 @@ resource "google_service_account" "creative_studio" {
 locals {
   asset_bucket_name = "creative-studio-${var.project_id}-assets"
   creative_studio_env_vars = {
-    PROJECT_ID            = var.project_id
-    LOCATION              = var.region
-    GEMINI_TTS_LOCATION   = var.gemini_tts_location
-    MODEL_ID              = var.model_id
-    GEMINI_CRITIQUE_MODEL_ID = var.gemini_critique_model_id
-    GEMINI_CRITIQUE_LOCATION = var.gemini_critique_location
+    PROJECT_ID                            = var.project_id
+    LOCATION                              = var.region
+    GEMINI_TTS_LOCATION                   = var.gemini_tts_location
+    MODEL_ID                              = var.model_id
+    GEMINI_CRITIQUE_MODEL_ID              = var.gemini_critique_model_id
+    GEMINI_CRITIQUE_LOCATION              = var.gemini_critique_location
     CHARACTER_CONSISTENCY_GEMINI_LOCATION = var.character_consistency_gemini_location
-    VEO_MODEL_ID          = var.veo_model_id
-    VEO_EXP_MODEL_ID      = var.veo_exp_model_id
-    LYRIA_MODEL_VERSION   = var.lyria_model_id
-    LYRIA_PROJECT_ID      = var.project_id
-    GENMEDIA_BUCKET       = local.asset_bucket_name
-    VIDEO_BUCKET          = local.asset_bucket_name
-    MEDIA_BUCKET          = local.asset_bucket_name
-    IMAGE_BUCKET          = local.asset_bucket_name
-    GCS_ASSETS_BUCKET     = local.asset_bucket_name
-    GENMEDIA_FIREBASE_DB  = google_firestore_database.create_studio_asset_metadata.name
-    SERVICE_ACCOUNT_EMAIL = google_service_account.creative_studio.email
-    EDIT_IMAGES_ENABLED   = var.edit_images_enabled
+    VEO_LOCATION                          = var.veo_location
+    VEO_MODEL_ID                          = var.veo_model_id
+    VEO_EXP_MODEL_ID                      = var.veo_exp_model_id
+    LYRIA_MODEL_VERSION                   = var.lyria_model_id
+    LYRIA_PROJECT_ID                      = var.project_id
+    GENMEDIA_BUCKET                       = local.asset_bucket_name
+    VIDEO_BUCKET                          = local.asset_bucket_name
+    MEDIA_BUCKET                          = local.asset_bucket_name
+    IMAGE_BUCKET                          = local.asset_bucket_name
+    GCS_ASSETS_BUCKET                     = local.asset_bucket_name
+    GENMEDIA_FIREBASE_DB                  = google_firestore_database.create_studio_asset_metadata.name
+    SERVICE_ACCOUNT_EMAIL                 = google_service_account.creative_studio.email
+    EDIT_IMAGES_ENABLED                   = var.edit_images_enabled
   }
 
   deployed_domain = var.use_lb ? ["https://${var.domain}"] : google_cloud_run_v2_service.creative_studio.urls

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "veo_model_id" {
   default     = "veo-3.1-fast-generate-001"
 }
 
+variable "veo_location" {
+  description = "Location for Veo API calls"
+  type        = string
+  default     = "us-central1"
+}
+
 variable "veo_exp_model_id" {
   description = "Experimental Veo model ID to use for video generation"
   type        = string


### PR DESCRIPTION
## Summary
- add a `veo_location` Terraform variable and pass it to Cloud Run as `VEO_LOCATION`
- keep the default at `us-central1`, matching the app's existing Veo default
- update the environment variable docs so Terraform-managed settings match `main.tf`

Fixes #926

## Testing
- `docker run --rm -v "$PWD":/workspace -w /workspace hashicorp/terraform:1.10 fmt -check -diff`
- `docker run --rm --entrypoint sh -v "$PWD":/workspace -w /workspace hashicorp/terraform:1.10 -c 'terraform init -backend=false >/tmp/tf-init.log && terraform validate'`\n- `git diff --check`