### PR TITLE
Default character consistency image selection

### DIFF
--- a/pages/test_character_consistency.py
+++ b/pages/test_character_consistency.py
@@ -30,6 +30,9 @@ from components.dialog import dialog
 
 logger = logging.getLogger(__name__)
 
+SELECT_IMAGE_STEP = 2
+CREATE_VIDEO_STEP = 3
+
 
 @me.stateclass
 class PageState:
@@ -128,7 +131,7 @@ This page allows you to test the character consistency workflow step-by-step.
                     )
                     me.button("Generate Alternatives", on_click=generate_alternatives, type="raised")
 
-                if state.current_step == 2:
+                if state.current_step == SELECT_IMAGE_STEP:
                     me.text("Step 2: Select the Best Image", style=me.Style(margin=me.Margin(bottom=16)))
                     if state.character_description:
                         with me.expansion_panel(title="Character Description"):
@@ -180,7 +183,7 @@ This page allows you to test the character consistency workflow step-by-step.
                                         )
                         me.button("Continue", on_click=next_step, type="raised")
 
-                if state.current_step == 3:
+                if state.current_step == CREATE_VIDEO_STEP:
                     me.text("Step 3: Create Video", style=me.Style(margin=me.Margin(bottom=16)))
                     with me.box(style=me.Style(display="flex", flex_direction="row", gap=16, margin=me.Margin(bottom=16))):
                         with me.box(style=me.Style(flex_grow=1)):
@@ -260,14 +263,27 @@ def on_modify_prompt_click(modifier: str):
     yield
 
 
+def _default_selected_image_url(state: PageState) -> str:
+    """Return the current selection, falling back to generated candidates."""
+    if state.user_selected_image_url:
+        return state.user_selected_image_url
+    if state.best_image_url:
+        return state.best_image_url
+    if state.candidate_image_urls:
+        return state.candidate_image_urls[0]
+    return ""
+
+
 def next_step(e: me.ClickEvent):
     """Move to the next step."""
     state = me.state(PageState)
+    if state.current_step == SELECT_IMAGE_STEP and not state.user_selected_image_url:
+        state.user_selected_image_url = _default_selected_image_url(state)
     state.current_step += 1
     if state.current_step > state.max_completed_step:
         state.max_completed_step = state.current_step
     state.status_message = f"Moved to step {state.current_step}"
-    if state.current_step == 3:
+    if state.current_step == CREATE_VIDEO_STEP:
         state.video_prompt = state.scene_prompt
     yield
 
@@ -312,6 +328,7 @@ def generate_alternatives(e: me.ClickEvent):
                 gcs_uri = step_result.data["best_image_gcs_uri"]
                 state.best_image_gcs_uri = gcs_uri
                 state.best_image_url = create_display_url(gcs_uri)
+                state.user_selected_image_url = _default_selected_image_url(state)
                 break
     except Exception as e:
         logger.error("Error during character consistency generation", exc_info=True)
@@ -322,7 +339,7 @@ def generate_alternatives(e: me.ClickEvent):
 
     state.is_generating = False
     state.status_message = "Generated alternatives."
-    state.current_step = 2
+    state.current_step = SELECT_IMAGE_STEP
     if state.current_step > state.max_completed_step:
         state.max_completed_step = state.current_step
     yield
@@ -336,7 +353,14 @@ def generate_video(e: me.ClickEvent):
     yield
 
     # Convert the display URL back to a GCS URI before passing it to the model.
-    gcs_uri = https_url_to_gcs_uri(state.user_selected_image_url)
+    selected_image_url = _default_selected_image_url(state)
+    if not selected_image_url:
+        state.status_message = "Select an image before generating video."
+        state.is_generating = False
+        yield
+        return
+    state.user_selected_image_url = selected_image_url
+    gcs_uri = https_url_to_gcs_uri(selected_image_url)
 
     for step_result in generate_character_video(
         user_email=app_state.user_email,

--- a/test/test_character_consistency_page.py
+++ b/test/test_character_consistency_page.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the character consistency test page."""
+
+# ruff: noqa: S101
+
+from pages.test_character_consistency import (
+    PageState,
+    _default_selected_image_url,
+)
+
+
+def test_default_selected_image_prefers_user_selection() -> None:
+    """Uses an explicit user selection before any generated default."""
+    state = PageState()
+    state.user_selected_image_url = "/media/bucket/manual.png"
+    state.best_image_url = "/media/bucket/best.png"
+    state.candidate_image_urls = ["/media/bucket/first.png"]
+
+    assert _default_selected_image_url(state) == "/media/bucket/manual.png"
+
+
+def test_default_selected_image_uses_best_image() -> None:
+    """Uses the model-selected image when the user did not choose one."""
+    state = PageState()
+    state.best_image_url = "/media/bucket/best.png"
+    state.candidate_image_urls = ["/media/bucket/first.png"]
+
+    assert _default_selected_image_url(state) == "/media/bucket/best.png"
+
+
+def test_default_selected_image_uses_first_candidate_without_best() -> None:
+    """Falls back to the first candidate only when no best image is set."""
+    state = PageState()
+    state.candidate_image_urls = [
+        "/media/bucket/first.png",
+        "/media/bucket/second.png",
+    ]
+
+    assert _default_selected_image_url(state) == "/media/bucket/first.png"


### PR DESCRIPTION
Fixes #855.

## What changed
- Use the generated best image as the default selection when a user continues without clicking a candidate.
- Keep a fallback to the first generated candidate if the best image is not available.
- Add a small unit test for the selection fallback order.

## Testing
- `python3 -m py_compile pages/test_character_consistency.py test/test_character_consistency_page.py`
- `git diff --check`
- `PYTHONPATH=/tmp/codex-ruff python3 -m ruff check test/test_character_consistency_page.py`