### PR TITLE
Document Gemini CLI cloud auth

### DIFF
--- a/docs-site/src/content/docs/experiments/mcp-genmedia/agents/geminicli.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/agents/geminicli.md
@@ -16,6 +16,19 @@ To configure these servers for gemini cli, you can either add these to your ~/.g
 
 > **Existing Users:** If you have previously installed the GenMedia extension using the older JSON format, please see the [Migration Guide](migration.md) for quick instructions on upgrading to the new interactive setup.
 
+## Authentication
+
+The GenMedia MCP servers call Vertex AI from the MCP server process. Gemini CLI's own Gemini API key or login does not authenticate these Vertex AI calls.
+
+Before starting Gemini CLI, configure Google Cloud Application Default Credentials (ADC) and a Google Cloud project ID:
+
+```bash
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT="$(gcloud config get-value project)"
+```
+
+For service accounts, set `GOOGLE_APPLICATION_CREDENTIALS` to the key file path instead. Use `GOOGLE_CLOUD_PROJECT` in the MCP server environment; `PROJECT_ID` is still accepted as a legacy fallback.
+
 ## .gemini/settings.json: Global Tool Timeout
 
 If you intend to use long-running tools like **Veo** (which takes minutes to generate video) or complex **Gemini TTS** prompts, you **MUST** increase the global tool execution timeout in your `~/.gemini/settings.json` file. 
@@ -48,7 +61,7 @@ A `sample_settings.json` is provided for your convenience.
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "240000",
         "MCP_SERVER_REQUEST_TIMEOUT": "30000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "imagen": {
@@ -56,7 +69,7 @@ A `sample_settings.json` is provided for your convenience.
       "env": {
         "MCP_SERVER_REQUEST_TIMEOUT": "55000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "chirp3-hd": {
@@ -64,28 +77,28 @@ A `sample_settings.json` is provided for your convenience.
       "env": {
         "MCP_SERVER_REQUEST_TIMEOUT": "55000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "lyria": {
       "command": "mcp-lyria-go",
       "env": {
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
     },
     "avtool": {
       "command": "mcp-avtool-go",
       "env": {
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
     },
     "gemini": {
       "command": "mcp-gemini-go",
       "env": {
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "120000",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
@@ -112,7 +125,7 @@ Here is an example of how to configure the `veo` server to use an insecure conne
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "240000",
         "MCP_SERVER_REQUEST_TIMEOUT": "30000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     }
   }
@@ -145,7 +158,7 @@ Then, add to that directory a `gemini-extension.json`
     {
       "name": "Google Cloud Project ID",
       "description": "The GCP Project ID where Vertex AI is enabled.",
-      "envVar": "PROJECT_ID",
+      "envVar": "GOOGLE_CLOUD_PROJECT",
       "sensitive": false
     },
     {
@@ -200,7 +213,7 @@ Then, add to that directory a `gemini-extension.json`
 
 ### Interactive Installation
 
-With the new `settings` array in `gemini-extension.json`, Gemini CLI will interactively ask you for your `PROJECT_ID` and `GENMEDIA_BUCKET` when you install the extension. These values are automatically stored securely in the extension's `.env` file and passed to the MCP servers!
+With the new `settings` array in `gemini-extension.json`, Gemini CLI will interactively ask you for your `GOOGLE_CLOUD_PROJECT` and `GENMEDIA_BUCKET` when you install the extension. These values are automatically stored securely in the extension's `.env` file and passed to the MCP servers!
 
 ```bash
 gemini extensions install ./sample_extensions/google-genmedia

--- a/experiments/mcp-genmedia/sample-agents/geminicli/README.md
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/README.md
@@ -14,6 +14,19 @@ To configure these servers for gemini cli, you can either add these to your ~/.g
 
 > **Existing Users:** If you have previously installed the GenMedia extension using the older JSON format, please see the [Migration Guide](MIGRATION.md) for quick instructions on upgrading to the new interactive setup.
 
+## Authentication
+
+The GenMedia MCP servers call Vertex AI from the MCP server process. Gemini CLI's own Gemini API key or login does not authenticate these Vertex AI calls.
+
+Before starting Gemini CLI, configure Google Cloud Application Default Credentials (ADC) and a Google Cloud project ID:
+
+```bash
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT="$(gcloud config get-value project)"
+```
+
+For service accounts, set `GOOGLE_APPLICATION_CREDENTIALS` to the key file path instead. Use `GOOGLE_CLOUD_PROJECT` in the MCP server environment; `PROJECT_ID` is still accepted as a legacy fallback.
+
 ## .gemini/settings.json: Global Tool Timeout
 
 If you intend to use long-running tools like **Veo** (which takes minutes to generate video) or complex **Gemini TTS** prompts, you **MUST** increase the global tool execution timeout in your `~/.gemini/settings.json` file. 
@@ -46,7 +59,7 @@ A `sample_settings.json` is provided for your convenience.
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "240000",
         "MCP_SERVER_REQUEST_TIMEOUT": "30000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "imagen": {
@@ -54,7 +67,7 @@ A `sample_settings.json` is provided for your convenience.
       "env": {
         "MCP_SERVER_REQUEST_TIMEOUT": "55000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "chirp3-hd": {
@@ -62,28 +75,28 @@ A `sample_settings.json` is provided for your convenience.
       "env": {
         "MCP_SERVER_REQUEST_TIMEOUT": "55000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "lyria": {
       "command": "mcp-lyria-go",
       "env": {
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
     },
     "avtool": {
       "command": "mcp-avtool-go",
       "env": {
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
     },
     "gemini": {
       "command": "mcp-gemini-go",
       "env": {
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "120000",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
@@ -110,7 +123,7 @@ Here is an example of how to configure the `veo` server to use an insecure conne
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "240000",
         "MCP_SERVER_REQUEST_TIMEOUT": "30000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORAGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     }
   }
@@ -143,7 +156,7 @@ Then, add to that directory a `gemini-extension.json`
     {
       "name": "Google Cloud Project ID",
       "description": "The GCP Project ID where Vertex AI is enabled.",
-      "envVar": "PROJECT_ID",
+      "envVar": "GOOGLE_CLOUD_PROJECT",
       "sensitive": false
     },
     {
@@ -198,7 +211,7 @@ Then, add to that directory a `gemini-extension.json`
 
 ### Interactive Installation
 
-With the new `settings` array in `gemini-extension.json`, Gemini CLI will interactively ask you for your `PROJECT_ID` and `GENMEDIA_BUCKET` when you install the extension. These values are automatically stored securely in the extension's `.env` file and passed to the MCP servers!
+With the new `settings` array in `gemini-extension.json`, Gemini CLI will interactively ask you for your `GOOGLE_CLOUD_PROJECT` and `GENMEDIA_BUCKET` when you install the extension. These values are automatically stored securely in the extension's `.env` file and passed to the MCP servers!
 
 ```bash
 gemini extensions install ./sample_extensions/google-genmedia

--- a/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia-images/gemini-extension.json
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia-images/gemini-extension.json
@@ -19,7 +19,7 @@
     {
       "name": "Google Cloud Project ID",
       "description": "The GCP Project ID where Vertex AI is enabled.",
-      "envVar": "PROJECT_ID",
+      "envVar": "GOOGLE_CLOUD_PROJECT",
       "sensitive": false
     },
     {

--- a/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia-video/gemini-extension.json
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia-video/gemini-extension.json
@@ -20,7 +20,7 @@
     {
       "name": "Google Cloud Project ID",
       "description": "The GCP Project ID where Vertex AI is enabled.",
-      "envVar": "PROJECT_ID",
+      "envVar": "GOOGLE_CLOUD_PROJECT",
       "sensitive": false
     },
     {

--- a/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia/gemini-extension.json
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/sample_extensions/google-genmedia/gemini-extension.json
@@ -51,7 +51,7 @@
     {
       "name": "Google Cloud Project ID",
       "description": "The GCP Project ID where Vertex AI is enabled.",
-      "envVar": "PROJECT_ID",
+      "envVar": "GOOGLE_CLOUD_PROJECT",
       "sensitive": false
     },
     {

--- a/experiments/mcp-genmedia/sample-agents/geminicli/sample_settings.json
+++ b/experiments/mcp-genmedia/sample-agents/geminicli/sample_settings.json
@@ -6,7 +6,7 @@
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "240000",
         "MCP_SERVER_REQUEST_TIMEOUT": "30000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "imagen": {
@@ -14,7 +14,7 @@
       "env": {
         "MCP_SERVER_REQUEST_TIMEOUT": "55000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "chirp3-hd": {
@@ -22,28 +22,28 @@
       "env": {
         "MCP_SERVER_REQUEST_TIMEOUT": "55000",
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID"
       }
     },
     "lyria": {
       "command": "mcp-lyria-go",
       "env": {
         "GENMEDIA_BUCKET": "YOUR_GOOGLE_CLOUD_STORGE_BUCKET",
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
     },
     "avtool": {
       "command": "mcp-avtool-go",
       "env": {
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }
     },
     "gemini": {
       "command": "mcp-gemini-go",
       "env": {
-        "PROJECT_ID": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT": "YOUR_GOOGLE_CLOUD_PROJECT_ID",
         "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "120000",
         "MCP_SERVER_REQUEST_TIMEOUT": "55000"
       }


### PR DESCRIPTION
Updates #243.

## What changed
- Clarify that the GenMedia MCP servers authenticate to Vertex AI with Google Cloud ADC, not the Gemini CLI API key.
- Prefer `GOOGLE_CLOUD_PROJECT` in the Gemini CLI examples and extension settings, while noting that `PROJECT_ID` remains a legacy fallback.
- Keep the docs-site page, sample README, sample settings, and extension examples aligned.

## Testing
- `python3 -m json.tool` on the changed JSON examples
- `git diff --check`
- `npm ci && npm run build` in `docs-site`