### PR TITLE
Fix Pixie transitions for short clips

### DIFF
--- a/models/video_processing.py
+++ b/models/video_processing.py
@@ -12,22 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import datetime
 import logging
+import math
+import os
 import tempfile
 import uuid
 
 import cv2
+import moviepy
 import numpy as np
-from common.metadata import MediaItem, add_media_item_to_firestore
-from google.cloud import storage
-from moviepy import *
-from moviepy import VideoFileClip, afx, vfx
+from moviepy import (
+    ColorClip,
+    CompositeAudioClip,
+    CompositeVideoClip,
+    VideoClip,
+    VideoFileClip,
+    afx,
+    concatenate_videoclips,
+    vfx,
+)
 from moviepy.audio.io.AudioFileClip import AudioFileClip
-from scipy.ndimage import gaussian_filter, map_coordinates
-from scipy.special import expit
-from skimage.transform import resize
+from scipy.ndimage import gaussian_filter
 
+from common.metadata import MediaItem, add_media_item_to_firestore
 from common.storage import download_from_gcs, store_to_gcs
 from config.default import Default
 
@@ -72,14 +80,47 @@ def _upload_to_gcs(local_path: str, destination_folder: str, mime_type: str) -> 
 
 
 # --- Transition Functions (moviepy v2.x compatible) --- #
-import moviepy
-import datetime
-
 print(f"DEBUG: Loading video_processing.py at {datetime.datetime.now()}. Moviepy version: {moviepy.__version__}")
+
+
+def _safe_transition_duration(clip1, clip2, transition_duration):
+    """Returns a transition duration that fits inside both clips."""
+    transition_duration = float(transition_duration)
+    if not math.isfinite(transition_duration) or transition_duration <= 0:
+        raise ValueError("Transition duration must be a positive number.")
+
+    max_transition_duration = min(clip1.duration, clip2.duration)
+    if max_transition_duration <= 0:
+        raise ValueError("Video clips must have positive duration for transitions.")
+
+    return min(transition_duration, max_transition_duration)
+
+
+def _match_clip_size(clip, target_size):
+    """Fits a clip into target_size with letterboxing when needed."""
+    if clip.size == target_size:
+        return clip
+
+    ratio = min(target_size[0] / clip.size[0], target_size[1] / clip.size[1])
+    resized_clip = clip.resized(ratio)
+    background = ColorClip(size=target_size, color=(0, 0, 0), duration=resized_clip.duration)
+    fitted_clip = CompositeVideoClip(
+        [background, resized_clip.with_position("center")],
+        size=target_size,
+    )
+
+    if resized_clip.audio:
+        fitted_clip.audio = resized_clip.audio
+
+    if getattr(clip, "fps", None):
+        fitted_clip.fps = clip.fps
+
+    return fitted_clip
 
 
 def crossfade(clip1, clip2, transition_duration, speed_curve="sigmoid"):
     print("DEBUG: Entering crossfade function")
+    transition_duration = _safe_transition_duration(clip1, clip2, transition_duration)
     transition_start = clip1.duration - transition_duration
     total_duration = clip1.duration + clip2.duration - transition_duration
 
@@ -122,7 +163,7 @@ def crossfade(clip1, clip2, transition_duration, speed_curve="sigmoid"):
 
     final_clip = VideoClip(make_frame, duration=total_duration)
     final_clip.fps = clip1.fps  # Set fps for the new clip
-    
+
     if clip1.audio and clip2.audio:
         print("DEBUG: Applying audio crossfade")
         audio1 = clip1.audio.with_effects([afx.AudioFadeOut(transition_duration)])
@@ -136,6 +177,7 @@ def crossfade(clip1, clip2, transition_duration, speed_curve="sigmoid"):
 
 
 def wipe(clip1, clip2, transition_duration, direction="left-to-right"):
+    transition_duration = _safe_transition_duration(clip1, clip2, transition_duration)
     width, height = clip1.size
 
     transition_start = clip1.duration - transition_duration
@@ -188,17 +230,20 @@ def wipe(clip1, clip2, transition_duration, direction="left-to-right"):
 
 
 def dipToBlack(clip1, clip2, transition_duration, **kwargs):
+    transition_duration = _safe_transition_duration(clip1, clip2, transition_duration)
     fade_duration = transition_duration / 2.0
+    total_duration = clip1.duration + clip2.duration - fade_duration
     clip1_faded = clip1.with_effects([vfx.FadeOut(fade_duration)])
     clip2_faded = clip2.with_effects([vfx.FadeIn(fade_duration)]).with_start(
         clip1.duration - fade_duration
     )
 
     black_clip = ColorClip(
-        size=clip1.size, color=(0, 0, 0), duration=clip1.duration + clip2.duration
+        size=clip1.size, color=(0, 0, 0), duration=total_duration
     )
 
     final_clip = CompositeVideoClip([black_clip, clip1_faded, clip2_faded])
+    final_clip = final_clip.with_duration(total_duration)
     final_clip.fps = clip1.fps
 
     if clip1.audio and clip2.audio:
@@ -297,29 +342,8 @@ def process_videos(
         clip1 = clips[0]
         clip2 = clips[1]
 
-        # Check for resolution mismatch before transitions that require it
-        if transition in ["x-fade", "wipe"]:
-            if clip1.size != clip2.size:
-                messages.append(f"Resized video 2 from {clip2.size} to match video 1's resolution of {clip1.size} while preserving aspect ratio.")
-                
-                # Import necessary classes locally to avoid polluting the global scope
-                from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
-                from moviepy.video.VideoClip import ColorClip
-
-                # Resize clip2 to fit within clip1's dimensions, preserving aspect ratio
-                ratio = min(clip1.size[0] / clip2.size[0], clip1.size[1] / clip2.size[1])
-                resized_clip2 = clip2.resize(ratio)
-
-                # Create a black background clip with the size of clip1
-                background = ColorClip(size=clip1.size, color=(0, 0, 0), duration=resized_clip2.duration)
-                
-                # Composite the resized clip2 onto the center of the background
-                # This makes clip2 have the same dimensions as clip1, with black bars
-                clip2 = CompositeVideoClip([background, resized_clip2.set_position("center")])
-
-                # Ensure the new composite clip has the same audio properties
-                if resized_clip2.audio:
-                    clip2.audio = resized_clip2.audio
+        if transition != "concat":
+            clip2 = _match_clip_size(clip2, clip1.size)
 
         if transition == "concat":
             final_clip = concatenate_videoclips(clips)

--- a/test/test_video_processing_transitions.py
+++ b/test/test_video_processing_transitions.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import sys
+import types
+
+import pytest
+from moviepy import ColorClip
+
+
+@pytest.fixture
+def video_processing(monkeypatch):
+    """Imports video_processing without initializing external services."""
+    metadata = types.ModuleType("common.metadata")
+    metadata.MediaItem = type("MediaItem", (), {})
+    metadata.add_media_item_to_firestore = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "common.metadata", metadata)
+
+    storage = types.ModuleType("common.storage")
+    storage.download_from_gcs = lambda *args, **kwargs: b""
+    storage.store_to_gcs = lambda *args, **kwargs: "gs://test-bucket/output.mp4"
+    monkeypatch.setitem(sys.modules, "common.storage", storage)
+
+    config_default = types.ModuleType("config.default")
+
+    class Default:
+        VIDEO_BUCKET = "test-bucket/videos"
+
+    config_default.Default = Default
+    monkeypatch.setitem(sys.modules, "config.default", config_default)
+
+    sys.modules.pop("models.video_processing", None)
+    return importlib.import_module("models.video_processing")
+
+
+def _clip(size=(16, 16), duration=0.5, color=(255, 0, 0)):
+    return ColorClip(size=size, color=color, duration=duration).with_fps(10)
+
+
+def _write_clip(path, size=(16, 16), duration=0.5, color=(255, 0, 0)):
+    clip = _clip(size=size, duration=duration, color=color)
+    try:
+        clip.write_videofile(str(path), codec="libx264", audio=False, logger=None)
+    finally:
+        clip.close()
+
+
+def test_transition_duration_is_limited_to_shorter_clip(video_processing):
+    clip1 = _clip(duration=0.5)
+    clip2 = _clip(duration=0.25, color=(0, 0, 255))
+
+    try:
+        assert video_processing._safe_transition_duration(clip1, clip2, 1.0) == pytest.approx(0.25)
+    finally:
+        clip1.close()
+        clip2.close()
+
+
+@pytest.mark.parametrize(
+    ("transition_name", "expected_duration"),
+    [
+        ("crossfade", 0.5),
+        ("wipe", 0.5),
+        ("dipToBlack", 0.625),
+    ],
+)
+def test_short_clips_produce_finite_transition(video_processing, transition_name, expected_duration):
+    clip1 = _clip(duration=0.5)
+    clip2 = _clip(duration=0.25, color=(0, 0, 255))
+
+    transition = getattr(video_processing, transition_name)
+    final_clip = transition(clip1, clip2, 1.0)
+
+    try:
+        assert final_clip.duration == pytest.approx(expected_duration)
+        assert final_clip.get_frame(0).shape == (16, 16, 3)
+        assert final_clip.get_frame(final_clip.duration - 0.1).shape == (16, 16, 3)
+    finally:
+        final_clip.close()
+        clip1.close()
+        clip2.close()
+
+
+def test_clip_size_matching_letterboxes_second_clip(video_processing):
+    clip = _clip(size=(8, 16), duration=0.5)
+
+    fitted_clip = video_processing._match_clip_size(clip, (16, 16))
+
+    try:
+        assert fitted_clip.size == (16, 16)
+        assert fitted_clip.duration == pytest.approx(0.5)
+        assert fitted_clip.get_frame(0).shape == (16, 16, 3)
+    finally:
+        fitted_clip.close()
+        clip.close()
+
+
+def test_process_videos_finishes_short_mismatched_transition(
+    video_processing,
+    monkeypatch,
+    tmp_path,
+):
+    first_video = tmp_path / "first.mp4"
+    second_video = tmp_path / "second.mp4"
+    _write_clip(first_video, size=(16, 16), duration=0.5)
+    _write_clip(second_video, size=(8, 16), duration=0.25, color=(0, 0, 255))
+
+    videos_by_uri = {
+        "gs://test/input/first.mp4": first_video.read_bytes(),
+        "gs://test/input/second.mp4": second_video.read_bytes(),
+    }
+    monkeypatch.setattr(
+        video_processing,
+        "download_from_gcs",
+        lambda uri: videos_by_uri[uri],
+    )
+
+    uploaded = {}
+
+    def store_to_gcs(**kwargs):
+        uploaded["contents"] = kwargs["contents"]
+        return "gs://test-bucket/processed/output.mp4"
+
+    monkeypatch.setattr(video_processing, "store_to_gcs", store_to_gcs)
+
+    output_uri = video_processing.process_videos(
+        ["gs://test/input/first.mp4", "gs://test/input/second.mp4"],
+        transition="x-fade",
+        transition_duration=1.0,
+    )
+
+    assert output_uri == "gs://test-bucket/processed/output.mp4"
+    assert len(uploaded["contents"]) > 0


### PR DESCRIPTION
## Summary
- clamp transition durations so they cannot exceed either input clip
- letterbox mismatched clip sizes with MoviePy v2 APIs before applying transitions
- add coverage for short clips, mismatched sizes, and the process_videos path

Fixes #863

## Testing
- python3.14 -m py_compile models/video_processing.py test/test_video_processing_transitions.py
- /tmp/vertex-ai-creative-studio-venv/bin/python -m pytest test/test_video_processing_transitions.py -q
- /tmp/vertex-ai-creative-studio-venv/bin/python -m ruff check models/video_processing.py test/test_video_processing_transitions.py --select F,E9,I