### PR TITLE
Expose Veo location in Terraform

### DIFF
--- a/docs-site/src/content/docs/core/installation/environment_variables.md
+++ b/docs-site/src/content/docs/core/installation/environment_variables.md
@@ -128,6 +128,7 @@ These variables are exposed in `variables.tf` and directly map to environment va
 | `gemini_critique_location` | `GEMINI_CRITIQUE_LOCATION` | `global` |
 | `character_consistency_gemini_location` | `CHARACTER_CONSISTENCY_GEMINI_LOCATION` | `global` |
 | `veo_model_id` | `VEO_MODEL_ID` | `veo-3.1-fast-generate-001` |
+| `veo_location` | `VEO_LOCATION` | `region` |
 | `veo_exp_model_id` | `VEO_EXP_MODEL_ID` | `veo-3.1-generate-001` |
 | `lyria_model_id` | `LYRIA_MODEL_VERSION` | `lyria-002` |
 | `edit_images_enabled` | `EDIT_IMAGES_ENABLED` | `true` |
@@ -150,7 +151,7 @@ These variables are computed within `main.tf` based on the resources Terraform c
 The following variables are **not** explicitly set in the `main.tf` configuration. This means the application will use the **default values defined in `config/default.py`** when deployed via Terraform.
 
 *   **Gemini Models:** `GEMINI_IMAGE_GEN_MODEL`, `GEMINI_IMAGE_GEN_LOCATION`, `GEMINI_AUDIO_ANALYSIS_MODEL_ID`
-*   **Veo:** `DEFAULT_VEO_MODEL_NAME`, `VEO_LOCATION`, `PREVIEW_LOCATION`, `VEO_PROJECT_ID`, `VEO_EXP_FAST_MODEL_ID`, `VEO_EXP_PROJECT_ID`
+*   **Veo:** `DEFAULT_VEO_MODEL_NAME`, `PREVIEW_LOCATION`, `VEO_PROJECT_ID`, `VEO_EXP_FAST_MODEL_ID`, `VEO_EXP_PROJECT_ID`
 *   **VTO (Virtual Try-On):** `VTO_LOCATION`, `VTO_MODEL_ID`, `GENMEDIA_VTO_*` collection names.
 *   **Imagen:** `MODEL_IMAGEN_PRODUCT_RECONTEXT`, `IMAGEN_GENERATED_SUBFOLDER`, `IMAGEN_EDITED_SUBFOLDER`
 *   **App Logic:** `APP_ENV`, `API_BASE_URL`, `GA_MEASUREMENT_ID`, `LIBRARY_MEDIA_PER_PAGE`, `USE_MEDIA_PROXY`

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -145,6 +145,7 @@ These variables are exposed in `variables.tf` and directly map to environment va
 | `gemini_critique_location` | `GEMINI_CRITIQUE_LOCATION` | `global` |
 | `character_consistency_gemini_location` | `CHARACTER_CONSISTENCY_GEMINI_LOCATION` | `global` |
 | `veo_model_id` | `VEO_MODEL_ID` | `veo-3.1-fast-generate-001` |
+| `veo_location` | `VEO_LOCATION` | `region` |
 | `veo_exp_model_id` | `VEO_EXP_MODEL_ID` | `veo-3.1-generate-001` |
 | `lyria_model_id` | `LYRIA_MODEL_VERSION` | `lyria-002` |
 | `edit_images_enabled` | `EDIT_IMAGES_ENABLED` | `true` |
@@ -167,7 +168,7 @@ These variables are computed within `main.tf` based on the resources Terraform c
 The following variables are **not** explicitly set in the `main.tf` configuration. This means the application will use the **default values defined in `config/default.py`** when deployed via Terraform.
 
 *   **Gemini Models:** `GEMINI_IMAGE_GEN_MODEL`, `GEMINI_IMAGE_GEN_LOCATION`, `GEMINI_AUDIO_ANALYSIS_MODEL_ID`
-*   **Veo:** `DEFAULT_VEO_MODEL_NAME`, `VEO_LOCATION`, `PREVIEW_LOCATION`, `VEO_PROJECT_ID`, `VEO_EXP_FAST_MODEL_ID`, `VEO_EXP_PROJECT_ID`
+*   **Veo:** `DEFAULT_VEO_MODEL_NAME`, `PREVIEW_LOCATION`, `VEO_PROJECT_ID`, `VEO_EXP_FAST_MODEL_ID`, `VEO_EXP_PROJECT_ID`
 *   **VTO (Virtual Try-On):** `VTO_LOCATION`, `VTO_MODEL_ID`, `GENMEDIA_VTO_*` collection names.
 *   **Imagen:** `MODEL_IMAGEN_PRODUCT_RECONTEXT`, `IMAGEN_GENERATED_SUBFOLDER`, `IMAGEN_EDITED_SUBFOLDER`
 *   **Interior Design:** `INTERIOR_DESIGN_VIDEO_MODEL`, `INTERIOR_DESIGN_IMAGE_MODEL`, `INTERIOR_DESIGN_VIDEO_DURATION`

--- a/main.tf
+++ b/main.tf
@@ -159,6 +159,7 @@ locals {
     GEMINI_CRITIQUE_LOCATION = var.gemini_critique_location
     CHARACTER_CONSISTENCY_GEMINI_LOCATION = var.character_consistency_gemini_location
     VEO_MODEL_ID          = var.veo_model_id
+    VEO_LOCATION          = coalesce(var.veo_location, var.region)
     VEO_EXP_MODEL_ID      = var.veo_exp_model_id
     LYRIA_MODEL_VERSION   = var.lyria_model_id
     LYRIA_PROJECT_ID      = var.project_id

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "veo_model_id" {
   default     = "veo-3.1-fast-generate-001"
 }
 
+variable "veo_location" {
+  description = "Location for Veo model API calls. Defaults to the deployment region when unset."
+  type        = string
+  default     = null
+}
+
 variable "veo_exp_model_id" {
   description = "Experimental Veo model ID to use for video generation"
   type        = string


### PR DESCRIPTION
## Summary

Adds a Terraform `veo_location` variable and passes it to Cloud Run as `VEO_LOCATION`.

The default behavior stays the same for existing deployments: when `veo_location` is unset, the app uses the deployment `region`. Deployments that need to keep infrastructure in another region can now set only the Veo API location, for example `us-central1`.

Fixes #926.

## Testing

- `git diff --check`
- `python3 -m compileall -q config models services pages test`
- Not run: `terraform fmt -check` because Terraform/OpenTofu is not installed in this environment.
