### PR TITLE
feat: add /healthz and /readyz health probe endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,6 +93,16 @@ async def favicon():
     return FileResponse("assets/favicon.ico")
 
 
+@app.get("/healthz", include_in_schema=False)
+async def healthz():
+    return {"status": "ok"}
+
+
+@app.get("/readyz", include_in_schema=False)
+async def readyz():
+    return {"status": "ok"}
+
+
 # Define allowed origins for CORS
 
 


### PR DESCRIPTION
## Summary

Adds standard `/healthz` and `/readyz` endpoints to the FastAPI application.

## Why

Cloud Run, Kubernetes, and load balancers commonly expect these endpoints for health and readiness probing. Without them, infrastructure must probe the full application root, which is heavier and less reliable.

## Changes

- `main.py`: add `GET /healthz` and `GET /readyz` returning `{"status": "ok"}`

Both endpoints are excluded from the OpenAPI schema (`include_in_schema=False`).

Co-authored-by: Catalin Lupuleti <lupuletic@users.noreply.github.com>