### PR TITLE
feat: add multi-proxy identity support and configurable auth enforcement

### DIFF
--- a/common/auth.py
+++ b/common/auth.py
@@ -11,20 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""FastAPI middleware for request identity and session state."""
 
 import uuid
-from fastapi import Request, Response
+from collections.abc import Awaitable, Callable
+
+from fastapi import Request
+from starlette.responses import Response
+
+from common.identity import ANONYMOUS_USER_EMAIL, get_authenticated_user_email
 from common.storage import get_or_create_session
 
-async def set_user_identity_and_session(request: Request, call_next):
-    """
-    FastAPI middleware to set user identity and session information.
-    """
-    # Get user email from header - assuming IAP
-    user_email = request.headers.get("X-Goog-Authenticated-User-Email")
+
+async def set_user_identity_and_session(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    """Set user identity and session information."""
+    user_email = get_authenticated_user_email(request.headers)
     if not user_email:
-        # Fallback for local development or unauthenticated access
-        user_email = "anonymous@google.com"
+        user_email = ANONYMOUS_USER_EMAIL
 
     # Get or create session ID from cookie
     session_id = request.cookies.get("session_id")
@@ -41,7 +47,11 @@ async def set_user_identity_and_session(request: Request, call_next):
     response = await call_next(request)
 
     # Set session ID cookie on the response
-    response.set_cookie(key="session_id", value=session_id, httponly=True, samesite='Lax')
+    response.set_cookie(
+        key="session_id",
+        value=session_id,
+        httponly=True,
+        samesite="Lax",
+    )
 
     return response
-

--- a/common/identity.py
+++ b/common/identity.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for reading authenticated user identity from trusted proxies."""
+
+import os
+from collections.abc import Mapping
+
+ANONYMOUS_USER_EMAIL = "anonymous@google.com"
+
+DEFAULT_AUTH_EMAIL_HEADERS = (
+    "X-Goog-Authenticated-User-Email",
+    "X-Auth-Request-Email",
+    "X-Forwarded-Email",
+    "X-Email",
+    "X-Authenticated-User",
+)
+
+LOCAL_APP_ENVS = {"", "dev", "development", "local", "test"}
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def auth_email_headers() -> tuple[str, ...]:
+    """Return trusted upstream identity headers, in priority order."""
+    configured_headers = os.environ.get("AUTH_EMAIL_HEADERS")
+    if not configured_headers:
+        return DEFAULT_AUTH_EMAIL_HEADERS
+
+    return tuple(
+        header.strip() for header in configured_headers.split(",") if header.strip()
+    )
+
+
+def normalize_user_email(value: str | None) -> str | None:
+    """Normalize identity-provider email header formats."""
+    if not value:
+        return None
+
+    user_email = value.split(",", maxsplit=1)[0].strip()
+    if not user_email:
+        return None
+
+    for prefix in ("accounts.google.com:", "mailto:", "email:"):
+        if user_email.lower().startswith(prefix):
+            user_email = user_email[len(prefix) :].strip()
+            break
+
+    return user_email or None
+
+
+def get_authenticated_user_email(
+    headers: Mapping[str, str] | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Read the authenticated user email from trusted request metadata."""
+    for header_name in auth_email_headers():
+        if headers:
+            user_email = normalize_user_email(headers.get(header_name))
+            if user_email:
+                return user_email
+
+        if environ:
+            environ_key = f"HTTP_{header_name.upper().replace('-', '_')}"
+            user_email = normalize_user_email(environ.get(environ_key))
+            if user_email:
+                return user_email
+
+    if environ:
+        return normalize_user_email(environ.get("MESOP_USER_EMAIL"))
+
+    return None
+
+
+def require_authenticated_user(app_env: str | None) -> bool:
+    """Return whether requests without upstream identity should be rejected."""
+    configured_value = os.environ.get("REQUIRE_AUTHENTICATED_USER")
+    if configured_value is not None:
+        return configured_value.strip().lower() in TRUE_VALUES
+
+    return (app_env or "") not in LOCAL_APP_ENVS

--- a/config/default.py
+++ b/config/default.py
@@ -20,6 +20,8 @@ from typing import TypedDict
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
+from common.identity import require_authenticated_user
+
 load_dotenv(override=True)
 
 
@@ -58,6 +60,7 @@ class Default:
     BUILD_DATE: str = ""
 
     APP_ENV: str = os.environ.get("APP_ENV", "")
+    REQUIRE_AUTHENTICATED_USER: bool = require_authenticated_user(APP_ENV)
     API_BASE_URL: str = os.environ.get(
         "API_BASE_URL",
         f"http://localhost:{os.environ.get('PORT', '8080')}",

--- a/docs-site/src/content/docs/core/installation/environment_variables.md
+++ b/docs-site/src/content/docs/core/installation/environment_variables.md
@@ -22,6 +22,8 @@ These variables define the fundamental operating context of the application.
 | **`PORT`** | `8080` | The port the application server listens on. |
 | **`SERVICE_ACCOUNT_EMAIL`** | *None* | The email of the service account used for authentication, if applicable. |
 | **`GA_MEASUREMENT_ID`** | *None* | Google Analytics Measurement ID for tracking user interactions. |
+| **`REQUIRE_AUTHENTICATED_USER`** | `true` outside local/dev/test, otherwise `false` | Reject non-health requests that do not include a trusted upstream identity header. Set this to `true` behind Netskope NPA/oauth2-proxy or IAP. |
+| **`AUTH_EMAIL_HEADERS`** | IAP + oauth2-proxy/Netskope defaults | Comma-separated trusted request headers to inspect for the authenticated user email. Defaults: `X-Goog-Authenticated-User-Email`, `X-Auth-Request-Email`, `X-Forwarded-Email`, `X-Email`, `X-Authenticated-User`. |
 
 ## 🧠 Gemini Models (Text & Multimodal)
 Controls which versions of the Gemini models are used for various tasks.
@@ -156,6 +158,7 @@ The following variables are **not** explicitly set in the `main.tf` configuratio
 *   **VTO (Virtual Try-On):** `VTO_LOCATION`, `VTO_MODEL_ID`, `GENMEDIA_VTO_*` collection names.
 *   **Imagen:** `MODEL_IMAGEN_PRODUCT_RECONTEXT`, `IMAGEN_GENERATED_SUBFOLDER`, `IMAGEN_EDITED_SUBFOLDER`
 *   **App Logic:** `APP_ENV`, `API_BASE_URL`, `GA_MEASUREMENT_ID`, `LIBRARY_MEDIA_PER_PAGE`, `USE_MEDIA_PROXY`
+*   **Auth:** `REQUIRE_AUTHENTICATED_USER`, `AUTH_EMAIL_HEADERS`
 *   **Collections:** `GENMEDIA_COLLECTION_NAME`, `SESSIONS_COLLECTION_NAME`
 
 ### 🛠️ How to Deploy with Custom Values

--- a/dotenv.template
+++ b/dotenv.template
@@ -37,6 +37,15 @@ PROJECT_ID=
 # [OPTIONAL] Google Analytics Measurement ID for tracking user interactions.
 # GA_MEASUREMENT_ID=
 
+# [OPTIONAL] Require every non-health request to contain a trusted upstream user header.
+# Default: true outside local/dev/test APP_ENV values, false for local/dev/test.
+# REQUIRE_AUTHENTICATED_USER=true
+
+# [OPTIONAL] Comma-separated trusted headers to read authenticated user email from.
+# Defaults support Google IAP plus oauth2-proxy/Netskope style headers:
+# X-Goog-Authenticated-User-Email,X-Auth-Request-Email,X-Forwarded-Email,X-Email,X-Authenticated-User
+# AUTH_EMAIL_HEADERS=
+
 # ==============================================================================
 # 🧠 Gemini Models (Text & Multimodal)
 # ==============================================================================

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -20,6 +20,8 @@ These variables define the fundamental operating context of the application.
 | **`PORT`** | `8080` | The port the application server listens on. |
 | **`SERVICE_ACCOUNT_EMAIL`** | *None* | The email of the service account used for authentication, if applicable. |
 | **`GA_MEASUREMENT_ID`** | *None* | Google Analytics Measurement ID for tracking user interactions. |
+| **`REQUIRE_AUTHENTICATED_USER`** | `true` outside local/dev/test, otherwise `false` | Reject non-health requests that do not include a trusted upstream identity header. Set this to `true` behind Netskope NPA/oauth2-proxy or IAP. |
+| **`AUTH_EMAIL_HEADERS`** | IAP + oauth2-proxy/Netskope defaults | Comma-separated trusted request headers to inspect for the authenticated user email. Defaults: `X-Goog-Authenticated-User-Email`, `X-Auth-Request-Email`, `X-Forwarded-Email`, `X-Email`, `X-Authenticated-User`. |
 
 ## 🧠 Gemini Models (Text & Multimodal)
 Controls which versions of the Gemini models are used for various tasks.
@@ -175,6 +177,7 @@ The following variables are **not** explicitly set in the `main.tf` configuratio
 *   **Interior Design:** `INTERIOR_DESIGN_VIDEO_MODEL`, `INTERIOR_DESIGN_IMAGE_MODEL`, `INTERIOR_DESIGN_VIDEO_DURATION`
 *   **Object Rotation:** `OBJECT_ROTATION_VIDEO_MODEL`, `OBJECT_ROTATION_IMAGE_MODEL`
 *   **App Logic:** `APP_ENV`, `API_BASE_URL`, `GA_MEASUREMENT_ID`, `LIBRARY_MEDIA_PER_PAGE`, `USE_MEDIA_PROXY`
+*   **Auth:** `REQUIRE_AUTHENTICATED_USER`, `AUTH_EMAIL_HEADERS`
 *   **Collections:** `GENMEDIA_COLLECTION_NAME`, `SESSIONS_COLLECTION_NAME`
 
 ### 🛠️ How to Deploy with Custom Values

--- a/main.py
+++ b/main.py
@@ -24,7 +24,12 @@ from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.middleware.wsgi import WSGIMiddleware
-from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import (
+    FileResponse,
+    JSONResponse,
+    RedirectResponse,
+    StreamingResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from google.auth import impersonated_credentials
 from google.cloud import storage
@@ -32,6 +37,10 @@ from pydantic import BaseModel
 
 import pages.shop_the_look
 from app_factory import app
+from common.identity import (
+    ANONYMOUS_USER_EMAIL,
+    get_authenticated_user_email,
+)
 from common.prompt_template_service import PromptTemplate
 from common.utils import create_display_url
 from routers import veo_router
@@ -83,6 +92,9 @@ class UserInfo(BaseModel):
     agent: str | None
 
 
+PUBLIC_PATH_PREFIXES = ("/healthz", "/readyz", "/favicon.ico")
+
+
 # FastAPI server with Mesop
 router = APIRouter()
 app.include_router(router)
@@ -98,6 +110,7 @@ async def favicon():
 
 from starlette.middleware.base import BaseHTTPMiddleware
 
+
 class ForwardedHostMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         forwarded_host = request.headers.get("X-Forwarded-Host")
@@ -109,14 +122,15 @@ class ForwardedHostMiddleware(BaseHTTPMiddleware):
             ]
         return await call_next(request)
 
+
 app.add_middleware(ForwardedHostMiddleware)
 
-app.add_middleware(
-    TrustedHostMiddleware, allowed_hosts=["*"]
-)
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=["*"])
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex=os.environ.get("CORS_ORIGIN_REGEX", r"https://.*|http://localhost:8080"),
+    allow_origin_regex=os.environ.get(
+        "CORS_ORIGIN_REGEX", r"https://.*|http://localhost:8080"
+    ),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -191,11 +205,19 @@ async def add_global_csp(request: Request, call_next):
 
 @app.middleware("http")
 async def set_request_context(request: Request, call_next):
-    user_email = request.headers.get("X-Goog-Authenticated-User-Email")
+    user_email = get_authenticated_user_email(request.headers)
     if not user_email:
-        user_email = "anonymous@google.com"
-    if user_email.startswith("accounts.google.com:"):
-        user_email = user_email.split(":")[-1]
+        user_email = ANONYMOUS_USER_EMAIL
+
+    if (
+        config.Default.REQUIRE_AUTHENTICATED_USER
+        and user_email == ANONYMOUS_USER_EMAIL
+        and not request.url.path.startswith(PUBLIC_PATH_PREFIXES)
+    ):
+        return JSONResponse(
+            {"detail": "Authentication required"},
+            status_code=401,
+        )
 
     session_id = request.cookies.get("session_id")
     if not session_id:
@@ -233,9 +255,6 @@ me.page(path="/test_vto_prompt_generator", title="Test VTO Prompt Generator")(
 me.page(path="/test_svg", title="Test SVG")(test_svg_page)
 me.page(path="/test_media_chooser", title="Test Media Chooser")(test_media_chooser_page)
 me.page(path="/test_async_veo", title="Test Async Veo")(test_async_veo_page)
-
-
-
 
 
 # Add a new endpoint to proxy GCS media for better caching.

--- a/state/state.py
+++ b/state/state.py
@@ -15,6 +15,11 @@
 import mesop as me
 from flask import request
 
+from common.identity import (
+    ANONYMOUS_USER_EMAIL,
+    get_authenticated_user_email,
+)
+
 
 @me.stateclass
 class AppState:
@@ -28,10 +33,11 @@ class AppState:
 
     def __init__(self):
         """Initializes the AppState, reading user info from the request context."""
-        if "HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL" in request.environ:
-            user_email = request.environ["HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL"]
-            if user_email.startswith("accounts.google.com:"):
-                user_email = user_email.split(":")[-1]
+        user_email = get_authenticated_user_email(
+            headers=request.headers,
+            environ=request.environ,
+        )
+        if user_email:
             self.user_email = user_email
             self.session_id = request.environ.get("MESOP_SESSION_ID", "")
         elif "MESOP_USER_EMAIL" in request.environ:
@@ -81,11 +87,13 @@ def toggle_theme(event: me.ClickEvent):
 
     yield
 
+
 def get_app_state() -> AppState:
     """-
     Returns the current application state.
     """
     return me.state(AppState)
+
 
 def get_user_email() -> str:
     """
@@ -93,11 +101,13 @@ def get_user_email() -> str:
     """
     return me.state(AppState).user_email
 
+
 def get_session_id() -> str:
     """
     Returns the current session ID.
     """
     return me.state(AppState).session_id
+
 
 def is_sidenav_open() -> bool:
     """
@@ -105,11 +115,13 @@ def is_sidenav_open() -> bool:
     """
     return me.state(AppState).sidenav_open
 
+
 def set_sidenav_open(is_open: bool):
     """
     Sets the sidenav open state.
     """
     me.state(AppState).sidenav_open = is_open
+
 
 def toggle_sidenav():
     """
@@ -118,11 +130,13 @@ def toggle_sidenav():
     me.state(AppState).sidenav_open = not me.state(AppState).sidenav_open
     yield
 
+
 def get_theme_mode() -> str:
     """
     Returns the current theme mode.
     """
     return me.state(AppState).theme_mode
+
 
 def set_theme_mode(mode: str):
     """
@@ -131,12 +145,14 @@ def set_theme_mode(mode: str):
     me.state(AppState).theme_mode = mode
     yield
 
+
 def get_user_and_session_info() -> tuple[str, str]:
     """
     Returns the current user's email and session ID.
     """
     app_state = me.state(AppState)
     return app_state.user_email, app_state.session_id
+
 
 def update_user_and_session_info(user_email: str, session_id: str):
     """
@@ -147,11 +163,13 @@ def update_user_and_session_info(user_email: str, session_id: str):
     app_state.session_id = session_id
     yield
 
+
 def is_logged_in() -> bool:
     """
     Returns whether the user is logged in.
     """
     return me.state(AppState).user_email != "anonymous@google.com"
+
 
 def get_current_user_id() -> str:
     """
@@ -159,11 +177,13 @@ def get_current_user_id() -> str:
     """
     return me.state(AppState).user_email
 
+
 def get_current_session_id() -> str:
     """
     Returns the current session ID.
     """
     return me.state(AppState).session_id
+
 
 def set_current_user_id(user_id: str):
     """
@@ -172,12 +192,14 @@ def set_current_user_id(user_id: str):
     me.state(AppState).user_email = user_id
     yield
 
+
 def set_current_session_id(session_id: str):
     """
     Sets the current session ID.
     """
     me.state(AppState).session_id = session_id
     yield
+
 
 def reset_app_state():
     """
@@ -186,9 +208,10 @@ def reset_app_state():
     app_state = me.state(AppState)
     app_state.sidenav_open = False
     app_state.theme_mode = "light"
-    app_state.user_email = "anonymous@google.com"
+    app_state.user_email = ANONYMOUS_USER_EMAIL
     app_state.session_id = ""
     yield
+
 
 def initialize_app_state():
     """
@@ -197,11 +220,13 @@ def initialize_app_state():
     reset_app_state()
     yield
 
+
 def get_state():
     """
     Returns the current application state.
     """
     return me.state(AppState)
+
 
 def update_state(new_state: AppState):
     """

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for trusted proxy identity helpers."""
+
+# ruff: noqa: D103, S101
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.identity import (
+    ANONYMOUS_USER_EMAIL,
+    auth_email_headers,
+    get_authenticated_user_email,
+    normalize_user_email,
+    require_authenticated_user,
+)
+
+
+def test_normalize_iap_email_prefix() -> None:
+    assert (
+        normalize_user_email("accounts.google.com:test.user@example.com")
+        == "test.user@example.com"
+    )
+
+
+def test_uses_iap_header_before_proxy_headers() -> None:
+    headers = {
+        "X-Goog-Authenticated-User-Email": "accounts.google.com:iap@example.com",
+        "X-Auth-Request-Email": "oauth@example.com",
+    }
+
+    assert get_authenticated_user_email(headers=headers) == "iap@example.com"
+
+
+def test_uses_oauth2_proxy_email_header() -> None:
+    headers = {"X-Auth-Request-Email": "oauth@example.com"}
+
+    assert get_authenticated_user_email(headers=headers) == "oauth@example.com"
+
+
+def test_uses_netskope_authenticated_user_header() -> None:
+    headers = {"X-Authenticated-User": "netskope@example.com"}
+
+    assert get_authenticated_user_email(headers=headers) == "netskope@example.com"
+
+
+def test_reads_wsgi_environ_header() -> None:
+    environ = {"HTTP_X_FORWARDED_EMAIL": "forwarded@example.com"}
+
+    assert get_authenticated_user_email(environ=environ) == "forwarded@example.com"
+
+
+def test_custom_auth_email_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_EMAIL_HEADERS", "X-Custom-Email")
+
+    assert auth_email_headers() == ("X-Custom-Email",)
+    assert (
+        get_authenticated_user_email(headers={"X-Custom-Email": "custom@example.com"})
+        == "custom@example.com"
+    )
+
+
+def test_require_authenticated_user_is_false_for_local_envs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REQUIRE_AUTHENTICATED_USER", raising=False)
+
+    assert not require_authenticated_user("local")
+    assert not require_authenticated_user("")
+
+
+def test_require_authenticated_user_is_true_for_prod_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REQUIRE_AUTHENTICATED_USER", raising=False)
+
+    assert require_authenticated_user("prod")
+
+
+def test_require_authenticated_user_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REQUIRE_AUTHENTICATED_USER", "false")
+
+    assert not require_authenticated_user("prod")
+
+    monkeypatch.setenv("REQUIRE_AUTHENTICATED_USER", "true")
+
+    assert require_authenticated_user("")
+
+
+def test_anonymous_user_constant_matches_existing_default() -> None:
+    assert ANONYMOUS_USER_EMAIL == "anonymous@google.com"


### PR DESCRIPTION
## Summary

Adds `common/identity.py` — a new module for reading authenticated user identity from trusted upstream proxy headers — and wires it into the application middleware.

## Why

The app currently only reads `X-Goog-Authenticated-User-Email` (Google IAP). Users deploying behind other proxies (oauth2-proxy, Netskope NPA, nginx auth) use different header conventions and cannot authenticate correctly today.

## Changes

**`common/identity.py`** (new)
- `get_authenticated_user_email()`: reads from multiple trusted headers in priority order
- Configurable via `AUTH_EMAIL_HEADERS` env var (comma-separated list)
- Default headers: `X-Goog-Authenticated-User-Email`, `X-Auth-Request-Email`, `X-Forwarded-Email`, `X-Email`, `X-Authenticated-User`
- Handles IAP prefix stripping (`accounts.google.com:`, `mailto:`, `email:`)

**`common/auth.py`** — updated to use `get_authenticated_user_email()`

**`config/default.py`** — adds `REQUIRE_AUTHENTICATED_USER` (default: `true` outside local/dev/test environments)

**`main.py`** — middleware updated to use identity module; unauthenticated requests return 401 when `REQUIRE_AUTHENTICATED_USER` is true, exempting `/healthz`, `/readyz`, and `/favicon.ico`

**Docs** — `AUTH_EMAIL_HEADERS` and `REQUIRE_AUTHENTICATED_USER` added to `dotenv.template` and environment variable docs

**`test/test_identity.py`** (new) — unit tests for the identity module

## Backwards Compatibility

Existing IAP deployments are unaffected: `X-Goog-Authenticated-User-Email` remains the highest-priority header. Local development (`APP_ENV=dev` or empty) is unaffected: `REQUIRE_AUTHENTICATED_USER` defaults to `false`.

Co-authored-by: Catalin Lupuleti <lupuletic@users.noreply.github.com>