### PR TITLE
fix(veo): eliminate 401 errors in async job polling

### DIFF
--- a/common/veo_utils.py
+++ b/common/veo_utils.py
@@ -11,25 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Utilities for interacting with Veo services from Mesop pages."""
 
 import logging
-import requests
+import threading
+
 from common.analytics import track_model_call
 from config.default import Default
 from config.veo_models import get_veo_model_config
 from models.requests import VideoGenerationRequest
+from services.veo_service import create_initial_job, process_veo_generation_task
 
 logger = logging.getLogger(__name__)
 config = Default()
 
+
 def start_async_veo_job(
-    request: VideoGenerationRequest,
-    user_email: str,
-    mode: str = "t2v"
+    request: VideoGenerationRequest, user_email: str, mode: str = "t2v"
 ) -> dict:
-    """
-    Initiates an asynchronous Veo generation job via the API.
-    Handles analytics logging and API error checking.
+    """Initiates an asynchronous Veo generation job by calling the service directly.
 
     Args:
         request: The generation request object.
@@ -37,17 +37,13 @@ def start_async_veo_job(
         mode: The operation mode (e.g., 't2v', 'i2v', 'extension').
 
     Returns:
-        A dictionary containing the job response (e.g., {'job_id': '...', 'status': '...'}).
-
-    Raises:
-        Exception: If the API call fails.
+        A dictionary containing the job response: {'job_id': '...', 'status': '...'}.
     """
-    api_url = f"{config.API_BASE_URL}/api/veo/generate_async"
-    headers = {"X-Goog-Authenticated-User-Email": user_email}
-    
     # Determine model name for analytics
     model_config = get_veo_model_config(request.model_version_id)
-    model_name_for_analytics = model_config.model_name if model_config else request.model_version_id
+    model_name_for_analytics = (
+        model_config.model_name if model_config else request.model_version_id
+    )
 
     try:
         with track_model_call(
@@ -58,12 +54,20 @@ def start_async_veo_job(
             video_count=request.video_count,
             mode=mode,
         ):
-            request_json = request.model_dump()
-            logger.info(f"Starting Veo Job. Request: {request_json}")
-            response = requests.post(api_url, json=request_json, headers=headers)
-            response.raise_for_status()
-            return response.json()
-            
-    except Exception as e:
-        logger.error(f"Failed to start Veo job: {e}")
-        raise e
+            # 1. Create the job record in Firestore immediately
+            job_id = create_initial_job(request, user_email)
+
+            # 2. Start the background generation task in a separate thread.
+            # This mimics the behavior of FastAPI's BackgroundTasks but works
+            # directly within the Mesop process without an HTTP call.
+            threading.Thread(
+                target=process_veo_generation_task,
+                args=(job_id, request, user_email),
+                daemon=True,
+            ).start()
+
+            return {"job_id": job_id, "status": "pending"}
+
+    except Exception:
+        logger.exception(f"Failed to start Veo job for user {user_email}")
+        raise

--- a/components/veo/extend_dialog.py
+++ b/components/veo/extend_dialog.py
@@ -17,9 +17,9 @@ from dataclasses import dataclass, field
 from typing import Callable
 
 import mesop as me
-import requests
 
 from common.analytics import log_ui_click
+from common.metadata import get_media_item_by_id
 from common.utils import create_display_url
 from common.veo_utils import start_async_veo_job
 from components.dialog import dialog, dialog_actions
@@ -292,26 +292,25 @@ def on_extend_click(e: me.ClickEvent):
     while state.job_status in ["pending", "processing", "created"]:
         time.sleep(2)
         try:
-            status_url = f"{config.API_BASE_URL}/api/veo/job/{state.job_id}"
-            resp = requests.get(status_url)
-            resp.raise_for_status()
-            status_data = resp.json()
-            state.job_status = status_data["status"]
+            item = get_media_item_by_id(state.job_id)
+            if not item:
+                state.is_loading = False
+                state.error_message = f"Job {state.job_id} not found."
+                yield
+                break
+            
+            state.job_status = item.status
 
             if state.job_status == "complete":
                 state.generated_video_uri = (
-                    status_data.get("video_uri") or status_data.get("video_uris")[0]
+                    item.gcsuri or (item.gcs_uris[0] if item.gcs_uris else "")
                 )
                 state.is_loading = False
                 yield
-                # Trigger a library refresh?
-                # We can't easily trigger the parent's refresh from here without a callback mechanism
-                # that Mesop doesn't fully support across modules easily.
-                # The user will see the success screen and click close.
                 break
             elif state.job_status == "failed":
                 state.is_loading = False
-                state.error_message = status_data.get("error_message", "Unknown error")
+                state.error_message = item.error_message or "Unknown error"
                 yield
                 break
 

--- a/pages/veo.py
+++ b/pages/veo.py
@@ -17,15 +17,18 @@ import datetime  # Required for timestamp
 import json
 import time
 
-import requests
-
 import mesop as me
 
 from common.analytics import log_ui_click, track_click, track_model_call
 from common.error_handling import AsyncVeoPollingFailedError, GenerationError
-from common.metadata import MediaItem, add_media_item_to_firestore
+from common.metadata import (
+    MediaItem,
+    add_media_item_to_firestore,
+    get_media_item_by_id,
+)
 from common.storage import store_to_gcs
 from common.utils import create_display_url, get_image_dimensions_from_base64
+from common.veo_utils import start_async_veo_job
 from components.dialog import dialog, dialog_actions
 from components.header import header
 from components.library.events import LibrarySelectionChangeEvent
@@ -42,7 +45,6 @@ from models.model_setup import VeoModelSetup
 from models.veo import APIReferenceImage, VideoGenerationRequest, generate_video
 from state.state import AppState
 from state.veo_state import PageState
-from config.veo_models import get_veo_model_config, DEFAULT_VEO_VERSION_ID
 
 config = Default()
 
@@ -60,7 +62,7 @@ def on_veo_load(e: me.LoadEvent):
 
     if image_path:
         # When an image is passed, default to the i2v mode and Veo 3.1 Fast model.
-        _update_state_for_new_model(DEFAULT_VEO_VERSION_ID)
+        _update_state_for_new_model("3.1-fast")
 
         image_uri = ""
         if image_path.startswith("https://"):
@@ -368,7 +370,7 @@ def on_click_extend_video(e: me.ClickEvent):
         model_version_id=state.veo_model,
         aspect_ratio=state.aspect_ratio,
         resolution=state.resolution,
-        duration_seconds=state.video_extend_length if state.video_extend_length != 0 else (model_config.supported_extension_durations[0] if model_config.supported_extension_durations else 7), # Use extension length or default
+        duration_seconds=state.video_extend_length, # Use extension length
         video_count=state.video_count,
         enhance_prompt=state.auto_enhance_prompt,
         generate_audio=state.generate_audio,
@@ -379,21 +381,7 @@ def on_click_extend_video(e: me.ClickEvent):
 
     # --- 1. Initiate Async Job ---
     try:
-        api_url = f"{config.API_BASE_URL}/api/veo/generate_async"
-        headers = {"X-Goog-Authenticated-User-Email": app_state.user_email}
-        
-        # Log analytics
-        with track_model_call(
-            model_name=model_config.model_name,
-            prompt_length=len(request.prompt) if request.prompt else 0,
-            duration_seconds=request.duration_seconds,
-            aspect_ratio=request.aspect_ratio,
-            video_count=request.video_count,
-            mode="extension", 
-        ):
-            response = requests.post(api_url, json=request.model_dump(), headers=headers)
-            response.raise_for_status()
-            data = response.json()
+        data = start_async_veo_job(request, app_state.user_email, mode="extension")
             
         state.current_job_id = data["job_id"]
         state.job_status = data["status"]
@@ -409,17 +397,17 @@ def on_click_extend_video(e: me.ClickEvent):
     while state.job_status in ["pending", "processing", "created"]:
         time.sleep(2) 
         try:
-            status_url = f"{config.API_BASE_URL}/api/veo/job/{state.current_job_id}"
-            resp = requests.get(status_url)
-            resp.raise_for_status()
-            status_data = resp.json()
-            state.job_status = status_data["status"]
+            item = get_media_item_by_id(state.current_job_id)
+            if not item:
+                raise AsyncVeoPollingFailedError(f"Job {state.current_job_id} not found in Firestore.")
+            
+            state.job_status = item.status
 
             if state.job_status == "complete":
                 # Success! Update state with results.
-                state.result_gcs_uris = status_data.get("video_uris", [])
-                if not state.result_gcs_uris and status_data.get("video_uri"):
-                     state.result_gcs_uris = [status_data["video_uri"]]
+                state.result_gcs_uris = item.gcs_uris or []
+                if not state.result_gcs_uris and item.gcsuri:
+                     state.result_gcs_uris = [item.gcsuri]
                 
                 state.result_display_urls = [create_display_url(uri) for uri in state.result_gcs_uris]
                 if state.result_display_urls:
@@ -433,7 +421,7 @@ def on_click_extend_video(e: me.ClickEvent):
                 break
 
             elif state.job_status == "failed":
-                state.error_message = status_data.get("error_message", "Unknown error during extension.")
+                state.error_message = item.error_message or "Unknown error during extension."
                 state.show_error_dialog = True
                 state.is_loading = False
                 yield
@@ -474,7 +462,7 @@ def on_click_clear(e: me.ClickEvent):  # pylint: disable=unused-argument
     state.veo_prompt_input = None
     state.original_prompt = None
     state.veo_prompt_textarea_key += 1
-    state.veo_model = DEFAULT_VEO_VERSION_ID
+    state.veo_model = "3.1-fast"
     # Get default duration for the reset model
     model_config = get_veo_model_config(state.veo_model)
     state.video_length = model_config.default_duration if model_config else 8
@@ -582,23 +570,7 @@ def on_click_veo(e: me.ClickEvent):  # pylint: disable=unused-argument
 
     # --- 1. Initiate Async Job ---
     try:
-        api_url = f"{config.API_BASE_URL}/api/veo/generate_async"
-        headers = {"X-Goog-Authenticated-User-Email": app_state.user_email}
-        
-        # Log the initial click/attempt
-        model_name_for_analytics = get_veo_model_config(request.model_version_id).model_name
-        
-        with track_model_call(
-            model_name=model_name_for_analytics,
-            prompt_length=len(request.prompt) if request.prompt else 0,
-            duration_seconds=request.duration_seconds,
-            aspect_ratio=request.aspect_ratio,
-            video_count=request.video_count,
-            mode=state.veo_mode,
-        ):
-            response = requests.post(api_url, json=request.model_dump(), headers=headers)
-            response.raise_for_status()
-            data = response.json()
+        data = start_async_veo_job(request, app_state.user_email, mode=state.veo_mode)
             
         state.current_job_id = data["job_id"]
         state.job_status = data["status"]
@@ -617,18 +589,18 @@ def on_click_veo(e: me.ClickEvent):  # pylint: disable=unused-argument
     while state.job_status in ["pending", "processing", "created"]:
         time.sleep(2) 
         try:
-            status_url = f"{config.API_BASE_URL}/api/veo/job/{state.current_job_id}"
-            resp = requests.get(status_url)
-            resp.raise_for_status()
-            status_data = resp.json()
-            state.job_status = status_data["status"]
+            item = get_media_item_by_id(state.current_job_id)
+            if not item:
+                raise AsyncVeoPollingFailedError(f"Job {state.current_job_id} not found in Firestore.")
+            
+            state.job_status = item.status
 
             if state.job_status == "complete":
                 # Success! Update state with results.
-                state.result_gcs_uris = status_data.get("video_uris", [])
+                state.result_gcs_uris = item.gcs_uris or []
                 # If only one URI is returned but we expected a list, handle it.
-                if not state.result_gcs_uris and status_data.get("video_uri"):
-                     state.result_gcs_uris = [status_data["video_uri"]]
+                if not state.result_gcs_uris and item.gcsuri:
+                     state.result_gcs_uris = [item.gcsuri]
                 
                 state.result_display_urls = [create_display_url(uri) for uri in state.result_gcs_uris]
                 if state.result_display_urls:
@@ -643,7 +615,7 @@ def on_click_veo(e: me.ClickEvent):  # pylint: disable=unused-argument
 
             elif state.job_status == "failed":
                 # Failure. Show error.
-                state.error_message = status_data.get("error_message", "Unknown error during generation.")
+                state.error_message = item.error_message or "Unknown error during generation."
                 state.show_error_dialog = True
                 state.is_loading = False
                 yield


### PR DESCRIPTION
## Problem

Mesop pages initiate and poll Veo jobs by calling the app's *own* `/api/veo/*` endpoints via `requests.post`/`requests.get`, manually setting an `X-Goog-Authenticated-User-Email` header:

```python
api_url = f"{config.API_BASE_URL}/api/veo/generate_async"
headers = {"X-Goog-Authenticated-User-Email": app_state.user_email}
response = requests.post(api_url, json=request.model_dump(), headers=headers)
```

Behind a Load Balancer + IAP, this fails with **401 Unauthorized** — the IAP header cannot be spoofed on an internal call, and the request never carries a valid IAP credential.

## Fix

Replace the internal HTTP round-trips with direct service / Firestore calls:

- `start_async_veo_job()` now calls `create_initial_job` + `process_veo_generation_task` directly (via a background thread) instead of POSTing to its own API
- Job polling reads status from Firestore via `get_media_item_by_id()` instead of `GET /api/veo/job/{id}`
- The same fix is applied to the Veo extend dialog (`components/veo/extend_dialog.py`), which had the identical self-referential polling pattern

This removes the self-referential HTTP calls entirely, eliminating the 401s and reducing latency.

## Scope

One focused piece extracted from #1062. Touches `pages/veo.py`, `common/veo_utils.py`, and `components/veo/extend_dialog.py`.

Co-authored-by: rootto <rootto@users.noreply.github.com>