### PR TITLE
perf(media): optimize GCS proxy to avoid event-loop blocking

### DIFF
--- a/main.py
+++ b/main.py
@@ -267,9 +267,20 @@ me.page(path="/test_media_chooser", title="Test Media Chooser")(test_media_choos
 me.page(path="/test_async_veo", title="Test Async Veo")(test_async_veo_page)
 
 
+# Global storage client instance to reuse connections
+_proxy_storage_client = None
+
+
+def get_proxy_storage_client():
+    global _proxy_storage_client
+    if _proxy_storage_client is None:
+        _proxy_storage_client = storage.Client()
+    return _proxy_storage_client
+
+
 # Add a new endpoint to proxy GCS media for better caching.
 @app.get("/media/{bucket_name}/{object_path:path}")
-async def get_media_proxy(request: Request, bucket_name: str, object_path: str):
+def get_media_proxy(request: Request, bucket_name: str, object_path: str):
     """Securely proxies a GCS object, checking for IAP authentication."""
     user_email = request.scope.get("MESOP_USER_EMAIL")
     app_env = config.Default().APP_ENV
@@ -282,7 +293,7 @@ async def get_media_proxy(request: Request, bucket_name: str, object_path: str):
         raise HTTPException(status_code=401, detail="Authentication required")
 
     try:
-        storage_client = storage.Client()
+        storage_client = get_proxy_storage_client()
         bucket = storage_client.bucket(bucket_name)
         blob = bucket.blob(object_path)
 
@@ -299,6 +310,8 @@ async def get_media_proxy(request: Request, bucket_name: str, object_path: str):
         stream = blob.open("rb")
         return StreamingResponse(stream, media_type=content_type, headers=headers)
 
+    except HTTPException:
+        raise
     except Exception as e:
         print(f"Error proxying GCS object: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")


### PR DESCRIPTION
## Summary

Three small but impactful optimizations to the `/media/{bucket}/{object}` GCS proxy endpoint, extracted from #1062.

## Changes

1. **Reuse the storage client.** The handler constructed a new `storage.Client()` on every request. Now a single module-level client is reused across requests, avoiding repeated connection/auth setup.

2. **Make the handler synchronous.** The endpoint was `async def` but performs blocking GCS I/O (`blob.open("rb")` + streaming). Under load this blocks the event loop and stalls all other requests. Making it a regular `def` lets FastAPI run it in a threadpool, keeping the event loop responsive.

3. **Stop swallowing HTTPExceptions.** The generic `except Exception` was catching the 404 `HTTPException` and re-raising it as a 500. Adding `except HTTPException: raise` before the generic handler preserves correct status codes.

## Scope

Touches only `main.py`. One focused piece from #1062.

Co-authored-by: rootto <rootto@users.noreply.github.com>