### PR TITLE
refactor(utils): add centralized get_media_type helper

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -163,3 +163,25 @@ def https_url_to_gcs_uri(url: str | None) -> str:
 
     # If it's not a recognized GCS URL, return the original input as a fallback.
     return url
+
+
+def get_media_type(mime_type: str | None = None, url: str | None = None) -> str:
+    """Determines the media type (image, video, audio) based on mime_type or URL."""
+    if mime_type:
+        if mime_type.startswith("video/"):
+            return "video"
+        if mime_type.startswith("image/"):
+            return "image"
+        if mime_type.startswith("audio/"):
+            return "audio"
+
+    if url:
+        url_lower = url.lower()
+        if any(ext in url_lower for ext in [".mp4", ".webm", ".mov"]):
+            return "video"
+        if any(ext in url_lower for ext in [".png", ".jpg", ".jpeg", ".webp", ".gif"]):
+            return "image"
+        if any(ext in url_lower for ext in [".wav", ".mp3", ".ogg"]):
+            return "audio"
+
+    return "image"  # Default fallback


### PR DESCRIPTION
## Summary

Adds a `get_media_type(mime_type, url)` helper to `common/utils.py` that classifies a media asset as `image`, `video`, or `audio` based on its MIME type or URL extension.

## Why

Media-type classification is currently done ad-hoc in multiple places. Centralizing it gives consistent rendering decisions and a single place to extend supported formats. This is an enabling refactor for the modernized library work (the remaining pieces of #1062).

## Scope

Additive only — one new function in `common/utils.py`, no existing behavior changed.

Co-authored-by: rootto <rootto@users.noreply.github.com>