### PR TITLE
docs: rebrand 'Vertex AI' to 'Google Cloud AI' in docs-site

### DIFF
--- a/docs-site/src/content/docs/core/index.md
+++ b/docs-site/src/content/docs/core/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GenMedia Creative Studio | Vertex AI"
+title: "GenMedia Creative Studio | Google Cloud AI"
 ---
 
 > ###### _This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security). This project is intended for demonstration purposes only. It is not intended for use in a production environment._
@@ -10,7 +10,7 @@ title: "GenMedia Creative Studio | Vertex AI"
 
 ## Table of Contents
 
-- [GenMedia Creative Studio | Vertex AI](#genmedia-creative-studio--vertex-ai)
+- [GenMedia Creative Studio | Google Cloud AI](#genmedia-creative-studio--google-cloud-ai)
 - [Table of Contents](#table-of-contents)
 - [GenMedia Creative Studio](#genmedia-creative-studio)
   - [Experiments](#experiments)

--- a/docs-site/src/content/docs/core/installation/cost_tracking.md
+++ b/docs-site/src/content/docs/core/installation/cost_tracking.md
@@ -68,7 +68,7 @@ ORDER BY
   estimated_cost_usd DESC;
 ```
 
-> **Note:** Pricing changes over time. Always refer to the official [Vertex AI Pricing Page](https://cloud.google.com/vertex-ai/pricing) to update your correlation multipliers.
+> **Note:** Pricing changes over time. Always refer to the official [Google Cloud AI Pricing Page](https://cloud.google.com/vertex-ai/pricing) to update your correlation multipliers.
 
 ## 4. A Note on Historical Logs
 

--- a/docs-site/src/content/docs/core/installation/environment_variables.md
+++ b/docs-site/src/content/docs/core/installation/environment_variables.md
@@ -14,8 +14,8 @@ These variables define the fundamental operating context of the application.
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
-| **`PROJECT_ID`** | *None* (Required) | The Google Cloud Project ID where resources (Vertex AI, Firestore, Storage) are located. |
-| **`LOCATION`** | `us-central1` | The default GCP region for most services (Vertex AI, etc.). |
+| **`PROJECT_ID`** | *None* (Required) | The Google Cloud Project ID where resources (Google Cloud AI, Firestore, Storage) are located. |
+| **`LOCATION`** | `us-central1` | The default GCP region for most services (Google Cloud AI, etc.). |
 | **`APP_ENV`** | `""` (Empty) | Defines the environment name (e.g., `dev`, `godemos`). This is used as a metadata tag on the Config page. |
 | **`GMCS_OVERRIDE_PATH`** | *None* | **(Development Only)** An absolute path to a directory containing configuration overrides. If a file exists in this path (e.g., `config/about_content.json`), the app will prioritize it over the local version. |
 | **`API_BASE_URL`** | `http://localhost:{PORT}` | The base URL for the application's backend APIs. |

--- a/docs-site/src/content/docs/experiments/Imagen_Product_Recontext/index.md
+++ b/docs-site/src/content/docs/experiments/Imagen_Product_Recontext/index.md
@@ -32,7 +32,7 @@ This repository contains Jupyter notebooks and tools to perform large-scale prod
 
 - Python 3.8+
 - Jupyter or VSCode
-- Google Cloud Vertex AI and access to Imagen Product Recontext API
+- Google Cloud AI and access to Imagen Product Recontext API
 - Required Python libraries are listed in `requirements.txt`.
 
 ### Installation

--- a/docs-site/src/content/docs/experiments/VTO/index.md
+++ b/docs-site/src/content/docs/experiments/VTO/index.md
@@ -15,7 +15,7 @@ The solution leverages **Google Cloud Vertex AI Prediction API** and a pre-train
 
 - Upload and preprocess a person image.
 - Load and encode multiple product images.
-- Make predictions using a hosted Google Vertex AI model.
+- Make predictions using a hosted Google Cloud AI model.
 - Display all try-on results in a side-by-side comparison layout.
 - Time and display each try-on result using concurrent processing for faster inference.
 
@@ -34,7 +34,7 @@ The solution leverages **Google Cloud Vertex AI Prediction API** and a pre-train
 - Python
 - Jupyter Notebook
 - PIL (Python Imaging Library)
-- Google Cloud Vertex AI
+- Google Cloud AI
 - Base64 encoding
 - `concurrent.futures` for parallel inference
 

--- a/docs-site/src/content/docs/experiments/brand_consistency/index.md
+++ b/docs-site/src/content/docs/experiments/brand_consistency/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Brand Consistency with Gemini & Vertex AI"
+title: "Brand Consistency with Gemini & Google Cloud AI"
 ---
 
 This repository contains two case study notebooks demonstrating how to build automated brand compliance pipelines for generative AI content. As detailed in the accompanying blog post, these examples tackle the challenge of "hallucinated styles" by using Gemini's multimodal capabilities to act as an automated creative director.
@@ -28,7 +28,7 @@ This notebook demonstrates:
 
 ### 2. [Video Generation Case Study]([Blogpost]_Case_Study_2_Cymber_Coffee_Video_Generation_py.ipynb)
 **Focus:** Temporal Consistency
-**Model:** Veo (via Vertex AI)
+**Model:** Veo (via Google Cloud AI)
 
 This notebook extends the concept to video generation:
 *   **Frame Sampling:** Extracting keyframes across the video's duration.
@@ -40,4 +40,4 @@ This notebook extends the concept to video generation:
 *   **SDK:** `google-genai`
 *   **Authentication:** 
     *   Image Generation: Google AI Studio API Key
-    *   Video Generation: Google Cloud Project (Vertex AI) authentication
+    *   Video Generation: Google Cloud Project (Google Cloud AI) authentication

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/agents/adk.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/agents/adk.md
@@ -2,7 +2,7 @@
 title: "ADK sample"
 ---
 
-This directory contains a Google Cloud Vertex AI Agent Development Kit sample agent that uses the MCP genmedia tools.
+This directory contains a Google Cloud AI Agent Development Kit sample agent that uses the MCP genmedia tools.
 
 ## Prerequisites
 

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/agents/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/agents/index.md
@@ -4,7 +4,7 @@ title: "Sample Agents that use the Genmedia MCP Tools"
 
 This directory contains sample agents which use the Genmedia MCP tools.
 
-* Google Cloud Vertex AI's Agent Development Kit (adk)
+* Google Cloud AI Agent Development Kit (adk)
 * Google Firebase Genkit (genkit)
 * Google Gemini CLI (geminicli)
 * Google Antigravity (antigravity)

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/host-on-cloud-run.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/host-on-cloud-run.md
@@ -100,7 +100,7 @@ This Dockerfile uses multi-stage builds to produce light-weight production image
 
 ### Option A: Using the Automated Deployment Script (Preferred / Convenience Method)
 
-For the quickest and most convenient deployment experience, use the interactive helper script. This automates the entire flow—verifying/creating the registry repository, executing the container build, deploying to Cloud Run, injecting required project environment variables, and configuring the necessary Vertex AI and GCS IAM role bindings in one command.
+For the quickest and most convenient deployment experience, use the interactive helper script. This automates the entire flow—verifying/creating the registry repository, executing the container build, deploying to Cloud Run, injecting required project environment variables, and configuring the necessary Google Cloud AI and GCS IAM role bindings in one command.
 
 Run the script from the root of the Go MCP workspace (`experiments/mcp-genmedia/mcp-genmedia-go/`) and follow the prompts:
 ```bash
@@ -141,7 +141,7 @@ gcloud builds submit . \
 ```
 
 ##### Step 3: Deploy the Custom Image to Cloud Run
-Deploy the newly built container image to a Cloud Run service. You **must** set the `GOOGLE_CLOUD_PROJECT` environment variable on the container so it can locate Vertex AI resources:
+Deploy the newly built container image to a Cloud Run service. You **must** set the `GOOGLE_CLOUD_PROJECT` environment variable on the container so it can locate Google Cloud AI resources:
 
 ```bash
 gcloud run deploy ${SERVER_NAME} \

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
@@ -47,7 +47,7 @@ The tool utilizes the following environment variables:
 
 *   `GOOGLE_CLOUD_PROJECT` (string): **Required**. Your Google Cloud Project ID.
     *   **Override**: You can override this globally for this specific server by setting `GEMINI_PROJECT_ID`.
-*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Vertex AI services.
+*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Google Cloud AI services.
     *   Default: `"us-central1"`
     *   **Fallback**: `LOCATION` is also supported as a fallback for `GOOGLE_CLOUD_LOCATION`.
     *   **Override**: You can override this globally for this specific server by setting `GEMINI_LOCATION`.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-imagen-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-imagen-go/index.md
@@ -2,7 +2,7 @@
 title: "MCP Imagen Server"
 ---
 
-This tool provides image generation capabilities using Google's Imagen models (via Vertex AI). It is one of the MCP tools for Google Cloud Genmedia services, functioning as an MCP server component to allow LLMs and other MCP clients to generate images from text prompts.
+This tool provides image generation capabilities using Google's Imagen models (via Google Cloud AI). It is one of the MCP tools for Google Cloud Genmedia services, functioning as an MCP server component to allow LLMs and other MCP clients to generate images from text prompts.
 
 ## MCP Tool Definition
 
@@ -37,7 +37,7 @@ The tool utilizes the following environment variables:
 
 *   `GOOGLE_CLOUD_PROJECT` (string): **Required**. Your Google Cloud Project ID. The application will terminate if this is not set. Note: `PROJECT_ID` is also supported as a fallback.
     *   **Override**: You can override this globally for this specific server by setting `IMAGEN_PROJECT_ID`.
-*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Vertex AI services.
+*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Google Cloud AI services.
     *   Default: `"us-central1"`
     *   **Fallback**: `LOCATION` is also supported as a fallback for `GOOGLE_CLOUD_LOCATION`.
     *   **Override**: You can override this globally for this specific server by setting `IMAGEN_LOCATION`.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-lyria-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-lyria-go/index.md
@@ -2,7 +2,7 @@
 title: "MCP Lyria Server"
 ---
 
-This tool provides music generation capabilities using Google's Lyria models (via Vertex AI). It is one of the MCP tools for Google Cloud Genmedia services, functioning as an MCP server component to allow LLMs and other MCP clients to generate music from text prompts.
+This tool provides music generation capabilities using Google's Lyria models (via Google Cloud AI). It is one of the MCP tools for Google Cloud Genmedia services, functioning as an MCP server component to allow LLMs and other MCP clients to generate music from text prompts.
 
 ## MCP Tool Definition
 
@@ -23,7 +23,7 @@ The following tool is exposed by this server:
     *   `output_gcs_bucket` (string, optional): Google Cloud Storage bucket name (without `gs://` prefix). If provided, audio is saved to GCS. If this parameter is empty but the `GENMEDIA_BUCKET` environment variable is set, `GENMEDIA_BUCKET` will be used.
     *   `file_name` (string, optional): Desired file name (e.g., "my_song.wav"). Used for GCS object and local file. If omitted, a unique name like "lyria_output_&lt;uid&gt;.wav" is generated.
     *   `local_path` (string, optional): Local directory path. If provided, audio is saved locally.
-    *   `model_id` (string, optional): Specific Lyria model ID to use for the Vertex AI endpoint.
+    *   `model_id` (string, optional): Specific Lyria model ID to use for the Google Cloud AI endpoint.
         *   Defaults to the value of the `DEFAULT_LYRIA_MODEL_ID (Deprecated)` environment variable, or `"lyria-3-clip-preview"` if the variable is not set.
 
 ## Environment Variable Configuration
@@ -32,13 +32,13 @@ The tool utilizes the following environment variables:
 
 *   `GOOGLE_CLOUD_PROJECT` (string): **Required**. Your Google Cloud Project ID. The application will terminate if this is not set. Note: `PROJECT_ID` is also supported as a fallback.
     *   **Override**: You can override this globally for this specific server by setting `LYRIA_PROJECT_ID`.
-*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Vertex AI services.
+*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Google Cloud AI services.
     *   Default: `"us-central1"`
     *   **Fallback**: `LOCATION` is also supported as a fallback for `GOOGLE_CLOUD_LOCATION`.
     *   **Override**: You can override this globally for this specific server by setting `LYRIA_LOCATION`. (Note: This is now the preferred way to set the location for this server, replacing the deprecated `LYRIA_LOCATION (Deprecated for V3)` variable).
 *   `LYRIA_LOCATION (Deprecated for V3)` (string): The specific Google Cloud location for the Lyria model endpoint.
     *   Default: Value of `GOOGLE_CLOUD_LOCATION` or `LOCATION` environment variable (e.g., `"us-central1"`).
-*   `LYRIA_MODEL_PUBLISHER (Deprecated)` (string): The publisher of the Lyria model in Vertex AI.
+*   `LYRIA_MODEL_PUBLISHER (Deprecated)` (string): The publisher of the Lyria model in Google Cloud AI.
     *   Default: `"google"`
 *   `DEFAULT_LYRIA_MODEL_ID (Deprecated)` (string): The default Lyria model ID to be used if not specified in the request.
     *   Default: `"lyria-3-clip-preview"` (fallback if the environment variable is not set).

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-nanobanana-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-nanobanana-go/index.md
@@ -27,7 +27,7 @@ The tool utilizes the following environment variables:
 
 *   `GOOGLE_CLOUD_PROJECT` (string): **Required**. Your Google Cloud Project ID.
     *   **Override**: You can override this globally for this specific server by setting `NANOBANANA_PROJECT_ID`.
-*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Vertex AI services.
+*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Google Cloud AI services.
     *   Default: `"us-central1"`
     *   **Fallback**: `LOCATION` is also supported as a fallback for `GOOGLE_CLOUD_LOCATION`.
     *   **Override**: You can override this globally for this specific server by setting `NANOBANANA_LOCATION`.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-veo-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-veo-go/index.md
@@ -2,7 +2,7 @@
 title: "MCP Veo Server (Version: 3.7.0)"
 ---
 
-This tool provides video generation capabilities using Google's Veo models (via Vertex AI). It is one of the MCP tools for Google Cloud Genmedia services, acting as an MCP server component to allow LLMs and other MCP clients to generate videos from text prompts or source images.
+This tool provides video generation capabilities using Google's Veo models (via Google Cloud AI). It is one of the MCP tools for Google Cloud Genmedia services, acting as an MCP server component to allow LLMs and other MCP clients to generate videos from text prompts or source images.
 
 ## MCP Tool Definitions
 
@@ -59,7 +59,7 @@ The tool utilizes the following environment variables:
 
 *   `GOOGLE_CLOUD_PROJECT` (string): **Required**. Your Google Cloud Project ID. The application will terminate if this is not set. Note: `PROJECT_ID` is also supported as a fallback.
     *   **Override**: You can override this globally for this specific server by setting `VEO_PROJECT_ID`.
-*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Vertex AI services.
+*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location/region for Google Cloud AI services.
     *   Default: `"us-central1"`
     *   **Fallback**: `LOCATION` is also supported as a fallback for `GOOGLE_CLOUD_LOCATION`.
     *   **Override**: You can override this globally for this specific server by setting `VEO_LOCATION`.

--- a/docs-site/src/content/docs/experiments/promptlandia/index.md
+++ b/docs-site/src/content/docs/experiments/promptlandia/index.md
@@ -46,7 +46,7 @@ The application is configured using environment variables, which can be set in a
 | Variable | Description | Default |
 | :--- | :--- | :--- |
 | `PROJECT_ID` | Your Google Cloud Project ID. | (Required) |
-| `LOCATION` | The Google Cloud region for Vertex AI. | `us-central1` |
+| `LOCATION` | The Google Cloud region for Google Cloud AI. | `us-central1` |
 | `MODEL_ID` | The primary Gemini model ID used for generation and improvement. | `gemini-3.1-pro-preview` |
 | `PLANNING_MODEL_ID` | The model ID used specifically for the "thinking thoughts" (planning) step of prompt improvement. | Defaults to `MODEL_ID` |
 

--- a/docs-site/src/content/docs/experiments/run-veo-run/index.md
+++ b/docs-site/src/content/docs/experiments/run-veo-run/index.md
@@ -30,7 +30,7 @@ To preventing stylistic drift during extensions, the app employs a closed-loop f
 ![Run, Veo, Run Architecture](docs/architecture_infographic.webp)
 
 *   **Frontend:** Lit WebComponents + Tailwind CSS (Techno-Brutalist Theme).
-*   **Backend:** Go (1.25+) acting as a secure proxy for Vertex AI and GCS.
+*   **Backend:** Go (1.25+) acting as a secure proxy for Google Cloud AI and GCS.
 *   **AI Models:**
     *   **Generation:** Veo 3.1 (`veo-3.1-fast-generate-preview`)
     *   **Analysis:** Gemini 3 (`gemini-3-flash-preview`)


### PR DESCRIPTION
## Summary

Replace generic platform references to 'Vertex AI' with 'Google Cloud AI' across 16 documentation files in `docs-site/`.

## What changed

**27 occurrences updated across 16 files:**

| File | Changes |
|------|---------|
| `core/index.md` | Page title and ToC anchor |
| `core/installation/environment_variables.md` | Env var descriptions (×2) |
| `core/installation/cost_tracking.md` | Pricing page link label (URL unchanged) |
| `experiments/brand_consistency/index.md` | Title + 2 parentheticals |
| `experiments/mcp-genmedia/host-on-cloud-run.md` | Prose descriptions (×2) |
| `experiments/mcp-genmedia/agents/index.md` | ADK product reference |
| `experiments/mcp-genmedia/agents/adk.md` | ADK product reference |
| `experiments/mcp-genmedia/mcp-imagen-go/index.md` | Intro + env var description |
| `experiments/mcp-genmedia/mcp-veo-go/index.md` | Intro + env var description |
| `experiments/mcp-genmedia/mcp-lyria-go/index.md` | Intro + 3 env var descriptions |
| `experiments/mcp-genmedia/mcp-nanobanana-go/index.md` | Env var description |
| `experiments/mcp-genmedia/mcp-gemini-go/index.md` | Env var description |
| `experiments/run-veo-run/index.md` | Architecture description |
| `experiments/promptlandia/index.md` | Env var table cell |
| `experiments/Imagen_Product_Recontext/index.md` | Requirements list |
| `experiments/VTO/index.md` | Features list + Technologies list |

## What was intentionally left unchanged

The following official product/API names, IAM role names, and URLs were preserved:

- `Vertex AI User` (IAM role `roles/aiplatform.user`) — matches GCP Console display name
- `Vertex AI API` — actual GCP API to enable
- `Vertex AI Agent Registry` — official product name
- `Vertex AI GenAI Eval Service` — official product name
- `Vertex AI Prediction API` — official API name
- `Vertex AI Veo 3.1` — model name in run-veo-run description
- `cloud.google.com/vertex-ai/pricing` — URL cannot be changed
- JSON code block in `geminicli.md` — user-facing copy-paste content
- `.dot` diagram node labels