### PR TITLE
fix(mcp-genmedia): codesign macOS binaries to avoid Gatekeeper SIGKILL

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+*   **Fix:** `install-online.sh` and `install.sh` now ad-hoc codesign (and clear the quarantine attribute on) macOS binaries after install. Previously, downloaded and locally-built darwin binaries could be silently killed by Gatekeeper (`SIGKILL`, exit 137) on launch with no error output, causing MCP clients to report failed/unresponsive server starts.
+
 ## 2026-07-10 (v3.9.1)
 
 *   **Feat:** Added support for `gemini-3.1-flash-lite-image` ("Nano Banana 2 Lite") with 1K resolution aspect ratios in `mcp-nanobanana-go` and `mcp-gemini-go`.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install-online.sh
@@ -145,6 +145,23 @@ else
     exit 1
 fi
 
+# macOS Gatekeeper will silently SIGKILL (exit 137) downloaded binaries that
+# aren't signed with a trusted/valid signature, since they inherit a
+# quarantine attribute from being fetched over the network. Our release
+# binaries are unsigned, so clear the quarantine flag and apply an ad-hoc
+# signature to let them run.
+if [[ "$OS" == "darwin" ]]; then
+    if command -v xattr >/dev/null 2>&1; then
+        xattr -dr com.apple.quarantine "$INSTALL_DIR"/mcp-*-go 2>/dev/null || true
+    fi
+    if command -v codesign >/dev/null 2>&1; then
+        echo_info "Ad-hoc signing binaries for macOS Gatekeeper..."
+        for bin in "$INSTALL_DIR"/mcp-*-go; do
+            codesign --force --sign - "$bin" 2>/dev/null || echo_err "Failed to sign $bin; it may be blocked by Gatekeeper. Run: codesign --force --sign - \"$bin\""
+        done
+    fi
+fi
+
 echo_success "Installation successful!"
 echo_info "The following servers were installed:"
 ls -1 "$INSTALL_DIR"/mcp-*-go | xargs -n 1 basename | sed 's/^/  - /'

--- a/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
@@ -75,6 +75,31 @@ check_path() {
 }
 
 #
+# Function to ad-hoc codesign a locally built binary on macOS.
+#
+# 'go install' produces binaries with a signature that macOS Gatekeeper can
+# reject at exec time, silently killing the process (SIGKILL / exit 137)
+# with no output. Re-signing with an ad-hoc signature resolves this. This is
+# a no-op on non-macOS platforms.
+#
+codesign_go_binary() {
+  local server_dir="$1"
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    return
+  fi
+  if ! command -v codesign &> /dev/null; then
+    return
+  fi
+  local binary_path="$HOME/go/bin/$server_dir"
+  if [ -f "$binary_path" ]; then
+    if ! codesign --force --sign - "$binary_path" 2>/dev/null; then
+      echo -e "${YELLOW}WARNING: Failed to ad-hoc sign $binary_path. It may be blocked by macOS Gatekeeper.${NC}"
+      echo -e "  Run manually: ${BLUE}codesign --force --sign - \"$binary_path\"${NC}"
+    fi
+  fi
+}
+
+#
 # Function to setup Agent Skills.
 #
 setup_agent_skills() {
@@ -160,6 +185,7 @@ main() {
             echo -e "${RED}ERROR: Failed to install $d. Please check the output above for details.${NC}"
             exit 1
           fi
+          codesign_go_binary "$d"
         done
         echo -e "${GREEN}All MCP servers have been installed successfully.${NC}"
         echo -e "\n${YELLOW}Reminder: Ensure ${BLUE}\$HOME/go/bin${YELLOW} is in your PATH to run the installed servers.${NC}"
@@ -175,6 +201,7 @@ main() {
           echo -e "${BLUE}Installing $server...${NC}"
                     # Run go mod tidy to prevent checksum mismatch errors
           if (cd "$server" && go mod tidy && go install); then
+            codesign_go_binary "$server"
             echo -e "${GREEN}$server has been installed successfully.${NC}"
             echo -e "\n${YELLOW}Reminder: Ensure ${BLUE}\$HOME/go/bin${YELLOW} is in your PATH to run the installed server.${NC}"
             setup_agent_skills


### PR DESCRIPTION
## Problem

On macOS, the pre-compiled `mcp-*-go` binaries installed via `install-online.sh` (and locally-built binaries from `install.sh`/`go install`) can be silently killed by Gatekeeper (`syspolicyd`) at process launch, with `SIGKILL` (exit code 137) and **no error output at all**.

This makes debugging MCP client failures very confusing: the MCP client (e.g. an IDE or agent CLI) just reports the server as failed to start / unresponsive, with zero diagnostic information, since the binary is killed before it can write anything to stdout/stderr.

### Root cause

- `.goreleaser.yaml` cross-compiles `darwin/amd64` and `darwin/arm64` binaries with no code signing step.
- Binaries downloaded via `curl` in `install-online.sh` pick up Gatekeeper quarantine metadata from macOS's "downloaded from the internet" tracking.
- The combination of an untrusted/broken signature + quarantine metadata causes `syspolicyd` to reject execution:
  ```\n  syspolicyd: [gk] rejecting due to lack of matching active rule\n  syspolicyd: Unable initialize qtn_proc: 3\n  ```\n- Confirmed via `spctl -a -v <binary>` → `rejected` for all 6 genmedia MCP binaries, both the online-installed and `go install`-built variants.

### Verification

Re-signing with an ad-hoc signature (`codesign --force --sign - <binary>`) resolves it immediately. Verified for all 6 servers (`mcp-veo-go`, `mcp-gemini-go`, `mcp-nanobanana-go`, `mcp-chirp3-go`, `mcp-lyria-go`, `mcp-avtool-go`) by:
1. Confirming exit 137 without the fix, exit 0 with it.
2. Running a full MCP JSON-RPC handshake (`initialize` + `tools/list`) over stdio against each binary post-fix — all respond correctly and list their expected tools.

## Fix

- `install-online.sh`: on `darwin`, after installing binaries, clear `com.apple.quarantine` and apply an ad-hoc codesign to each installed binary.
- `install.sh`: on `Darwin`, ad-hoc codesign each binary built via `go install` (same root cause can affect locally-built binaries too, since `go build`/`go install` do not produce a Gatekeeper-trusted signature).
- Updated `CHANGELOG.md` with an Unreleased entry.

Both changes are no-ops on Linux/Windows and degrade gracefully if `codesign`/`xattr` aren't available.