### PR TITLE
chore(ci): least-privilege workflow permissions (zizmor)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -17,6 +15,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -44,6 +44,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,8 +15,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/mcp-genmedia-go.yml
+++ b/.github/workflows/mcp-genmedia-go.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - "experiments/mcp-genmedia/mcp-genmedia-go/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Applies least-privilege GitHub Actions `permissions:` to address the zizmor `excessive-permissions` findings surfaced during review of #1554 and #1555.

### `deploy-docs.yml`
- **Before:** workflow-level grant of `contents: read`, `pages: write`, `id-token: write` (all jobs get the broad Pages-deploy scopes).
- **After:** top-level default `permissions: contents: read`; the `pages: write` + `id-token: write` scopes are moved to the `deploy` job that actually performs the GitHub Pages deployment. The `build` job gets only `contents: read`.

### `mcp-genmedia-go.yml`
- **Before:** no `permissions:` block (implicit default token scopes).
- **After:** explicit least-privilege top-level `permissions: contents: read` (the single Go build/test/lint job only needs repo checkout).

### Rationale
No permission a job actually uses was removed — Pages deploy still has `pages: write`/`id-token: write`, just scoped to the deploy job. Follow-up per maintainer decision to keep permissions hardening in its own reviewed PR (separate from the dependency-bump PRs #1554/#1555). Please review — not for auto-merge.