### PR TITLE
fix: parenthesize multi-type except clauses (SyntaxError blocks import on main)

### DIFF
--- a/common/storage.py
+++ b/common/storage.py
@@ -27,7 +27,7 @@ try:
     import urllib3.contrib.pyopenssl
 
     urllib3.contrib.pyopenssl.extract_from_urllib3()
-except ImportError, AttributeError:
+except (ImportError, AttributeError):
     pass
 
 try:
@@ -49,7 +49,7 @@ try:
                 return _wrapper
 
             setattr(OpenSSL.SSL.Context, _attr_name, _make_wrapper(_attr))
-except ImportError, AttributeError:
+except (ImportError, AttributeError):
     pass
 
 db = FirebaseClient(cfg.GENMEDIA_FIREBASE_DB).get_client()

--- a/config/default.py
+++ b/config/default.py
@@ -285,7 +285,7 @@ def load_build_info() -> None:
                 data = json.load(f)
                 Default.BUILD_COMMIT = data.get("commit", "unknown")
                 Default.BUILD_DATE = data.get("date", "unknown")
-        except FileNotFoundError, json.JSONDecodeError:
+        except (FileNotFoundError, json.JSONDecodeError):
             pass
 
 
@@ -325,7 +325,7 @@ def load_about_page_config():
     try:
         with open(config_path) as f:
             content = json.load(f)
-    except FileNotFoundError, json.JSONDecodeError:
+    except (FileNotFoundError, json.JSONDecodeError):
         return None
 
     # The rest of the function that processes GCS URLs remains the same

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ try:
     import urllib3.contrib.pyopenssl
 
     urllib3.contrib.pyopenssl.extract_from_urllib3()
-except ImportError, AttributeError:
+except (ImportError, AttributeError):
     pass
 
 try:
@@ -44,7 +44,7 @@ try:
                 return _wrapper
 
             setattr(OpenSSL.SSL.Context, _attr_name, _make_wrapper(_attr))
-except ImportError, AttributeError:
+except (ImportError, AttributeError):
     pass
 
 import google.auth


### PR DESCRIPTION
## What

Six Python-2-style `except A, B:` clauses are invalid under Python 3 and raise `SyntaxError`, which prevents the application from importing at all — the container cannot start. This parenthesizes them to the correct `except (A, B):` tuple form in the three affected files:

- `main.py` (lines 25, 47)
- `common/storage.py` (lines 30, 52)
- `config/default.py` (lines 288, 328)

These were introduced across #1547 / #1542.

## Verification

`python3 -m py_compile main.py common/storage.py config/default.py` now exits 0 (previously failed on all three). A repo-wide grep confirms no remaining unparenthesized Python-2 `except <Type>, <name>:` clauses.

## Credit

Extracted from the work of @PetricaRadan in #1577 (this hotfix lands just the import-blocking syntax fix separately; the rest of #1577 is being handled independently). Authorship is preserved via `git cherry-pick -x`.
