### PR TITLE
fix: default Gemini calls to the global endpoint (GEMINI_LOCATION)

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -70,6 +70,10 @@ class Default:
     # Gemini
     PROJECT_ID: str = os.environ.get("PROJECT_ID")
     LOCATION: str = os.environ.get("LOCATION", "us-central1")
+    # Gemini 3.x models are not served from single regions such as us-central1 —
+    # only from the global endpoint (and the us/eu multi-regions). LOCATION stays
+    # regional because Veo/Imagen/Lyria/VTO and the Cloud Tasks queue need it.
+    GEMINI_LOCATION: str = os.environ.get("GEMINI_LOCATION", "global")
     GEMINI_TTS_LOCATION: str = os.environ.get("GEMINI_TTS_LOCATION", "global")
     GA_MEASUREMENT_ID: str = os.environ.get("GA_MEASUREMENT_ID")
     MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-3.5-flash")

--- a/dotenv.template
+++ b/dotenv.template
@@ -54,6 +54,12 @@ PROJECT_ID=
 # Default: gemini-3.5-flash
 # MODEL_ID=gemini-3.5-flash
 
+# [OPTIONAL] The endpoint used for Gemini text/multimodal calls. Gemini 3.x models
+# are NOT served from single regions such as us-central1 (requests 404); keep this
+# at "global" — or a us/eu multi-region — independently of LOCATION.
+# Default: global
+# GEMINI_LOCATION=global
+
 # [OPTIONAL] The specific model used for image generation features.
 # Default: gemini-2.5-flash-image
 # GEMINI_IMAGE_GEN_MODEL=gemini-2.5-flash-image

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,7 @@ locals {
   creative_studio_env_vars = {
     PROJECT_ID            = var.project_id
     LOCATION              = var.region
+    GEMINI_LOCATION       = var.gemini_location
     GEMINI_TTS_LOCATION   = var.gemini_tts_location
     MODEL_ID              = var.model_id
     GEMINI_AUDIO_ANALYSIS_MODEL_ID = var.gemini_audio_analysis_model_id

--- a/models/gemini.py
+++ b/models/gemini.py
@@ -1226,7 +1226,7 @@ def generate_text(
     contents = [types.Content(role="user", parts=parts)]
 
     client = GeminiModelSetup.init(
-        location=cfg.LOCATION,
+        location=cfg.GEMINI_LOCATION,
     )
 
     # print(f"Sending request to model: {model_name}")

--- a/models/model_setup.py
+++ b/models/model_setup.py
@@ -119,7 +119,9 @@ class GeminiModelSetup:
         """Init method for Gemini client. Model is specified at call time."""
         config = Default()
         effective_project_id = project_id if project_id else config.PROJECT_ID
-        effective_location = location if location else config.LOCATION
+        # Defaults to GEMINI_LOCATION (global), not LOCATION — Gemini 3.x models
+        # 404 on single-region endpoints like us-central1.
+        effective_location = location if location else config.GEMINI_LOCATION
 
         if not effective_project_id or not effective_location:
             raise ValueError("Project ID and Location must be set for Gemini client.")

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "model_id" {
   default     = "gemini-3.5-flash"
 }
 
+variable "gemini_location" {
+  description = "Endpoint used for Gemini text/multimodal calls. Gemini 3.x models are not served from single regions such as us-central1 — keep this at 'global' (or a us/eu multi-region) even when region is regional."
+  type        = string
+  default     = "global"
+}
+
 variable "gemini_audio_analysis_model_id" {
   description = "Gemini model ID to use for audio analysis features"
   type        = string


### PR DESCRIPTION
## Problem

The application's default Gemini client inherited `cfg.LOCATION`, which defaults to `us-central1`. But the repo's current default models — `MODEL_ID=gemini-3.5-flash` and `GEMINI_AUDIO_ANALYSIS_MODEL_ID=gemini-3.1-flash-lite` — are **not served from single-region endpoints** like `us-central1`. Calls there fail with `404 NOT_FOUND` (`Publisher model '.../locations/us-central1/.../gemini-3.x-...' not found`), breaking best-frame analysis and audio analysis.

## Fix

Add a dedicated `GEMINI_LOCATION` (default `global`) and use it for the Gemini text/multimodal clients:

- `GeminiModelSetup.init()` now defaults to `cfg.GEMINI_LOCATION` instead of `cfg.LOCATION`.
- `generate_text()` now passes `cfg.GEMINI_LOCATION`.
- `LOCATION` stays regional — Veo/Imagen/Lyria/VTO and the Cloud Tasks queue still need a region.

This mirrors the repo's **existing per-feature convention**, where Gemini endpoints already default to `global` (`GEMINI_TTS_LOCATION`, `GEMINI_CRITIQUE_LOCATION`, `CHARACTER_CONSISTENCY_GEMINI_LOCATION`, `GEMINI_IMAGE_GEN_LOCATION`). The only gap was the bare default client + `generate_text`, which this closes. The env var is plumbed all the way through: `config/default.py` → `dotenv.template` → `variables.tf` → `main.tf` Cloud Run env.

## Validation

Verified live against Vertex AI, changing only the location:

| model | `us-central1` | `global` |
|---|---|---|
| gemini-3.5-flash | **404 NOT_FOUND** | **200 OK** |
| gemini-3.1-flash-lite | **404 NOT_FOUND** | **200 OK** |

Confirmed both with raw `google-genai` calls and through the app's own `generate_text` code path. `python3 -m py_compile` passes on all touched Python files.

## Scope

**Endpoint-only.** The Cloud Run cpu/memory (OOM) limit bump and the `THUMBNAIL_QUEUE_ID` handling that were bundled in the original work are intentionally **left for a separate PR** so this change stays small and focused. This PR does not modify cpu/memory limits and does not remove `THUMBNAIL_QUEUE_ID`.

## Credit

The original fix and diagnosis are the work of **Radan Petrica (@PetricaRadan)** in #1577. It has been re-authored here by a maintainer so the Google CLA check passes; the endpoint behavior was independently validated before adoption. Thank you, @PetricaRadan.
