### PR TITLE
fix(mcp-nanobanana-go): save generated images to GCS via gcs_bucket_uri; return signed URLs

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/ENV_VARS.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/ENV_VARS.md
@@ -12,7 +12,8 @@ This document lists environment variables used by the MCP servers in this reposi
 | `<PREFIX>_LOCATION` | No | Server-specific override for location (e.g., `CHIRP3_LOCATION=eu`). | None | All |
 | `ALLOW_UNSAFE_MODELS` | No | Optional (`true`/`false`). Allows users to bypass strict local model constraint validation to test experimental or pre-release model strings. | `false` | Veo, Imagen, Gemini, NanoBanana, Lyria |
 | `ENABLE_OPTIONAL_HEADER_CAPTURE` | No | Optional (`true`/`false`). Intended for internal debugging. Injects raw Bearer token to capture `x-goog-sherlog-link`. | `false` | Imagen, Gemini, NanoBanana, Lyria |
-| `GENMEDIA_BUCKET` | No | A default GCS bucket to use for outputs if one isn't specified in a tool request. | None | All |
+| `GENMEDIA_BUCKET` | No | A default GCS bucket to use for outputs if one isn't specified in a tool request. For NanoBanana, generated images fall back to `<bucket>/nanobanana_outputs/`. | None | All |
+| `NANOBANANA_SIGNED_URL_EXPIRY_HOURS` | No | Validity (hours) of the V4 signed HTTPS URL returned for each uploaded image. Clamped to `168` (V4 max); `0` disables signed-URL generation (the `gs://` URI is still returned). Signing under ADC without a private key needs `roles/iam.serviceAccountTokenCreator` on the runtime SA (non-fatal if absent). | `24` | NanoBanana |
 | `VERTEX_API_ENDPOINT` | No | Overrides the Base URL of the Vertex AI client for testing against staging, preview, or sandbox environments. | None | Veo, Imagen, Gemini, NanoBanana, Lyria |
 | `GCS_DOWNLOAD_TIMEOUT` | No | Timeout for GCS download/streaming operations. Accepts Go duration strings (e.g. `"30s"`, `"5m"`). | `5m` | All |
 | `MCP_CUSTOM_PATH` | No | Overrides the system `PATH` for `ffmpeg` and `ffprobe` tool executions. | None | AVTool |

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
@@ -33,6 +33,30 @@ The tool utilizes the following environment variables:
     *   Default: `false`
 *   `ENABLE_OPTIONAL_HEADER_CAPTURE` (boolean): Optional (`true`/`false`). Intended for internal debugging. When set to `true`, the server intercepts API requests and injects the raw ADC Bearer token to capture and surface the `x-goog-sherlog-link` header in the tool output. This feature is supported for NanoBanana.
     *   Default: `false`
+*   `GENMEDIA_BUCKET` (string): Optional. Bucket name (no `gs://` prefix) used as the **fallback** destination for generated images when the `gcs_bucket_uri` parameter is not passed. Images are written under `<bucket>/nanobanana_outputs/`.
+*   `NANOBANANA_SIGNED_URL_EXPIRY_HOURS` (integer): Optional. Validity, in hours, of the V4 signed HTTPS URLs returned alongside each uploaded image.
+    *   Default: `24`
+    *   Values are clamped to `168` (7 days, the V4 maximum).
+    *   Set to `0` to disable signed-URL generation entirely (the `gs://` URI is still returned).
+
+## Saving to Google Cloud Storage
+
+When `gcs_bucket_uri` (or the `GENMEDIA_BUCKET` fallback) is set, the tool uploads each generated image to GCS, returns the `gs://` URI, and additionally returns a **V4-signed HTTPS URL** so MCP clients can display the image without the bucket being public. This is useful for remote/containerized deployments (SSE bridge, Cloud Run) where no retrievable local directory exists — without a bucket configured and no `output_directory`, generated image bytes are discarded.
+
+### Signed URLs — credentials
+
+Generating a signed URL requires an RSA signer:
+
+*   With a **service-account JSON key** (`GOOGLE_APPLICATION_CREDENTIALS`), signing is done locally — no extra IAM required.
+*   Under **Application Default Credentials without a private key** (the normal Cloud Run / GKE / metadata-server case), the tool signs via the IAM `signBlob` API. This requires the **runtime service account to hold `roles/iam.serviceAccountTokenCreator` on itself** (which grants `iam.serviceAccounts.signBlob`):
+
+    ```bash
+    gcloud iam service-accounts add-iam-policy-binding RUNTIME_SA_EMAIL \
+      --member="serviceAccount:RUNTIME_SA_EMAIL" \
+      --role="roles/iam.serviceAccountTokenCreator"
+    ```
+
+*   **If this permission is absent, signing is skipped (non-fatal): the upload still succeeds and the `gs://` URI is still returned — only the HTTPS signed link is omitted.**
 
 ## Example Usage
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-
 go 1.26.0
 
 require (
+	cloud.google.com/go/storage v1.64.0
 	github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20260809202617-5aa54b9922e4
 	github.com/mark3labs/mcp-go v0.57.0
 	go.opentelemetry.io/otel v1.45.0
@@ -17,7 +18,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/monitoring v1.29.0 // indirect
-	cloud.google.com/go/storage v1.64.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -22,9 +22,11 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -64,6 +66,16 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		outputDir = strings.TrimSpace(dir)
 	}
 
+	// gcsBucketURI: explicit "gcs_bucket_uri" argument takes precedence. If not
+	// provided, fall back to the server-wide GENMEDIA_BUCKET default (mirrors
+	// the fallback behavior documented for the other genmedia MCP tools).
+	gcsBucketURI := ""
+	if u, ok := request.GetArguments()["gcs_bucket_uri"].(string); ok && strings.TrimSpace(u) != "" {
+		gcsBucketURI = strings.TrimSpace(u)
+	} else if appConfig != nil && appConfig.GenmediaBucket != "" {
+		gcsBucketURI = appConfig.GenmediaBucket + "/nanobanana_outputs/"
+	}
+
 	// --- Construct Gemini Request ---
 	var parts []*genai.Part
 	parts = append(parts, genai.NewPartFromText(prompt))
@@ -88,6 +100,7 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		attribute.String("prompt", prompt),
 		attribute.String("model", model),
 		attribute.String("output_directory", outputDir),
+		attribute.String("gcs_bucket_uri", gcsBucketURI),
 	)
 
 	// --- API Call ---
@@ -132,20 +145,47 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 			}
 			if part.InlineData != nil {
 				log.Printf("part %d mime-type: %s", n, part.InlineData.MIMEType)
+				saved := false
 
 				if outputDir != "" {
 					if err := os.MkdirAll(outputDir, 0755); err != nil {
 						return mcp.NewToolResultError(fmt.Sprintf("failed to create output directory: %v", err)), nil
 					}
-					fileName := fmt.Sprintf("gemini_%s_%d.png", gentime, n)
+					fileName := fmt.Sprintf("gemini_%s_%d%s", gentime, n, extForMimeType(part.InlineData.MIMEType))
 					filePath := filepath.Join(outputDir, fileName)
 					if err := os.WriteFile(filePath, part.InlineData.Data, 0644); err != nil {
 						return mcp.NewToolResultError(fmt.Sprintf("failed to write image file: %v", err)), nil
 					}
 					savedFiles = append(savedFiles, filePath)
-				} else {
-					// If no output dir, should we return base64? For now, we just log.
-					log.Println("Received image data but no output_directory was specified. Image not saved.")
+					saved = true
+				}
+
+				if gcsBucketURI != "" {
+					bucketName, objectPrefix := parseGCSBucketAndPrefix(gcsBucketURI)
+					objectName := fmt.Sprintf("%sgemini_%s_%d%s", objectPrefix, gentime, n, extForMimeType(part.InlineData.MIMEType))
+					if err := common.UploadToGCS(ctx, bucketName, objectName, part.InlineData.MIMEType, part.InlineData.Data); err != nil {
+						log.Printf("failed to upload image to gs://%s/%s: %v", bucketName, objectName, err)
+						fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated image to GCS: %v]", err)
+					} else {
+						gcsURI := fmt.Sprintf("gs://%s/%s", bucketName, objectName)
+						savedFiles = append(savedFiles, gcsURI)
+						saved = true
+
+						// Best-effort: also return a V4 signed HTTPS URL so clients
+						// (e.g. Claude) can fetch/display the image without the
+						// bucket being public. Non-fatal on failure.
+						if expiry := signedURLExpiry(); expiry > 0 {
+							if signedURL, sErr := generateSignedURL(ctx, bucketName, objectName, expiry); sErr != nil {
+								log.Printf("failed to generate signed URL for %s: %v", gcsURI, sErr)
+							} else {
+								fmt.Fprintf(&responseText, "\n\nSigned URL for %s (valid %s):\n%s", objectName, expiry, signedURL)
+							}
+						}
+					}
+				}
+
+				if !saved {
+					log.Println("Received image data but no output_directory or gcs_bucket_uri was specified/valid. Image not saved.")
 				}
 			}
 		}
@@ -187,5 +227,80 @@ func inferMimeType(path string) string {
 		// Defaulting to a common image type if extension is unknown, as the API might handle it.
 		// A more robust solution might involve reading file headers.
 		return "image/png"
+	}
+}
+
+// signedURLExpiry returns the validity duration for generated V4 signed URLs.
+// Controlled by the NANOBANANA_SIGNED_URL_EXPIRY_HOURS env var. Defaults to
+// 24 hours. Values are clamped to 168 hours (7 days, the V4 maximum). Set to
+// "0" to disable signed URL generation entirely.
+func signedURLExpiry() time.Duration {
+	const def = 24 * time.Hour
+	v := strings.TrimSpace(os.Getenv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS"))
+	if v == "" {
+		return def
+	}
+	h, err := strconv.Atoi(v)
+	if err != nil || h < 0 {
+		log.Printf("invalid NANOBANANA_SIGNED_URL_EXPIRY_HOURS=%q, using default of 24", v)
+		return def
+	}
+	if h == 0 {
+		return 0
+	}
+	if h > 168 {
+		log.Printf("NANOBANANA_SIGNED_URL_EXPIRY_HOURS=%d exceeds the V4 maximum of 168 (7 days); clamping to 168", h)
+		h = 168
+	}
+	return time.Duration(h) * time.Hour
+}
+
+// generateSignedURL creates a V4 GET signed URL for a GCS object. The signing
+// key is detected automatically from the ambient credentials (e.g. the
+// service-account JSON key referenced by GOOGLE_APPLICATION_CREDENTIALS).
+func generateSignedURL(ctx context.Context, bucketName, objectName string, expiry time.Duration) (string, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("storage.NewClient: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	return client.Bucket(bucketName).SignedURL(objectName, &storage.SignedURLOptions{
+		Scheme:  storage.SigningSchemeV4,
+		Method:  "GET",
+		Expires: time.Now().Add(expiry),
+	})
+}
+
+// parseGCSBucketAndPrefix splits a "bucket/optional/prefix/" string (with or
+// without a leading gs:// scheme) into a bucket name and an object name
+// prefix that is guaranteed to be empty or end with a "/".
+func parseGCSBucketAndPrefix(uri string) (bucket, prefix string) {
+	uri = strings.TrimPrefix(uri, "gs://")
+	uri = strings.TrimPrefix(uri, "/")
+	parts := strings.SplitN(uri, "/", 2)
+	bucket = parts[0]
+	if len(parts) > 1 && parts[1] != "" {
+		prefix = parts[1]
+		if !strings.HasSuffix(prefix, "/") {
+			prefix += "/"
+		}
+	}
+	return bucket, prefix
+}
+
+// extForMimeType returns a reasonable file extension for a given image MIME type.
+func extForMimeType(mimeType string) string {
+	switch mimeType {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	case "image/png":
+		return ".png"
+	default:
+		return ".png"
 	}
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseGCSBucketAndPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		wantBucket string
+		wantPrefix string
+	}{
+		{"bucket only", "my-bucket", "my-bucket", ""},
+		{"bucket only with gs scheme", "gs://my-bucket", "my-bucket", ""},
+		{"bucket with trailing slash", "gs://my-bucket/", "my-bucket", ""},
+		{"bucket and prefix", "gs://my-bucket/prefix", "my-bucket", "prefix/"},
+		{"bucket and prefix trailing slash preserved", "gs://my-bucket/prefix/", "my-bucket", "prefix/"},
+		{"bucket and nested prefix", "gs://my-bucket/a/b/c", "my-bucket", "a/b/c/"},
+		{"bucket and nested prefix trailing slash", "gs://my-bucket/a/b/c/", "my-bucket", "a/b/c/"},
+		{"no gs scheme with prefix", "my-bucket/spike_a", "my-bucket", "spike_a/"},
+		{"leading slash stripped", "/my-bucket/prefix", "my-bucket", "prefix/"},
+		{"gs scheme leading slash", "gs:///my-bucket/prefix", "my-bucket", "prefix/"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBucket, gotPrefix := parseGCSBucketAndPrefix(tc.uri)
+			if gotBucket != tc.wantBucket {
+				t.Errorf("parseGCSBucketAndPrefix(%q) bucket = %q, want %q", tc.uri, gotBucket, tc.wantBucket)
+			}
+			if gotPrefix != tc.wantPrefix {
+				t.Errorf("parseGCSBucketAndPrefix(%q) prefix = %q, want %q", tc.uri, gotPrefix, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestExtForMimeType(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		want     string
+	}{
+		{"image/jpeg", ".jpg"},
+		{"image/webp", ".webp"},
+		{"image/gif", ".gif"},
+		{"image/png", ".png"},
+		{"application/octet-stream", ".png"}, // unknown -> default png
+		{"", ".png"},                         // empty -> default png
+		{"image/JPEG", ".png"},               // case-sensitive: not matched -> default png
+	}
+	for _, tc := range tests {
+		t.Run(tc.mimeType, func(t *testing.T) {
+			if got := extForMimeType(tc.mimeType); got != tc.want {
+				t.Errorf("extForMimeType(%q) = %q, want %q", tc.mimeType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSignedURLExpiry(t *testing.T) {
+	const def = 24 * time.Hour  // default validity
+	const max = 168 * time.Hour // V4 ceiling
+	tests := []struct {
+		name   string
+		env    string // value to set; "" means unset/empty
+		setEnv bool
+		want   time.Duration
+	}{
+		{"unset defaults to 24h", "", false, def},
+		{"empty defaults to 24h", "", true, def},
+		{"explicit 24h", "24", true, 24 * time.Hour},
+		{"1h", "1", true, 1 * time.Hour},
+		{"exactly 168 stays 168", "168", true, max},
+		{"over 168 clamps to 168", "200", true, max},
+		{"way over clamps to 168", "100000", true, max},
+		{"zero disables", "0", true, 0},
+		{"negative -> default", "-5", true, def},
+		{"non-numeric -> default", "notanumber", true, def},
+		{"float -> default (Atoi fails)", "24.5", true, def},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS", tc.env)
+			} else {
+				// Ensure it is unset for this case.
+				t.Setenv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS", "")
+				// t.Setenv cannot truly unset; empty string is treated as unset by signedURLExpiry.
+			}
+			if got := signedURLExpiry(); got != tc.want {
+				t.Errorf("signedURLExpiry() with env=%q = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -50,10 +50,10 @@ func init() {
 	flag.StringVar(&transport, "transport", "stdio", "Transport type (stdio, sse, or http)")
 	flag.IntVar(&port, "p", 0, "Port for SSE/HTTP server (defaults to PORT env var or 8080/8081)")
 	flag.IntVar(&port, "port", 0, "Port for SSE/HTTP server (defaults to PORT env var or 8080/8081)")
-	flag.Parse()
 }
 
 func main() {
+	flag.Parse() // Ensure flags are parsed before use
 
 	var cleanup func()
 	appConfig, cleanup = common.Init(serviceName, version)


### PR DESCRIPTION
## Problem

`mcp-nanobanana-go` advertised a `gcs_bucket_uri` parameter in both the tool schema (`main.go`) and the README, but the handler never read it — it only honored `output_directory`. For remote/containerized deployments (SSE bridge, Cloud Run) where no retrievable local directory exists, the generated image bytes were **silently dropped** while the tool advertised a GCS path it never used. This is broken for exactly the deployment model the genmedia MCP suite is meant to support.

## Fix

Honor `gcs_bucket_uri` and mirror the pattern already established by the sibling `mcp-imagen-go` tool:

- Resolve the bucket from `gcs_bucket_uri`, falling back to `<GENMEDIA_BUCKET>/nanobanana_outputs/` when the argument is omitted.
- Upload via the existing `common.UploadToGCS` helper and return the `gs://` URI. Upload failures are **non-fatal** (a warning is surfaced; behavior otherwise unchanged).
- Return a **V4 signed HTTPS URL** for each uploaded image so MCP clients can render it without the bucket being public. Best-effort / non-fatal.
- Pick correct file extensions (`.jpg` / `.webp` / `.gif` / `.png`) for both local and GCS object names instead of hard-coding `.png`.
- The existing `output_directory` local-save path is untouched (it just gains the correct extension). Both sinks can run together; no breaking change.

## Signed-URL expiry (24h default) + Token Creator note

Signed-URL validity is controlled by `NANOBANANA_SIGNED_URL_EXPIRY_HOURS`:

- **Default 24h** (a conservative default, since the URL makes the object fetchable by anyone holding it).
- Values are clamped to the **V4 maximum of 168h** (7 days).
- `0` **disables** signed-URL generation (the `gs://` URI is still returned).

Signing needs an RSA signer. With a service-account JSON key (`GOOGLE_APPLICATION_CREDENTIALS`) signing is done locally. Under **ADC without a private key** (the normal Cloud Run / GKE / metadata-server case) the tool signs via the IAM `signBlob` API, which requires the runtime SA to hold **`roles/iam.serviceAccountTokenCreator` on itself**. If that permission is absent, signing is skipped (non-fatal): the upload still succeeds and the `gs://` URI is still returned — only the HTTPS link is omitted. This is documented in the tool README and in `ENV_VARS.md`.

## Prerequisite changes

- **`main.go`**: moved `flag.Parse()` out of `init()` and into `main()` (mirrors `mcp-avtool-go`). In `init()` it consumed the `go test` harness's own flags, aborting the test binary before any test ran. Flag *definitions* stay where they were.
- **`go.mod`**: `cloud.google.com/go/storage` promoted from an indirect to a direct `require` at `v1.64.0` (main's current version) via `go mod tidy`. This is the only manifest change — no new module and no dependency downgrades.

## Tests

Added `handlers_test.go` with table tests for the pure helpers `parseGCSBucketAndPrefix`, `extForMimeType`, and `signedURLExpiry` (28 subtests, all passing). Includes coverage of the 24h default, the 168h clamp, and `0`-disables.

## Validation

Re-applied fresh on current `main` and validated end-to-end during a spike (Go 1.26.1):

- `GOWORK=off go build ./...`, `go vet ./...`, `go test ./...` — all exit 0.
- **Case A (explicit `gcs_bucket_uri`)**: object lands in the bucket; `gs://` URI returned; **signed URL fetches HTTP 200**.
- **Case B (`GENMEDIA_BUCKET` fallback)**: object lands under `<bucket>/nanobanana_outputs/`; `gs://` + signed URL returned.
- **Case C (no sink)**: bytes dropped on stock `main` (bug confirmed); graceful non-crash on the fix.
- **Local `output_directory`**: still works (regression check), now with correct extension.
- **V4 signing under metadata-server ADC (no private key)** works when the runtime SA holds `roles/iam.serviceAccountTokenCreator`; degrades gracefully to `gs://`-only otherwise.
- Expiry env verified live: default validity, `0` disables, values clamp to 168h.

## Credit

Adapted from the work of **@danielamigos** in #1560; re-authored under a CLA-covered maintainer so it can land now (see #1560 for the original).
