### PR TITLE
chore(terraform): raise Cloud Run memory to 4Gi (parameterize cpu/mem)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -213,8 +213,8 @@ resource "google_cloud_run_v2_service" "creative_studio" {
       image = var.initial_container_image
       resources {
         limits = {
-          cpu    = "1000m"
-          memory = "1024Mi"
+          cpu    = var.cloud_run_cpu
+          memory = var.cloud_run_memory
         }
       }
       dynamic "env" {

--- a/variables.tf
+++ b/variables.tf
@@ -145,3 +145,15 @@ variable "gemini_tts_location" {
   description = "Location for the Gemini TTS model"
   default     = "global"
 }
+
+variable "cloud_run_cpu" {
+  description = "CPU limit for the Creative Studio Cloud Run service container."
+  type        = string
+  default     = "2000m"
+}
+
+variable "cloud_run_memory" {
+  description = "Memory limit for the Creative Studio Cloud Run service container. Raised above the previous 1024Mi to give headroom for in-process video thumbnail decode, which was observed peaking ~1133 MiB and OOM-killing the instance."
+  type        = string
+  default     = "4Gi"
+}


### PR DESCRIPTION
## What

Parameterize the Creative Studio Cloud Run container `cpu`/`memory` limits as
Terraform variables and raise the **memory default to `4Gi`** (cpu default
`2000m`, up from the previously hard-coded `1000m` / `1024Mi`).

## Why (OOM context)

`models/video_processing.py:extract_and_upload_thumbnail` downloads a generated
video into a `TemporaryDirectory` (tmpfs, i.e. RAM on Cloud Run) and decodes it
in-process (moviepy / OpenCV `VideoFileClip`). Investigation observed this path
**peaking ~1133 MiB against the hard-coded 1024 MiB limit**, OOM-killing the
single Cloud Run instance during thumbnail extraction.

This change gives comfortable headroom (>3.5x the observed peak) and makes the
limits configurable so operators can tune per-project without editing the
resource block.

## Scope / caveats

- **This is a limit bump (stopgap), not an algorithmic memory fix.** It does not
  stream/frame-seek the thumbnail or bound concurrent in-process decode threads;
  under concurrent video jobs memory still scales with concurrency. A durable
  memory-efficiency fix remains a sensible follow-up.
- **`THUMBNAIL_QUEUE_ID` is intentionally left untouched.** The related OOM change
  in #1577 also dropped `THUMBNAIL_QUEUE_ID` (forcing the in-process thread
  fallback); that is a separate behavioral decision and is **not** included here.
  Current `main` behavior is preserved.
- The diff is limited to `variables.tf` (two new variables) and the
  `resources.limits` block in `main.tf`.

## Validation

- `terraform validate` → **Success! The configuration is valid.**
- `terraform fmt -check` on the added `variables.tf` block → clean. (An unrelated,
  pre-existing alignment diff in the `locals` env-var map in `main.tf` is present
  on `main` today and is deliberately left as-is to keep this change minimal.)

## Credit

Adapted from @PetricaRadan's OOM headroom change in #1577, with the memory limit
raised to 4GiB per maintainer. This does not close #1577.
