### PR TITLE
chore(mcp-genmedia): adopt release-please (MCP-only, monorepo-isolated)

### DIFF
--- a/.github/workflows/mcp-pr-title-lint.yml
+++ b/.github/workflows/mcp-pr-title-lint.yml
@@ -11,7 +11,10 @@
 name: MCP PR Title (Conventional Commits)
 
 on:
-  pull_request_target:
+  # Use pull_request (not pull_request_target): this check only reads the PR
+  # title, so a read-only token is sufficient and we avoid the dangerous-trigger
+  # security exposure of running with write scope on untrusted fork code.
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/mcp-pr-title-lint.yml
+++ b/.github/workflows/mcp-pr-title-lint.yml
@@ -1,0 +1,46 @@
+# Conventional Commits lint for the genmedia MCP servers ONLY.
+#
+# release-please derives the SemVer bump from Conventional Commit messages. On a
+# squash-merge repo, the PR title becomes the commit subject, so this check keeps
+# the *PR title* conventional for PRs that touch the MCP tree.
+#
+# Scope / isolation: the `paths` filter restricts this check to PRs that modify
+# `experiments/mcp-genmedia/mcp-genmedia-go/**`. Core-app-only PRs never run it,
+# so it imposes nothing on core contributors.
+
+name: MCP PR Title (Conventional Commits)
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+    paths:
+      - "experiments/mcp-genmedia/mcp-genmedia-go/**"
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-mcp-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title is a Conventional Commit
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            deps
+            chore
+            docs
+            refactor
+            test
+            build
+            ci
+            style
+            revert

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,56 @@
+# release-please for the genmedia MCP servers ONLY (monorepo-isolated).
+#
+# Scope / isolation:
+#   * This workflow manages ONLY the `experiments/mcp-genmedia/mcp-genmedia-go`
+#     component. Isolation is enforced in two independent layers:
+#       1. The push trigger is path-filtered to the MCP tree (+ the two
+#          release-please config files), so pushes that touch only the core app
+#          never start this workflow.
+#       2. release-please-config.json declares a single package rooted at the MCP
+#          path, so release-please only considers commits touching that path and
+#          only ever proposes edits to that path's VERSION + CHANGELOG.
+#   * It never reads, proposes, or edits the core app's version files
+#     (root pyproject.toml, config/default.py).
+#
+# Handoff to goreleaser:
+#   Merging the release PR makes release-please create the tag `mcp-v<X.Y.Z>` and
+#   a GitHub Release. That `mcp-v*` tag is what the existing MCP Servers Release
+#   workflow (.github/workflows/mcp-release.yml) triggers on to run goreleaser,
+#   which injects `-X main.version` from the tag. See RELEASING.md.
+#
+#   IMPORTANT: a tag pushed with the default GITHUB_TOKEN does NOT trigger
+#   another workflow (GitHub's recursion guard). For the mcp-v* tag to chain
+#   into goreleaser, provide a repo/org secret RELEASE_PLEASE_TOKEN (a PAT or a
+#   GitHub App token with `contents: write` + `pull-requests: write`). Without
+#   it, release-please still opens the release PR and creates the tag + Release,
+#   but a maintainer must run goreleaser (or re-push the tag) to publish binaries.
+
+name: release-please (MCP genmedia)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "experiments/mcp-genmedia/mcp-genmedia-go/**"
+      - "release-please-config.json"
+      - ".release-please-manifest.json"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run release-please
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        with:
+          # Prefer a PAT / App token so the created mcp-v* tag triggers the
+          # goreleaser workflow; fall back to GITHUB_TOKEN (PR + tag still made,
+          # but the goreleaser handoff must be done manually until the PAT exists).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: main

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "experiments/mcp-genmedia/mcp-genmedia-go": "3.10.0"
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/RELEASING.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/RELEASING.md
@@ -30,12 +30,70 @@ For releases the **git tag is the source of truth** — no file edit is required
 release time. The `VERSION` file keeps local and CI builds honest, and it is the
 file a future automation step (see below) will bump.
 
-## Cutting a release
+## Cutting a release (automated — release-please)
 
-1. Update `VERSION` to the new semver (this is the human-editable single source).
-2. Commit the `VERSION` bump (and `CHANGELOG.md`) to `main`.
-3. Tag the release, e.g. `git tag v<version> && git push origin v<version>`.
-4. goreleaser builds the artifacts, injecting the tag as the version.
+Releases of the MCP servers are automated with
+[release-please](https://github.com/googleapis/release-please), scoped to **this
+tree only** (`experiments/mcp-genmedia/mcp-genmedia-go`). It never touches the
+core app's version (root `pyproject.toml`, `config/default.py`) — see
+[MCP-only isolation](#mcp-only-isolation-important) below.
+
+The normal flow is:
+
+1. **Land Conventional-Commit PRs.** Write MCP changes as Conventional Commits
+   (`feat:` → minor, `fix:`/`perf:` → patch, `feat!:` or a `BREAKING CHANGE:`
+   footer → major). On squash-merge the **PR title** becomes the commit subject,
+   so the PR title must be conventional — the `MCP PR Title (Conventional
+   Commits)` check enforces this for PRs that touch this tree.
+2. **release-please maintains a standing "release PR."** On every push to `main`
+   that touches this tree, the `release-please (MCP genmedia)` workflow opens or
+   updates a release PR that bumps `VERSION` and prepends the derived entries to
+   `CHANGELOG.md`. It only considers commits under this path.
+3. **Merge the release PR** when you want to cut the release (the human gate).
+   On merge, release-please creates the tag **`mcp-v<version>`** and a GitHub
+   Release with the changelog notes.
+4. **goreleaser publishes the binaries.** The `mcp-v*` tag triggers
+   `.github/workflows/mcp-release.yml`, which strips the `mcp-` prefix and runs
+   goreleaser, injecting `-X main.version={{.Version}}` from the tag.
+
+### Tag format and the goreleaser handoff
+
+release-please emits `mcp-v<version>` (component `mcp` + `-v` + version). This is
+deliberate:
+
+* It **matches the existing `mcp-release.yml` trigger** (`tags: ['mcp-v*']`) so
+  goreleaser still fires unchanged.
+* It is **MCP-specific** and does not collide with a bare, repo-wide `vX.Y.Z`
+  that would imply a *core-app* release.
+
+> **Token note.** A tag pushed by release-please with the default `GITHUB_TOKEN`
+> will **not** trigger the goreleaser workflow (GitHub's workflow-recursion
+> guard). To chain automatically, add a repo/org secret `RELEASE_PLEASE_TOKEN`
+> (a PAT or GitHub App token with `contents: write` + `pull-requests: write`).
+> Without it, the release PR, tag, and Release are still created, but a
+> maintainer must publish the binaries manually (re-push the `mcp-v*` tag or run
+> goreleaser).
+
+### MCP-only isolation (important)
+
+This pipeline is **isolated to the MCP servers**. Isolation holds on two
+independent layers:
+
+1. `release-please-config.json` declares a **single package** rooted at
+   `experiments/mcp-genmedia/mcp-genmedia-go`; release-please only inspects
+   commits touching that path and only ever edits that path's `VERSION` +
+   `CHANGELOG.md`.
+2. The workflow's push trigger is **path-filtered** to the MCP tree, so a push
+   that changes only core-app files never even starts release-please.
+
+The core app versions separately via root `pyproject.toml` and
+`config/default.py`; release-please does not read, propose, or edit them.
+
+### Manual fallback
+
+If you ever need to cut a release by hand: bump `VERSION`, update `CHANGELOG.md`,
+commit to `main`, then `git tag mcp-v<version> && git push origin mcp-v<version>`
+— the `mcp-v*` tag drives goreleaser exactly as above.
 
 ## Local builds
 
@@ -53,11 +111,14 @@ startup log line, e.g.:
 Starting mcp-veo-go MCP Server (Version: 3.10.0, Transport: stdio)
 ```
 
-## Future: release-please (step b)
+## Automation history
 
-This VERSION-file + ldflags plumbing is step (a) of the automation plan. It is
-intentionally compatible with a later
-[release-please](https://github.com/googleapis/release-please) adoption:
-release-please will automate bumping the `VERSION` file and maintaining
-`CHANGELOG.md` from Conventional Commit messages, then the tag it creates drives
-goreleaser exactly as described above.
+* **Step (a)** — single `VERSION` file + build-time ldflags injection (replaced
+  the seven hand-edited `const version` declarations).
+* **Step (b)** — release-please adoption (this document's automated flow):
+  release-please bumps the `VERSION` file and maintains `CHANGELOG.md` from
+  Conventional Commit messages, then the `mcp-v*` tag it creates drives
+  goreleaser exactly as described above. Config lives in
+  `release-please-config.json` and `.release-please-manifest.json` at the repo
+  root (root is release-please's required location for these two files; they are
+  configuration only and do not version the core app).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "include-v-in-tag": true,
+  "tag-separator": "-",
+  "packages": {
+    "experiments/mcp-genmedia/mcp-genmedia-go": {
+      "component": "mcp",
+      "release-type": "simple",
+      "package-name": "genmedia-mcp-servers",
+      "changelog-path": "CHANGELOG.md",
+      "version-file": "VERSION"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adopt [release-please](https://github.com/googleapis/release-please) to automate versioning + changelog + tagging for the **genmedia MCP servers only** (`experiments/mcp-genmedia/mcp-genmedia-go`). This is automation **step (b)**, layered on top of step (a) (single `VERSION` source + ldflags injection, #1595, already merged).

Added (config only + docs — **no tool-behavior changes**):

| File | Purpose |
|---|---|
| `release-please-config.json` | Manifest-driven config. **One** package rooted at `experiments/mcp-genmedia/mcp-genmedia-go`, component `mcp`, `release-type: simple` with `version-file: VERSION`, `include-component-in-tag: true` → tag `mcp-v<version>`. |
| `.release-please-manifest.json` | Seeds that one component at the current `3.10.0`. |
| `.github/workflows/release-please.yml` | Runs release-please on pushes to `main`, **path-filtered** to the MCP tree; opens/updates the standing release PR. |
| `.github/workflows/mcp-pr-title-lint.yml` | Conventional-Commit PR-title check, **scoped by `paths`** to MCP PRs only (imposes nothing on core-app PRs). |
| `experiments/mcp-genmedia/mcp-genmedia-go/RELEASING.md` | Documents the new automated MCP-only flow, tag format, and goreleaser handoff. |

> The two release-please JSON files live at the repo root **by tool convention** (release-please requires them there). They are configuration only — they do **not** version the core app. Please don't mistake their root location for scope creep: the diff touches **zero** core-app files.

## Why

The MCP release process was fully manual (hand-edit version consts, hand-write CHANGELOG, hand-pick SemVer, manual tag ×2 + Release). That caused real bugs: `mcp-chirp3-go` drifted, and #1592 shipped `feat`-worthy code unversioned. Step (a) killed the const drift; step (b) removes the remaining hand-work: release-please derives the SemVer bump and CHANGELOG from Conventional Commits and cuts the tag/Release on merge of a release PR — keeping the human gate on *merging* the release PR.

## Isolation design (MCP-only, monorepo-safe)

Isolation holds on **two independent layers**:

1. **Config scope** — `release-please-config.json` declares a single package rooted at the MCP path. release-please only considers commits touching that path and only ever edits that path's `VERSION` + `CHANGELOG.md` (plus its own root manifest bookkeeping file).
2. **Trigger scope** — the workflow's `push` trigger is `paths`-filtered to `experiments/mcp-genmedia/mcp-genmedia-go/**` (+ the two config files), so a push that changes only core-app files never even starts release-please.

The core app versions separately via root `pyproject.toml` (`1.12.3`) and `config/default.py`. release-please does **not** read, propose, or edit either.

### Tag format & the goreleaser handoff

release-please emits **`mcp-v<version>`** (component `mcp` + `-v` + version). This is deliberate:

* It **matches the existing trigger** in `.github/workflows/mcp-release.yml` (`tags: ['mcp-v*']`) — goreleaser still fires unchanged, strips the `mcp-` prefix, and injects `-X main.version={{.Version}}` from the tag (compatible with step (a)).
* It is **MCP-specific** and does **not** collide with a bare, repo-wide `vX.Y.Z` that would imply a *core-app* release.

So the chain is: Conventional-Commit PRs → standing release PR (VERSION + CHANGELOG) → **merge** → release-please tags `mcp-v<version>` + GitHub Release → `mcp-release.yml` runs goreleaser → binaries.

## Dry-run isolation proof (demonstrated, not asserted)

Ran the release-please CLI in `--dry-run` against a fork branch carrying this config plus two synthetic commits — a `feat(core)` touching **only** `pyproject.toml` + `config/default.py`, and a `feat(mcp-genmedia)` touching the MCP tree:

```
title: chore: release mcp 3.11.0
## [3.11.0](compare/mcp-v3.10.0...mcp-v3.11.0)

updates: 3
  experiments/mcp-genmedia/mcp-genmedia-go/CHANGELOG.md   [Changelog]
  experiments/mcp-genmedia/mcp-genmedia-go/VERSION        [DefaultUpdater]
  .release-please-manifest.json                           [ReleasePleaseManifest]
```

* Proposes exactly **3 files**: the MCP `VERSION`, the MCP `CHANGELOG.md`, and release-please's own root manifest — **nothing** under `pyproject.toml`/`config/default.py` (grep for those + `1.13.0`: **0 hits**).
* The `feat(core)` commit is **absent** from the changelog; the `feat(mcp-genmedia)` commit **is** present → a core-only change does not release the MCP component, an MCP change does.
* Tag computed as `mcp-v3.11.0` → matches the goreleaser trigger.

## Required secret/permissions (for the tag → goreleaser handoff)

A tag pushed by release-please using the default `GITHUB_TOKEN` will **not** trigger another workflow (GitHub's recursion guard). For the `mcp-v*` tag to automatically drive goreleaser, add a repo/org secret **`RELEASE_PLEASE_TOKEN`** — a PAT or GitHub App token with `contents: write` + `pull-requests: write`. The workflow falls back to `GITHUB_TOKEN` if the secret is absent: the release PR, tag, and Release are still created, but a maintainer must publish binaries manually (re-push the `mcp-v*` tag or run goreleaser) until the secret exists. No token is embedded in this PR.

## Scope / safety

* **No tool-behavior changes.** Only release automation config + docs.
* Diff touches **only** the MCP tree + `.github/` + the two root release-please JSON files (config only).
* **Not** creating tags or GitHub Releases in this PR.
