### PR TITLE
feat(config): centralize Vertex AI API version

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -70,6 +70,11 @@ class Default:
     # Gemini
     PROJECT_ID: str = os.environ.get("PROJECT_ID")
     LOCATION: str = os.environ.get("LOCATION", "us-central1")
+    # Centralized Vertex AI API version for all google-genai client inits.
+    # Defaults to "v1beta1" (the google-genai SDK default for Vertex AI) so the
+    # effective behavior is unchanged; override via VERTEX_API_VERSION to switch
+    # the API surface in one place.
+    VERTEX_API_VERSION: str = os.environ.get("VERTEX_API_VERSION", "v1beta1")
     # Gemini 3.x models are not served from single regions such as us-central1 —
     # only from the global endpoint (and the us/eu multi-regions). LOCATION stays
     # regional because Veo/Imagen/Lyria/VTO and the Cloud Tasks queue need it.

--- a/models/character_consistency.py
+++ b/models/character_consistency.py
@@ -268,7 +268,12 @@ def generate_character_video(
 
 def _generate_imagen_candidates(reference_image_bytes_list, all_descriptions, final_prompt, negative_prompt):
     """Generates candidate images with Imagen."""
-    client = genai.Client(vertexai=True, project=cfg.PROJECT_ID, location=cfg.LOCATION)
+    client = genai.Client(
+        vertexai=True,
+        project=cfg.PROJECT_ID,
+        location=cfg.LOCATION,
+        http_options={"api_version": cfg.VERTEX_API_VERSION},
+    )
     edit_model = cfg.CHARACTER_CONSISTENCY_IMAGEN_MODEL
     reference_images_for_generation = []
     for i, image_bytes in enumerate(reference_image_bytes_list[:4]):
@@ -316,10 +321,16 @@ def _generate_video_from_image(
 ) -> tuple[bytes, str]:
     """Generates a video from an image."""
     gemini_client = genai.Client(
-        vertexai=True, project=cfg.PROJECT_ID, location=cfg.LOCATION
+        vertexai=True,
+        project=cfg.PROJECT_ID,
+        location=cfg.LOCATION,
+        http_options={"api_version": cfg.VERTEX_API_VERSION},
     )
     veo_client = genai.Client(
-        vertexai=True, project=cfg.PROJECT_ID, location=cfg.LOCATION
+        vertexai=True,
+        project=cfg.PROJECT_ID,
+        location=cfg.LOCATION,
+        http_options={"api_version": cfg.VERTEX_API_VERSION},
     )
 
     pil_image = PIL_Image.open(io.BytesIO(image_bytes))
@@ -376,7 +387,12 @@ def _outpaint_image(image_bytes: bytes, prompt: str) -> bytes:
     """
     Performs outpainting on an image to a 16:9 aspect ratio.
     """
-    client = genai.Client(vertexai=True, project=cfg.PROJECT_ID, location=cfg.LOCATION)
+    client = genai.Client(
+        vertexai=True,
+        project=cfg.PROJECT_ID,
+        location=cfg.LOCATION,
+        http_options={"api_version": cfg.VERTEX_API_VERSION},
+    )
     edit_model = cfg.CHARACTER_CONSISTENCY_IMAGEN_MODEL
 
     initial_image = PIL_Image.open(io.BytesIO(image_bytes))

--- a/models/image_models.py
+++ b/models/image_models.py
@@ -66,6 +66,7 @@ class ImagenModelSetup:
             vertexai=config.INIT_VERTEX,
             project=project_id,
             location=location,
+            http_options={"api_version": config.VERTEX_API_VERSION},
         )
         return client
 

--- a/models/upscale.py
+++ b/models/upscale.py
@@ -58,7 +58,12 @@ def upscale_image(input_gcs_uri: str, upscale_factor: str) -> Tuple[str, str, st
     Returns:
         Tuple of (output_gcs_uri, original_resolution, upscaled_resolution)
     """
-    client = genai.Client(vertexai=True, project=cfg.PROJECT_ID, location=cfg.LOCATION)
+    client = genai.Client(
+        vertexai=True,
+        project=cfg.PROJECT_ID,
+        location=cfg.LOCATION,
+        http_options={"api_version": cfg.VERTEX_API_VERSION},
+    )
 
     # Get original resolution
     original_resolution = get_image_resolution(input_gcs_uri)

--- a/models/veo.py
+++ b/models/veo.py
@@ -45,6 +45,7 @@ def get_veo_client(model_name: str) -> genai.Client:
             vertexai=True,
             project=config.VEO_PROJECT_ID,
             location=location,
+            http_options={"api_version": config.VERTEX_API_VERSION},
         )
     return _clients[location]
 

--- a/models/vto.py
+++ b/models/vto.py
@@ -27,7 +27,12 @@ cfg = Default()
 
 def init_client() -> genai.Client:
     """Initializes the GenAI client."""
-    return genai.Client(vertexai=True, project=cfg.PROJECT_ID, location=cfg.LOCATION)
+    return genai.Client(
+        vertexai=True,
+        project=cfg.PROJECT_ID,
+        location=cfg.LOCATION,
+        http_options={"api_version": cfg.VERTEX_API_VERSION},
+    )
 
 
 def generate_vto_image(


### PR DESCRIPTION
## What

Centralize the Vertex AI API version used by all `google-genai` client
initializations into a single configurable setting.

- Add `VERTEX_API_VERSION` to `config/default.py` (default `"v1beta1"`,
  overridable via the `VERTEX_API_VERSION` environment variable).
- Thread it as `http_options={"api_version": cfg.VERTEX_API_VERSION}` into the
  client inits that previously lacked any API-version configuration:
  - `models/character_consistency.py` (Imagen candidates, gemini + veo clients, outpaint)
  - `models/image_models.py` (`ImagenModelSetup`)
  - `models/upscale.py`
  - `models/veo.py` (`get_veo_client`)
  - `models/vto.py` (`init_client`)

## Why

Previously the Vertex API version was implicit at every call site, making it
impossible to switch API surfaces without editing each file. This puts the
version in one place.

## Behavior

Behavior-preserving: the default `"v1beta1"` matches the `google-genai` SDK's
existing default API version for Vertex AI, so no runtime behavior changes
unless `VERTEX_API_VERSION` is explicitly overridden.

## Attribution

Reimplements the intent of #924 by @calebjubal as a small, clean diff against
current `main` — thanks @calebjubal for identifying this. The original branch had
drifted far behind `main` (whole-tree diff / conflicting), so this re-lands the
same idea cleanly.

Refs #913.
