### PR TITLE
feat(terraform): production hardening (remote state, lifecycle, timeouts, cost labels)

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,35 @@
+/**
+* Copyright 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+# Remote state backend (GCS).
+#
+# The state bucket is intentionally NOT hardcoded here so this configuration
+# stays reusable across projects and no project-specific value is committed to
+# version control. Supply the bucket at init time, e.g.:
+#
+#   terraform init -backend-config="bucket=YOUR_TF_STATE_BUCKET"
+#
+# The bucket must already exist and have versioning enabled. Create it once with:
+#
+#   gcloud storage buckets create gs://YOUR_TF_STATE_BUCKET \
+#     --project=YOUR_PROJECT_ID --location=us-central1 --uniform-bucket-level-access
+#   gcloud storage buckets update gs://YOUR_TF_STATE_BUCKET --versioning
+terraform {
+  backend "gcs" {
+    # bucket = "YOUR_TF_STATE_BUCKET"  # provide via -backend-config
+    prefix = "creative-studio/prod"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -24,20 +24,28 @@ terraform {
     }
   }
 }
-provider "google" {
-  project = var.project_id
-  region  = var.region
-  default_labels = {
-    app = "genmedia-studio"
+locals {
+  # Applied to every resource that supports labels (via provider default_labels)
+  # for cost allocation, filtering, and billing reports.
+  common_labels = {
+    app         = "genmedia-studio"
+    environment = var.environment
+    team        = var.team
+    owner       = var.owner
+    cost_center = var.cost_center
   }
 }
 
+provider "google" {
+  project        = var.project_id
+  region         = var.region
+  default_labels = local.common_labels
+}
+
 provider "google-beta" {
-  project = var.project_id
-  region  = var.region
-  default_labels = {
-    app = "genmedia-studio"
-  }
+  project        = var.project_id
+  region         = var.region
+  default_labels = local.common_labels
 }
 
 data "google_project" "project" {
@@ -98,6 +106,16 @@ resource "google_cloud_run_service_iam_member" "iap_cloudrun_access" {
   member   = google_project_service_identity.iap_sa.member
 }
 
+# Reserved (static) global IP for the external load balancer. Managed by
+# Terraform so the address is stable across load balancer recreation. When
+# var.reserved_ip_address is set, that pre-existing address is used instead.
+resource "google_compute_global_address" "lb_ipv4" {
+  count      = var.use_lb && var.reserved_ip_address == null ? 1 : 0
+  name       = "creativestudio-lb-ip"
+  ip_version = "IPV4"
+  depends_on = [null_resource.sleep]
+}
+
 module "lb-http" {
   count                           = var.use_lb ? 1 : 0
   source                          = "terraform-google-modules/lb-http/google//modules/serverless_negs"
@@ -108,6 +126,8 @@ module "lb-http" {
   ssl                             = var.use_lb
   managed_ssl_certificate_domains = [var.domain]
   https_redirect                  = var.use_lb
+  address                         = coalesce(var.reserved_ip_address, one(google_compute_global_address.lb_ipv4[*].address))
+  create_address                  = false
   backends = {
     default = {
       description = "Creative Studio backend"
@@ -208,6 +228,8 @@ resource "google_cloud_run_v2_service" "creative_studio" {
   launch_stage         = var.use_lb ? "GA" : "BETA"
 
   template {
+    timeout                          = var.cloud_run_timeout
+    max_instance_request_concurrency = var.cloud_run_max_concurrency
     containers {
       name  = "creative-studio"
       image = var.initial_container_image
@@ -269,6 +291,17 @@ resource "google_storage_bucket" "assets" {
     method          = ["GET"]
     response_header = ["Content-Type"]
     max_age_seconds = 3600
+  }
+  dynamic "lifecycle_rule" {
+    for_each = var.asset_lifecycle_age_days > 0 ? [1] : []
+    content {
+      condition {
+        age = var.asset_lifecycle_age_days
+      }
+      action {
+        type = "Delete"
+      }
+    }
   }
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,36 @@
+# Example Terraform variables file.
+# Copy this to terraform.tfvars and fill in your actual values.
+# NEVER commit terraform.tfvars to version control.
+
+# --- Required ---
+project_id = "your-gcp-project-id"
+
+# --- Access / networking ---
+region       = "us-central1"
+use_lb       = true
+domain       = "creative-studio.example.com"
+initial_user = "you@example.com"
+
+# Reserved (static) LB IP. Leave null to have Terraform create and manage a
+# static global IP; set to an existing reserved address to reuse one.
+# reserved_ip_address = "203.0.113.10"
+
+# --- Cloud Run tuning ---
+# cloud_run_cpu             = "2000m"
+# cloud_run_memory          = "4Gi"
+# cloud_run_timeout         = "1800s"
+# cloud_run_max_concurrency = 4
+
+# --- Storage lifecycle ---
+# Delete assets older than this many days (0 disables the rule).
+# asset_lifecycle_age_days = 90
+
+# --- Cost-allocation labels ---
+environment = "prod"
+team        = "creative-studio"
+owner       = "creative-studio"
+cost_center = "creative-studio"
+
+# --- Safety ---
+# Keep false in production to prevent accidental data loss.
+enable_data_deletion = false

--- a/variables.tf
+++ b/variables.tf
@@ -157,3 +157,52 @@ variable "cloud_run_memory" {
   type        = string
   default     = "4Gi"
 }
+
+variable "cloud_run_timeout" {
+  description = "Maximum request timeout for the Creative Studio Cloud Run service. Long-running media generation (e.g. Veo) can exceed the default 5 minutes, so this defaults to 30 minutes."
+  type        = string
+  default     = "1800s"
+}
+
+variable "cloud_run_max_concurrency" {
+  description = "Maximum number of concurrent requests handled by a single Cloud Run instance. Kept low because media generation is CPU/memory intensive per request."
+  type        = number
+  default     = 4
+}
+
+variable "asset_lifecycle_age_days" {
+  description = "Age in days after which objects in the assets bucket are deleted by a lifecycle rule. Set to 0 to disable the lifecycle rule."
+  type        = number
+  default     = 90
+}
+
+variable "reserved_ip_address" {
+  description = "Reserved (static) global IP address for the load balancer. When null, a static IP is created and managed by Terraform (google_compute_global_address) so it survives load balancer recreation."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "environment" {
+  description = "Deployment environment label used for cost allocation and filtering (e.g. dev, staging, prod)."
+  type        = string
+  default     = "prod"
+}
+
+variable "team" {
+  description = "Owning team label used for cost allocation."
+  type        = string
+  default     = "creative-studio"
+}
+
+variable "owner" {
+  description = "Owner label used for cost allocation. Must be a valid GCP label value (lowercase letters, numbers, dashes, underscores)."
+  type        = string
+  default     = "creative-studio"
+}
+
+variable "cost_center" {
+  description = "Cost center label used for cost allocation and billing reports."
+  type        = string
+  default     = "creative-studio"
+}


### PR DESCRIPTION
## What

Production-hardening improvements to the root Terraform module. This **refiles the
still-relevant remainder of #899** against current `main` as a small, focused PR.

Implemented gaps (each verified still absent on `main`):

- **`backend.tf`** — GCS remote-state backend. The state bucket is supplied at
  init time via `-backend-config="bucket=..."` rather than hardcoded, so no
  project-specific value is committed.
- **`terraform.tfvars.example`** — example variables file (placeholder values only).
- **Assets bucket 90-day lifecycle rule** — `age`-based `Delete`, configurable via
  `asset_lifecycle_age_days` (set to `0` to disable).
- **Cloud Run `timeout` (30m) + `max_instance_request_concurrency` (4)** — both
  configurable via variables.
- **Reserved (static) global LB IP** — `google_compute_global_address` wired into
  `module.lb-http`; an existing address can be reused via `reserved_ip_address`.
- **Extended cost-allocation labels** — `environment` / `team` / `owner` /
  `cost_center`, applied uniformly through the provider `default_labels`.

## Why

These are the production-hardening items from #899 that never landed. The
highest-impact pieces of that PR (2 vCPU / 4Gi Cloud Run sizing, internal-LB
ingress, uniform bucket-level access, Firestore composite indexes, and
least-privilege service accounts) already arrived on `main` independently, so
#899's whole-tree diff is stale and mostly superseded.

## Least-privilege note

This PR **intentionally omits** #899's broad `roles/run.admin` and
`roles/cloudbuild.builds.editor` grants. They conflict with `main`'s
least-privilege service-account posture (which uses narrower `roles/run.developer`
plus scoped roles). **No IAM changes are introduced by this PR.**

## Verification

- `terraform init -backend=false` + `terraform validate` → **Success! The
  configuration is valid.** (Terraform v1.9.8)
- Added variables are `terraform fmt`-clean. (The repo has no Terraform CI gate,
  and a pre-existing unrelated formatting quirk in `main.tf`'s env-vars local was
  left untouched.)

## Attribution

Thanks to the original author, **@sivaprogrowth**, for the initial #899 proposal
that this builds on. This is not a "Closes" — #899 is being closed separately
with a note linking here.
