### PR TITLE
feat(mcp-genmedia): optional seed for Nano Banana + Veo tools

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/args.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/args.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"math"
+)
+
+// ParseOptionalNonNegativeInt32 extracts an optional integer MCP argument.
+func ParseOptionalNonNegativeInt32(args map[string]interface{}, name string) (*int32, error) {
+	value, ok := args[name]
+	if !ok || value == nil {
+		return nil, nil
+	}
+
+	var parsed int64
+	switch v := value.(type) {
+	case float64:
+		if math.Trunc(v) != v {
+			return nil, fmt.Errorf("%s must be an integer", name)
+		}
+		parsed = int64(v)
+	case float32:
+		if math.Trunc(float64(v)) != float64(v) {
+			return nil, fmt.Errorf("%s must be an integer", name)
+		}
+		parsed = int64(v)
+	case int:
+		parsed = int64(v)
+	case int32:
+		parsed = int64(v)
+	case int64:
+		parsed = v
+	default:
+		return nil, fmt.Errorf("%s must be a number", name)
+	}
+
+	if parsed < 0 || parsed > math.MaxInt32 {
+		return nil, fmt.Errorf("%s must be between 0 and %d", name, math.MaxInt32)
+	}
+
+	result := int32(parsed)
+	return &result, nil
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/args_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/args_test.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "testing"
+
+func TestParseOptionalNonNegativeInt32(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]interface{}
+		want    *int32
+		wantErr bool
+	}{
+		{
+			name: "missing",
+			args: map[string]interface{}{},
+		},
+		{
+			name: "float64 integer",
+			args: map[string]interface{}{"seed": float64(42)},
+			want: int32Ptr(42),
+		},
+		{
+			name: "int",
+			args: map[string]interface{}{"seed": 7},
+			want: int32Ptr(7),
+		},
+		{
+			name:    "fractional",
+			args:    map[string]interface{}{"seed": float64(1.5)},
+			wantErr: true,
+		},
+		{
+			name:    "negative",
+			args:    map[string]interface{}{"seed": -1},
+			wantErr: true,
+		},
+		{
+			name:    "too large",
+			args:    map[string]interface{}{"seed": int64(2147483648)},
+			wantErr: true,
+		},
+		{
+			name:    "not numeric",
+			args:    map[string]interface{}{"seed": "42"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseOptionalNonNegativeInt32(tt.args, "seed")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %d", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Fatalf("expected %d, got %v", *tt.want, got)
+			}
+		})
+	}
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
@@ -15,6 +15,7 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
+- `seed` (number, optional): Non-negative integer seed for best-effort reproducible image generation.
 
 
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -61,6 +61,11 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		}
 	}
 
+	seed, err := common.ParseOptionalNonNegativeInt32(request.GetArguments(), "seed")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	outputDir := ""
 	if dir, ok := request.GetArguments()["output_directory"].(string); ok && strings.TrimSpace(dir) != "" {
 		outputDir = strings.TrimSpace(dir)
@@ -102,6 +107,9 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		attribute.String("output_directory", outputDir),
 		attribute.String("gcs_bucket_uri", gcsBucketURI),
 	)
+	if seed != nil {
+		span.SetAttributes(attribute.Int("seed", int(*seed)))
+	}
 
 	// --- API Call ---
 	log.Printf("Calling GenerateContent with Model: %s, Prompt: \"%s\"", model, prompt)
@@ -112,6 +120,7 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		ImageConfig: &genai.ImageConfig{
 			AspectRatio: aspectRatio,
 		},
+		Seed: seed,
 	}
 	contents := &genai.Content{Parts: parts, Role: "USER"}
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -106,6 +106,7 @@ func main() {
 		mcp.WithArray("images", mcp.Description("Optional. A list of local file paths or GCS URIs for input media (images, videos, or PDFs)."), mcp.Items(map[string]any{"type": "string"})),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save generated image(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated images (e.g., your-bucket/outputs/).")),
+		mcp.WithNumber("seed", mcp.Description("Optional. Non-negative integer seed for best-effort reproducible image generation.")),
 	)
 
 	handlerWithClient := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/README.md
@@ -18,6 +18,7 @@ The server exposes the following tools:
     *   `num_videos` (number, optional): Number of videos to generate. Note: the maximum is model-dependent.
     *   `aspect_ratio` (string, optional): Aspect ratio of the generated videos. Note: supported aspect ratios are model-dependent.
     *   `duration` (number, optional): Duration of the generated video in seconds. Note: the supported duration range is model-dependent.
+    *   `seed` (number, optional): Non-negative integer seed for best-effort reproducible video generation.
 
 ### 2. `veo_i2v` (Image-to-Video)
 
@@ -33,6 +34,7 @@ The server exposes the following tools:
     *   `num_videos` (number, optional): Number of videos. Default: `1`. Min: `1`, Max: `4`.
     *   `aspect_ratio` (string, optional): Aspect ratio. Default: `"16:9"`.
     *   `duration` (number, optional): Duration in seconds. Default: `5`. Min: `5`, Max: `8`.
+    *   `seed` (number, optional): Non-negative integer seed for best-effort reproducible video generation.
 
 ### 3. `veo_extend_video` (Extend Video)
 
@@ -46,10 +48,12 @@ The server exposes the following tools:
     *   `output_directory` (string, optional): Local directory for download. Same logic as `veo_t2v`.
     *   `model` (string, optional): Model to use. Supported by Veo 3.1 models.
     *   `num_videos` (number, optional): Number of videos. Default: `1`. Min: `1`, Max: `4`.
+    *   `seed` (number, optional): Non-negative integer seed for best-effort reproducible video generation.
 
 ### 4. `veo_first_last_to_video` & `veo_reference_to_video` & `veo_ingredients_to_video`
 
 *   **Description**: Advanced video generation features supporting reference images and start/end frame interpolation.
+*   These tools also support the common Veo generation parameters, including `seed` (number, optional): a non-negative integer seed for best-effort reproducible video generation.
 
 ## Environment Variable Configuration
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"strings"
 
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel"
@@ -45,6 +46,11 @@ func veoTextToVideoHandler(client *genai.Client, ctx context.Context, request mc
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	seed, err := common.ParseOptionalNonNegativeInt32(request.GetArguments(), "seed")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	span.SetAttributes(
 		attribute.String("prompt", prompt),
 		attribute.String("gcs_bucket", gcsBucket),
@@ -56,6 +62,9 @@ func veoTextToVideoHandler(client *genai.Client, ctx context.Context, request mc
 		attribute.Bool("generate_audio", generateAudio),
 		attribute.String("person_generation", personGeneration),
 	)
+	if seed != nil {
+		span.SetAttributes(attribute.Int("seed", int(*seed)))
+	}
 
 	mcpServer := server.ServerFromContext(ctx)
 	var progressToken mcp.ProgressToken
@@ -77,6 +86,7 @@ func veoTextToVideoHandler(client *genai.Client, ctx context.Context, request mc
 		OutputGCSURI:     gcsBucket,
 		DurationSeconds:  &durationSecs,
 		PersonGeneration: personGeneration,
+		Seed:             seed,
 	}
 
 	if generateAudio {
@@ -130,6 +140,11 @@ func veoImageToVideoHandler(client *genai.Client, ctx context.Context, request m
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	seed, err := common.ParseOptionalNonNegativeInt32(request.GetArguments(), "seed")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	span.SetAttributes(
 		attribute.String("image_uri", imageURI),
 		attribute.String("mime_type", mimeType),
@@ -143,6 +158,9 @@ func veoImageToVideoHandler(client *genai.Client, ctx context.Context, request m
 		attribute.Bool("generate_audio", generateAudio),
 		attribute.String("person_generation", personGeneration),
 	)
+	if seed != nil {
+		span.SetAttributes(attribute.Int("seed", int(*seed)))
+	}
 
 	mcpServer := server.ServerFromContext(ctx)
 	var progressToken mcp.ProgressToken
@@ -169,6 +187,7 @@ func veoImageToVideoHandler(client *genai.Client, ctx context.Context, request m
 		OutputGCSURI:     gcsBucket,
 		DurationSeconds:  &durationSecs,
 		PersonGeneration: personGeneration,
+		Seed:             seed,
 	}
 
 	if generateAudio {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers_extended.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/handlers_extended.go
@@ -85,6 +85,11 @@ func veoFirstLastToVideoHandler(client *genai.Client, ctx context.Context, reque
 		}
 	}
 
+	seed, err := common.ParseOptionalNonNegativeInt32(request.GetArguments(), "seed")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	span.SetAttributes(
 		attribute.String("first_image_uri", firstImageURI),
 		attribute.String("last_image_uri", lastImageURI),
@@ -92,6 +97,9 @@ func veoFirstLastToVideoHandler(client *genai.Client, ctx context.Context, reque
 		attribute.String("model", modelName),
 		attribute.String("person_generation", personGeneration),
 	)
+	if seed != nil {
+		span.SetAttributes(attribute.Int("seed", int(*seed)))
+	}
 
 	mcpServer := server.ServerFromContext(ctx)
 	var progressToken mcp.ProgressToken
@@ -118,6 +126,7 @@ func veoFirstLastToVideoHandler(client *genai.Client, ctx context.Context, reque
 		OutputGCSURI:     gcsBucket,
 		DurationSeconds:  &durationSecs,
 		PersonGeneration: personGeneration,
+		Seed:             seed,
 		LastFrame: &genai.Image{
 			GCSURI:   lastImageURI,
 			MIMEType: lastMimeType,
@@ -212,12 +221,20 @@ func veoReferenceToVideoHandler(client *genai.Client, ctx context.Context, reque
 		return mcp.NewToolResultError(fmt.Sprintf("Model %s does not support reference image to video generation.", modelName)), nil
 	}
 
+	seed, err := common.ParseOptionalNonNegativeInt32(request.GetArguments(), "seed")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	span.SetAttributes(
 		attribute.String("prompt", prompt),
 		attribute.String("model", modelName),
 		attribute.Int("num_reference_images", len(referenceImages)),
 		attribute.String("person_generation", personGeneration),
 	)
+	if seed != nil {
+		span.SetAttributes(attribute.Int("seed", int(*seed)))
+	}
 
 	mcpServer := server.ServerFromContext(ctx)
 	var progressToken mcp.ProgressToken
@@ -240,6 +257,7 @@ func veoReferenceToVideoHandler(client *genai.Client, ctx context.Context, reque
 		DurationSeconds:  &durationSecs,
 		ReferenceImages:  referenceImages,
 		PersonGeneration: personGeneration,
+		Seed:             seed,
 	}
 
 	if generateAudio {
@@ -287,6 +305,11 @@ func veoExtendVideoHandler(client *genai.Client, ctx context.Context, request mc
 		return mcp.NewToolResultError(fmt.Sprintf("Model %s does not support video extension.", modelName)), nil
 	}
 
+	seed, err := common.ParseOptionalNonNegativeInt32(request.GetArguments(), "seed")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	span.SetAttributes(
 		attribute.String("video_uri", videoURI),
 		attribute.String("mime_type", mimeType),
@@ -300,6 +323,9 @@ func veoExtendVideoHandler(client *genai.Client, ctx context.Context, request mc
 		attribute.Bool("generate_audio", generateAudio),
 		attribute.String("person_generation", personGeneration),
 	)
+	if seed != nil {
+		span.SetAttributes(attribute.Int("seed", int(*seed)))
+	}
 
 	mcpServer := server.ServerFromContext(ctx)
 	var progressToken mcp.ProgressToken
@@ -326,6 +352,7 @@ func veoExtendVideoHandler(client *genai.Client, ctx context.Context, request mc
 		OutputGCSURI:     gcsBucket,
 		DurationSeconds:  &durationSecs,
 		PersonGeneration: personGeneration,
+		Seed:             seed,
 	}
 
 	if generateAudio {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo.go
@@ -120,6 +120,9 @@ func main() {
 		mcp.WithNumber("duration",
 			mcp.Description("Duration of the generated video in seconds. Note: the supported duration range is model-dependent."),
 		),
+		mcp.WithNumber("seed",
+			mcp.Description("Optional. Non-negative integer seed for best-effort reproducible video generation."),
+		),
 		mcp.WithBoolean("generate_audio",
 			mcp.DefaultBool(true),
 			mcp.Description("Optional. Generate audio for the video. Only supported by Veo 3 models. Defaults to true."),
@@ -264,6 +267,9 @@ func main() {
 		mcp.WithString("aspect_ratio",
 			mcp.Description("Aspect ratio of the generated videos. Note: supported aspect ratios are model-dependent."),
 		),
+		mcp.WithNumber("seed",
+			mcp.Description("Optional. Non-negative integer seed for best-effort reproducible video generation."),
+		),
 		mcp.WithBoolean("generate_audio",
 			mcp.DefaultBool(true),
 			mcp.Description("Optional. Generate audio for the video. Only supported by Veo 3 models. Defaults to true."),
@@ -287,6 +293,7 @@ func main() {
 		mcp.WithArgument("duration", mcp.ArgumentDescription("The duration of the video in seconds.")),
 		mcp.WithArgument("aspect_ratio", mcp.ArgumentDescription("The aspect ratio of the generated video.")),
 		mcp.WithArgument("model", mcp.ArgumentDescription("The model to use for generation.")),
+		mcp.WithArgument("seed", mcp.ArgumentDescription("Optional seed for best-effort reproducible video generation.")),
 	), func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		prompt, ok := request.Params.Arguments["prompt"]
 		if !ok || strings.TrimSpace(prompt) == "" {


### PR DESCRIPTION
## What

Adds an **optional** `seed` parameter to the Nano Banana (Gemini image) tool and
the Veo video tools in the `mcp-genmedia-go` servers. When a seed is provided it
is passed through to the GenAI SDK config; when it is omitted, behavior is
unchanged (the API selects a random seed as before).

## Why

Seeds enable best-effort reproducible generation, which is valuable for
iterative workflows, regression testing, and reproducible demos. This re-lands
the seed support originally proposed in #1443 by @Haihan-Jiang as a clean, small
diff — the original branch had grown large and stale (a 900+ file diff), so the
seed change is re-implemented here on top of current `main`. Thanks
@Haihan-Jiang for the original design and implementation.

## Tools touched

- **Nano Banana / Gemini image** (`mcp-nanobanana-go`): `nanobanana_image_generation`
  — sets `GenerateContentConfig.Seed`.
- **Veo** (`mcp-veo-go`) — sets `GenerateVideosConfig.Seed` in all five handlers:
  `veo_t2v`, `veo_i2v`, `veo_first_last_to_video`, `veo_reference_to_video`
  (and its alias `veo_ingredients_to_video`), and `veo_extend_video`.

## Implementation

- New shared helper `common.ParseOptionalNonNegativeInt32` in `mcp-common`
  (with unit tests) centralizes parsing/validation so it is not duplicated per
  server, matching the approach in #1443.
- The seed is validated as a **non-negative `int32`**: absent → no-op (optional),
  fractional / negative / out-of-range / non-numeric → rejected with a clear
  error before any API call.
- Tool input schemas register `seed` as an optional number; READMEs updated
  concisely.

## Validation

- `mcp-common`, `mcp-nanobanana-go`, `mcp-veo-go`: `GOWORK=off go build ./...`
  and `GOWORK=off go vet ./...` all pass.
- `go test ./...` in `mcp-common` passes, covering: missing (optional),
  `float64`/`int` accepted, and `1.5` / `-1` / `2147483648` / `"42"` rejected.
- Backward compatible: invoking any tool without `seed` behaves exactly as
  before (the `*int32` is `nil`, so the SDK uses a random seed).

## Reproducibility note (best effort)

Consistent with the SDK/API semantics, reproducibility is **best effort**, not a
hard guarantee. Empirically on SDK `google.golang.org/genai` v1.63.0 against the
current model IDs: same prompt + same seed on `gemini-3.1-flash-image` produced
pixel-identical images (occasional divergence — best effort), and on
`veo-3.1-fast-generate-001` produced near-identical video (frame MAD ~1.8), while
a different seed clearly varied output — meeting each API's documented
"best-effort / consistent-if-inputs-unchanged" wording.

Scope is intentionally limited to Nano Banana + Veo (exactly what #1443
targeted). Rolling seed into other tools (Imagen/Lyria/Chirp3) is a separate
future decision and is **not** part of this PR.
