### PR TITLE
feat(mcp-gemini): return generated images (inline bytes + gcs_bucket_uri)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/file_utils.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/file_utils.go
@@ -182,3 +182,28 @@ func FormatBytes(bytes int64) string {
 	}
 	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }
+
+// NormalizeImageMIMEType returns a usable image MIME type for generated image
+// bytes when the model response omits one.
+func NormalizeImageMIMEType(mimeType string) string {
+	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
+	if mimeType == "" {
+		return "image/png"
+	}
+	return mimeType
+}
+
+// ImageExtensionForMIMEType returns a suitable file extension for known image
+// MIME types and defaults to png.
+func ImageExtensionForMIMEType(mimeType string) string {
+	switch NormalizeImageMIMEType(mimeType) {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	default:
+		return ".png"
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/file_utils_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/file_utils_test.go
@@ -49,3 +49,46 @@ func TestGetTail(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeImageMIMEType(t *testing.T) {
+	testCases := []struct {
+		mimeType string
+		expected string
+	}{
+		{"", "image/png"},
+		{" IMAGE/WEBP ", "image/webp"},
+		{"image/jpeg", "image/jpeg"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.mimeType, func(t *testing.T) {
+			actual := NormalizeImageMIMEType(tc.mimeType)
+			if actual != tc.expected {
+				t.Errorf("expected '%s', but got '%s'", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestImageExtensionForMIMEType(t *testing.T) {
+	testCases := []struct {
+		mimeType string
+		expected string
+	}{
+		{"", ".png"},
+		{"image/png", ".png"},
+		{"image/jpeg", ".jpg"},
+		{"image/webp", ".webp"},
+		{"image/gif", ".gif"},
+		{"application/octet-stream", ".png"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.mimeType, func(t *testing.T) {
+			actual := ImageExtensionForMIMEType(tc.mimeType)
+			if actual != tc.expected {
+				t.Errorf("expected '%s', but got '%s'", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -174,6 +175,41 @@ func ParseGCSPath(gcsURI string) (bucketName, objectName string, err error) {
 		return "", "", fmt.Errorf("invalid GCS URI format: %s. Expected gs://bucket/object", gcsURI)
 	}
 	return parts[0], parts[1], nil
+}
+
+// ParseGCSPrefix extracts the bucket name and optional object prefix from a
+// user-provided GCS output prefix. Unlike ParseGCSPath, bucket-only paths such
+// as gs://bucket are valid because callers append generated filenames later.
+func ParseGCSPrefix(gcsURI string) (bucketName, objectPrefix string, err error) {
+	normalizedURI := EnsureGCSPathPrefix(strings.TrimSpace(gcsURI))
+	if normalizedURI == "gs://" {
+		return "", "", fmt.Errorf("invalid GCS URI format: %s. Expected gs://bucket[/prefix]", gcsURI)
+	}
+
+	trimmedURI := strings.TrimPrefix(normalizedURI, "gs://")
+	parts := strings.SplitN(trimmedURI, "/", 2)
+	if parts[0] == "" {
+		return "", "", fmt.Errorf("invalid GCS URI format: %s. Expected gs://bucket[/prefix]", gcsURI)
+	}
+	if len(parts) == 2 {
+		objectPrefix = strings.Trim(parts[1], "/")
+	}
+	return parts[0], objectPrefix, nil
+}
+
+// JoinGCSObjectName joins an optional object prefix and filename with URL path
+// semantics so GCS object names always use forward slashes.
+func JoinGCSObjectName(objectPrefix, filename string) string {
+	objectPrefix = strings.Trim(objectPrefix, "/")
+	if objectPrefix == "" {
+		return filename
+	}
+	return path.Join(objectPrefix, filename)
+}
+
+// BuildGCSURI returns a gs:// URI for an object.
+func BuildGCSURI(bucketName, objectName string) string {
+	return fmt.Sprintf("gs://%s/%s", bucketName, objectName)
 }
 
 // EnsureGCSPathPrefix ensures that a given path starts with "gs://".

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils_test.go
@@ -38,6 +38,59 @@ func TestParseGCSPath(t *testing.T) {
 	}
 }
 
+func TestParseGCSPrefix(t *testing.T) {
+	testCases := []struct {
+		gcsURI         string
+		expectedBucket string
+		expectedPrefix string
+		expectError    bool
+	}{
+		{"gs://bucket", "bucket", "", false},
+		{"gs://bucket/outputs", "bucket", "outputs", false},
+		{"gs://bucket/outputs/nested/", "bucket", "outputs/nested", false},
+		{"bucket/outputs", "bucket", "outputs", false},
+		{"", "", "", true},
+		{"gs://", "", "", true},
+		{"gs:///outputs", "", "", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.gcsURI, func(t *testing.T) {
+			bucket, prefix, err := ParseGCSPrefix(tc.gcsURI)
+			if (err != nil) != tc.expectError {
+				t.Errorf("expected error: %v, but got: %v", tc.expectError, err)
+			}
+			if bucket != tc.expectedBucket {
+				t.Errorf("expected bucket '%s', but got '%s'", tc.expectedBucket, bucket)
+			}
+			if prefix != tc.expectedPrefix {
+				t.Errorf("expected prefix '%s', but got '%s'", tc.expectedPrefix, prefix)
+			}
+		})
+	}
+}
+
+func TestJoinGCSObjectName(t *testing.T) {
+	testCases := []struct {
+		prefix   string
+		filename string
+		expected string
+	}{
+		{"", "image.png", "image.png"},
+		{"outputs", "image.png", "outputs/image.png"},
+		{"/outputs/nested/", "image.png", "outputs/nested/image.png"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.prefix, func(t *testing.T) {
+			actual := JoinGCSObjectName(tc.prefix, tc.filename)
+			if actual != tc.expected {
+				t.Errorf("expected '%s', but got '%s'", tc.expected, actual)
+			}
+		})
+	}
+}
+
 func TestDownloadFromGCS(t *testing.T) {
 	// This is a basic integration test that requires a running GCS emulator.
 	// You can start one with: gcloud beta emulators gcs start --project=test-project

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
@@ -64,6 +65,18 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 		outputDir = strings.TrimSpace(dir)
 	}
 
+	gcsOutputURI := ""
+	gcsBucketName := ""
+	gcsObjectPrefix := ""
+	if gcsURI, ok := request.GetArguments()["gcs_bucket_uri"].(string); ok && strings.TrimSpace(gcsURI) != "" {
+		gcsOutputURI = common.EnsureGCSPathPrefix(strings.TrimSpace(gcsURI))
+		var err error
+		gcsBucketName, gcsObjectPrefix, err = common.ParseGCSPrefix(gcsOutputURI)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid gcs_bucket_uri: %v", err)), nil
+		}
+	}
+
 	// --- Construct Gemini Request ---
 	var parts []*genai.Part
 	parts = append(parts, genai.NewPartFromText(prompt))
@@ -88,6 +101,7 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 		attribute.String("prompt", prompt),
 		attribute.String("model", model),
 		attribute.String("output_directory", outputDir),
+		attribute.String("gcs_bucket_uri", gcsOutputURI),
 	)
 
 	// --- API Call ---
@@ -116,6 +130,10 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 	// --- Process Response ---
 	var responseText strings.Builder
 	var savedFiles []string
+	var gcsSavedURIs []string
+	var responseImages []mcp.Content
+	generatedImages := 0
+	returnImageDataInResponse := outputDir == "" && gcsOutputURI == ""
 
 	// Check for optional Sherlog header
 	if resp.SDKHTTPResponse != nil && resp.SDKHTTPResponse.Headers != nil {
@@ -131,33 +149,62 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 				responseText.WriteString(part.Text)
 			}
 			if part.InlineData != nil {
-				log.Printf("part %d mime-type: %s", n, part.InlineData.MIMEType)
+				generatedImages++
+				mimeType := common.NormalizeImageMIMEType(part.InlineData.MIMEType)
+				fileName := fmt.Sprintf("gemini_%s_%d%s", gentime, n, common.ImageExtensionForMIMEType(mimeType))
+				log.Printf("part %d mime-type: %s", n, mimeType)
 
 				if outputDir != "" {
 					if err := os.MkdirAll(outputDir, 0755); err != nil {
 						return mcp.NewToolResultError(fmt.Sprintf("failed to create output directory: %v", err)), nil
 					}
-					fileName := fmt.Sprintf("gemini_%s_%d.png", gentime, n)
 					filePath := filepath.Join(outputDir, fileName)
 					if err := os.WriteFile(filePath, part.InlineData.Data, 0644); err != nil {
 						return mcp.NewToolResultError(fmt.Sprintf("failed to write image file: %v", err)), nil
 					}
 					savedFiles = append(savedFiles, filePath)
-				} else {
-					// If no output dir, should we return base64? For now, we just log.
-					log.Println("Received image data but no output_directory was specified. Image not saved.")
+				}
+
+				if gcsOutputURI != "" {
+					objectName := common.JoinGCSObjectName(gcsObjectPrefix, fileName)
+					if err := common.UploadToGCS(ctx, gcsBucketName, objectName, mimeType, part.InlineData.Data); err != nil {
+						return mcp.NewToolResultError(fmt.Sprintf("failed to upload image to GCS: %v", err)), nil
+					}
+					gcsSavedURIs = append(gcsSavedURIs, common.BuildGCSURI(gcsBucketName, objectName))
+				}
+
+				if returnImageDataInResponse {
+					responseImages = append(responseImages, mcp.ImageContent{
+						Type:     "image",
+						Data:     base64.StdEncoding.EncodeToString(part.InlineData.Data),
+						MIMEType: mimeType,
+					})
 				}
 			}
 		}
 	}
 
 	// --- Format Final Result ---
-	finalMessage := responseText.String()
+	finalMessage := strings.TrimSpace(responseText.String())
+	if finalMessage == "" && generatedImages > 0 {
+		finalMessage = fmt.Sprintf("Generated %d image(s).", generatedImages)
+	}
 	if len(savedFiles) > 0 {
 		finalMessage += fmt.Sprintf("\n\nGenerated and saved %d image(s): %s", len(savedFiles), strings.Join(savedFiles, ", "))
 	}
+	if len(gcsSavedURIs) > 0 {
+		finalMessage += fmt.Sprintf("\n\nGenerated and uploaded %d image(s) to GCS: %s", len(gcsSavedURIs), strings.Join(gcsSavedURIs, ", "))
+	}
+	if returnImageDataInResponse && len(responseImages) > 0 {
+		finalMessage += "\n\nImage(s) are included in this MCP response as base64 data."
+	}
 
-	return &mcp.CallToolResult{Content: []mcp.Content{mcp.TextContent{Type: "text", Text: strings.TrimSpace(finalMessage)}}}, nil
+	contentItems := []mcp.Content{mcp.TextContent{Type: "text", Text: strings.TrimSpace(finalMessage)}}
+	if returnImageDataInResponse {
+		contentItems = append(contentItems, responseImages...)
+	}
+
+	return &mcp.CallToolResult{Content: contentItems}, nil
 }
 
 func inferMimeType(path string) string {


### PR DESCRIPTION
## What

Makes the Gemini image-generation MCP handler (`gemini_image_generation`)
actually return the images it generates, instead of discarding them when no
local `output_directory` is provided.

- **Inline bytes:** when neither `output_directory` nor `gcs_bucket_uri` is set,
  the handler now returns the generated image bytes as MCP `image` content
  (base64), instead of only logging `"...Image not saved."`.
- **`gcs_bucket_uri`:** when provided, each generated image is uploaded to the
  requested GCS prefix and the resulting `gs://` URIs are reported. The argument
  is already declared on the tool; this wires up its behavior.
- **MIME normalization:** the image MIME type is normalized and the saved/uploaded
  filename extension is derived from it (png/jpg/webp/gif).

## Why

Previously the Gemini handler only wrote images to a local directory. Callers
without local filesystem access (the common MCP case) received a text-only
response and the image was silently dropped. This closes that gap while keeping
existing local-save behavior intact.

## Re-land + attribution

This re-lands the Gemini image-output support from #1441 by **@Haihan-Jiang** —
thank you, @Haihan-Jiang. The original PR branch could not be reused because its
history was corrupted by a git-history scrub that produced a 901-file artifact
diff, so this is a clean, minimal re-implementation of just that residual.

The NanoBanana handler changes from #1441 are **intentionally excluded**: they
are already superseded on `main` by #1592 (GCS output + V4 signed URLs +
`GENMEDIA_BUCKET` fallback) and #1599 (seed support). Re-landing them would
regress that work.

## Files changed

- `mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go` — parse `gcs_bucket_uri`,
  MIME-normalized filenames, GCS upload branch, inline-bytes branch, content assembly.
- `mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils.go` — add `ParseGCSPrefix`,
  `JoinGCSObjectName`, `BuildGCSURI`.
- `mcp-genmedia/mcp-genmedia-go/mcp-common/file_utils.go` — add `NormalizeImageMIMEType`,
  `ImageExtensionForMIMEType`.
- `mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_utils_test.go`,
  `file_utils_test.go` — unit tests for the new helpers.

## Backward compatibility

Existing callers that pass `output_directory` continue to save files exactly as
before (now with a MIME-correct extension). Callers that pass no destination now
receive images inline rather than a "not saved" log line. No existing argument
or behavior is removed.

## Verification

- `cd mcp-common && GOWORK=off go build ./... && GOWORK=off go test ./...` — pass
  (including the new helper tests).
- `cd mcp-gemini-go && GOWORK=off go build ./... && GOWORK=off go vet ./...` — clean.
- Confirmed `gcs_bucket_uri` is optional (bare `prompt`-only invocation compiles
  and routes to the inline-bytes branch via `returnImageDataInResponse`).
