### PR TITLE
feat(mcp-genmedia): add MCP Genmedia DevContainer

### DIFF
--- a/experiments/mcp-genmedia/.devcontainer/Dockerfile
+++ b/experiments/mcp-genmedia/.devcontainer/Dockerfile
@@ -1,0 +1,53 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
+
+ARG GO_VERSION=1.26.0
+ARG TARGETARCH
+
+ENV GOPATH=/home/node/go
+ENV GOBIN=/usr/local/bin
+ENV PATH=/usr/local/go/bin:${GOPATH}/bin:${PATH}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        ffmpeg \
+        gettext-base \
+        jq \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "${arch}" in \
+        amd64|arm64) go_arch="${arch}" ;; \
+        *) echo "Unsupported Go architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" -o /tmp/go.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm /tmp/go.tar.gz
+
+COPY mcp-genmedia-go /tmp/mcp-genmedia-go
+
+# Build the servers through the module Makefile so each binary carries the
+# ldflags-injected VERSION from the single source-of-truth VERSION file
+# (see #1595/#1596). `make build` compiles every server into ./bin with
+# `-X main.version=$(cat VERSION)`; we then install those onto PATH (GOBIN).
+RUN cd /tmp/mcp-genmedia-go \
+    && make build \
+    && install -m 0755 bin/* "${GOBIN}/" \
+    && rm -rf /tmp/mcp-genmedia-go
+
+COPY .devcontainer/scripts /usr/local/share/mcp-genmedia-devcontainer/scripts
+COPY .devcontainer/templates /usr/local/share/mcp-genmedia-devcontainer/templates
+
+RUN chmod +x /usr/local/share/mcp-genmedia-devcontainer/scripts/*.sh \
+    && printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'exec npx --yes https://github.com/google-gemini/gemini-cli "$@"' \
+        > /usr/local/bin/gemini \
+    && chmod +x /usr/local/bin/gemini \
+    && mkdir -p /home/node/go \
+    && chown -R node:node /home/node/go
+
+USER node

--- a/experiments/mcp-genmedia/.devcontainer/README.md
+++ b/experiments/mcp-genmedia/.devcontainer/README.md
@@ -1,0 +1,48 @@
+# MCP Genmedia DevContainer
+
+A ready-to-use development container that builds the MCP Genmedia Go servers and
+wires them into the Gemini CLI, so you can exercise the genmedia tools (Veo,
+Imagen, Nano Banana, Lyria, Chirp3-HD, AVTool, Gemini) without a manual setup.
+
+## What it does
+
+- **Toolchain** — pins Go (`GO_VERSION=1.26.0`) matching the module `go.work`,
+  plus `ffmpeg`, `jq`, and `gettext-base`.
+- **Servers** — builds every server via the module `Makefile` (`make build`), so
+  each binary carries the ldflags-injected version from the single
+  source-of-truth `VERSION` file, then installs them onto `PATH`.
+- **Gemini CLI** — installs a `gemini` launcher and, on create, runs
+  `scripts/configure-gemini.sh` to drop a `google-genmedia-devcontainer`
+  extension into `~/.gemini/extensions/`.
+
+## Configuration
+
+The container reads these variables from your host environment (via
+`containerEnv` in `devcontainer.json`):
+
+| Variable | Purpose |
+| --- | --- |
+| `GOOGLE_CLOUD_PROJECT` | GCP project for Vertex AI (preferred). |
+| `PROJECT_ID` | Legacy fallback for the project. |
+| `GOOGLE_CLOUD_LOCATION` | Preferred Vertex AI region (`LOCATION` is the fallback). |
+| `GEMINI_LOCATION` | Per-server override for the Gemini endpoint; defaults to `global`. |
+| `GENMEDIA_BUCKET` | Default GCS bucket for generated media. |
+
+`configure-gemini.sh` resolves the project (falling back to `gcloud config`),
+derives a default `GENMEDIA_BUCKET` when unset, defaults the Gemini server to the
+`global` endpoint, and renders the extension. The extension follows main's
+canonical settings-based (`version 3.x`) pattern: per-server `env` carries only
+timeouts, while `GOOGLE_CLOUD_PROJECT` and `GENMEDIA_BUCKET` are declared in the
+top-level `settings` block and resolved from the environment at runtime.
+
+## Usage
+
+Open the `experiments/mcp-genmedia` folder in a Dev Containers-capable editor and
+"Reopen in Container". Once built, run `gemini` and the genmedia MCP servers are
+available.
+
+## Attribution
+
+This DevContainer re-lands the work originally contributed by @Haihan-Jiang in
+[#1442](https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/pull/1442),
+with alignment updates to match current `main`.

--- a/experiments/mcp-genmedia/.devcontainer/devcontainer.json
+++ b/experiments/mcp-genmedia/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "MCP Genmedia + Gemini CLI",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "node",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "containerEnv": {
+    "GOOGLE_CLOUD_PROJECT": "${localEnv:GOOGLE_CLOUD_PROJECT}",
+    "PROJECT_ID": "${localEnv:PROJECT_ID}",
+    "GENMEDIA_BUCKET": "${localEnv:GENMEDIA_BUCKET}",
+    "GOOGLE_CLOUD_LOCATION": "${localEnv:GOOGLE_CLOUD_LOCATION}",
+    "GEMINI_LOCATION": "${localEnv:GEMINI_LOCATION}"
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.config/gcloud,target=/home/node/.config/gcloud,type=bind,consistency=cached"
+  ],
+  "postCreateCommand": "/usr/local/share/mcp-genmedia-devcontainer/scripts/configure-gemini.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
+}

--- a/experiments/mcp-genmedia/.devcontainer/scripts/configure-gemini.sh
+++ b/experiments/mcp-genmedia/.devcontainer/scripts/configure-gemini.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+template_path="/usr/local/share/mcp-genmedia-devcontainer/templates/gemini-extension.json"
+extension_dir="${HOME}/.gemini/extensions/google-genmedia-devcontainer"
+
+# Project: GOOGLE_CLOUD_PROJECT is preferred; PROJECT_ID is the legacy fallback
+# (see ENV_VARS.md). Fall back to the active gcloud config if neither is set.
+project_id="${GOOGLE_CLOUD_PROJECT:-${PROJECT_ID:-}}"
+if [[ -z "${project_id}" ]] && command -v gcloud >/dev/null 2>&1; then
+  project_id="$(gcloud config get-value project 2>/dev/null || true)"
+fi
+
+# Location: GOOGLE_CLOUD_LOCATION is preferred; LOCATION is the fallback.
+location="${GOOGLE_CLOUD_LOCATION:-${LOCATION:-us-central1}}"
+
+# The Gemini server defaults to the global endpoint (see #1591); GEMINI_LOCATION
+# overrides it per-server. Default to "global" here, allowing host override.
+gemini_location="${GEMINI_LOCATION:-global}"
+
+genmedia_bucket="${GENMEDIA_BUCKET:-}"
+if [[ -z "${genmedia_bucket}" && -n "${project_id}" ]]; then
+  genmedia_bucket="gs://${project_id}-mcp-genmedia"
+fi
+
+# Export the settings the v3.x extension declares (GOOGLE_CLOUD_PROJECT,
+# GENMEDIA_BUCKET) plus location vars, so the MCP servers — which read the
+# process environment directly — pick them up at runtime.
+export GOOGLE_CLOUD_PROJECT="${project_id}"
+export GENMEDIA_BUCKET="${genmedia_bucket}"
+export GOOGLE_CLOUD_LOCATION="${location}"
+export GEMINI_LOCATION="${gemini_location}"
+
+mkdir -p "${extension_dir}"
+# The settings-based v3.x extension carries project/bucket via the top-level
+# `settings` block (resolved from the environment), so only GEMINI_LOCATION is
+# templated into the extension.
+envsubst '${GEMINI_LOCATION}' \
+  < "${template_path}" \
+  > "${extension_dir}/gemini-extension.json"
+
+echo "Configured Gemini CLI extension at ${extension_dir}/gemini-extension.json"
+echo "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-unset}"
+echo "GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION}"
+echo "GEMINI_LOCATION=${GEMINI_LOCATION}"
+echo "GENMEDIA_BUCKET=${GENMEDIA_BUCKET:-unset}"

--- a/experiments/mcp-genmedia/.devcontainer/templates/gemini-extension.json
+++ b/experiments/mcp-genmedia/.devcontainer/templates/gemini-extension.json
@@ -1,0 +1,65 @@
+{
+  "name": "google-genmedia-devcontainer",
+  "version": "3.0.0",
+  "mcpServers": {
+    "veo": {
+      "command": "mcp-veo-go",
+      "env": {
+        "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "240000",
+        "MCP_SERVER_REQUEST_TIMEOUT": "30000"
+      }
+    },
+    "imagen": {
+      "command": "mcp-imagen-go",
+      "env": {
+        "MCP_SERVER_REQUEST_TIMEOUT": "55000"
+      }
+    },
+    "chirp3-hd": {
+      "command": "mcp-chirp3-go",
+      "env": {
+        "MCP_SERVER_REQUEST_TIMEOUT": "55000"
+      }
+    },
+    "lyria": {
+      "command": "mcp-lyria-go",
+      "env": {
+        "MCP_SERVER_REQUEST_TIMEOUT": "55000"
+      }
+    },
+    "avtool": {
+      "command": "mcp-avtool-go",
+      "env": {
+        "MCP_SERVER_REQUEST_TIMEOUT": "55000"
+      }
+    },
+    "nanobanana": {
+      "command": "mcp-nanobanana-go",
+      "env": {
+        "MCP_SERVER_REQUEST_TIMEOUT": "55000"
+      }
+    },
+    "gemini": {
+      "command": "mcp-gemini-go",
+      "env": {
+        "GEMINI_LOCATION": "${GEMINI_LOCATION}",
+        "MCP_REQUEST_MAX_TOTAL_TIMEOUT": "120000",
+        "MCP_SERVER_REQUEST_TIMEOUT": "55000"
+      }
+    }
+  },
+  "settings": [
+    {
+      "name": "Google Cloud Project ID",
+      "description": "The GCP Project ID where Vertex AI is enabled.",
+      "envVar": "GOOGLE_CLOUD_PROJECT",
+      "sensitive": false
+    },
+    {
+      "name": "GenMedia GCS Bucket",
+      "description": "The GCS bucket URI (gs://your-bucket) to save generated media.",
+      "envVar": "GENMEDIA_BUCKET",
+      "sensitive": false
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a Dev Containers setup under `experiments/mcp-genmedia/.devcontainer/` that builds the MCP Genmedia Go servers and wires them into the Gemini CLI, so contributors get a one-step, reproducible environment for exercising the genmedia tools (Veo, Imagen, Nano Banana, Lyria, Chirp3-HD, AVTool, Gemini).

## Why

There is no devcontainer anywhere on `main` today. This re-lands the MCP Genmedia DevContainer originally contributed by @Haihan-Jiang in #1442 — thanks @Haihan-Jiang! The original PR branch had been rebased/history-scrubbed and now presents an 885-file / ~128k-line artifact diff (re-adding the entire already-present `experiments/mcp-genmedia` tree), which is why it shows as CONFLICTING. Rather than untangle that branch, this brings the four genuinely net-new devcontainer files back as a clean, small diff.

## Alignment updates applied (to match current `main`)

- **Versioned build via the single source of truth.** The Dockerfile now builds the servers through the module `Makefile` (`make build`), so each binary is stamped with the ldflags-injected `VERSION` from the single source-of-truth `VERSION` file (per #1595/#1596), instead of a bare `go install` that leaves the version unstamped. No per-file version consts are reintroduced.
- **Location convention (#1591).** Prefer `GOOGLE_CLOUD_LOCATION` over a bare `LOCATION`, and default the Gemini server to the **global** endpoint via `GEMINI_LOCATION` (default `global`, host-overridable).
- **Settings-based v3.x extension.** `templates/gemini-extension.json` is refreshed from the older `v1.0.0` per-server-hardcoded-env approach to `main`'s canonical settings-based `v3.x` pattern: per-server `env` carries only timeouts, while `GOOGLE_CLOUD_PROJECT` and `GENMEDIA_BUCKET` are declared in the top-level `settings` block and resolved from the environment.
- Seed (#1599) needs no config change (it is a tool parameter, not an env/config value).

`GO_VERSION` remains pinned at `1.26.0`, matching the module `go.work`/`go.mod`.

## Files

- `experiments/mcp-genmedia/.devcontainer/Dockerfile`
- `experiments/mcp-genmedia/.devcontainer/devcontainer.json`
- `experiments/mcp-genmedia/.devcontainer/scripts/configure-gemini.sh`
- `experiments/mcp-genmedia/.devcontainer/templates/gemini-extension.json`
- `experiments/mcp-genmedia/.devcontainer/README.md` (short usage + attribution note)

## Verification

- `python3 -m json.tool devcontainer.json` — valid JSON ✅
- `python3 -m json.tool templates/gemini-extension.json` — valid JSON ✅ (and the `envsubst`-rendered output is valid JSON, with `GEMINI_LOCATION` correctly substituted into the `gemini` server env)
- `bash -n scripts/configure-gemini.sh` — syntax OK ✅
- Aligned build path exercised locally: `go build` with `-ldflags "-X main.version=$(cat VERSION)"` compiles a server and the resulting binary runs ✅
- **`docker build` was NOT run** — Docker is not available in the build environment. The Dockerfile was reviewed statically instead; the base image, Go 1.26.0 pin, `make`/`ffmpeg`/`jq`/`gettext-base` install, `make build` + install onto `GOBIN`, and the Gemini CLI launcher were verified by inspection.
