### PR TITLE
feat(mcp): add full omni_video_generation tool surface and shared media persistence

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions.go
@@ -65,6 +65,19 @@ type InteractionRequest struct {
 	ResponseModalities []string    `json:"response_modalities,omitempty"`
 	Input              []InputItem `json:"input"`
 	Store              bool        `json:"store"`
+	// GenerationConfig carries sampling controls (temperature/top_p). It is only
+	// sent when non-nil; the Omni Interactions endpoint parses and validates these
+	// (empirically confirmed: temperature is range-checked to [0.0, 2.0]).
+	GenerationConfig *GenerationConfig `json:"generation_config,omitempty"`
+}
+
+// GenerationConfig models the subset of generation_config the suite sends. Fields
+// are pointers so an unset value is omitted from the wire entirely (the endpoint
+// rejects unknown fields, so we only send what it accepts — e.g. candidate_count
+// is deliberately NOT modeled because the endpoint rejects it, findings/p2a).
+type GenerationConfig struct {
+	Temperature *float32 `json:"temperature,omitempty"`
+	TopP        *float32 `json:"top_p,omitempty"`
 }
 
 // InputItem is one entry in an interaction's input array. For Omni the shape is
@@ -223,12 +236,19 @@ func toLibRequest(req *InteractionRequest) *interactions.InteractionRequest {
 	}
 
 	store := req.Store
-	return &interactions.InteractionRequest{
+	libReq := &interactions.InteractionRequest{
 		Model:              req.Model,
 		ResponseModalities: req.ResponseModalities,
 		Input:              contents,
 		Store:              &store,
 	}
+	if req.GenerationConfig != nil {
+		libReq.GenerationConfig = &interactions.GenerationConfig{
+			Temperature: req.GenerationConfig.Temperature,
+			TopP:        req.GenerationConfig.TopP,
+		}
+	}
+	return libReq
 }
 
 // fromLibResponse translates the library's response type into the suite's own

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions_test.go
@@ -64,7 +64,10 @@ func TestInteractionsClientCreate(t *testing.T) {
 	baseURL := ts.URL + "/v1beta1/projects/test-project/locations/global/interactions"
 	c := newTestClient(baseURL, ts.Client())
 
-	req := buildOmniRequest("gemini-omni-flash-preview", OmniParams{Prompt: "a red balloon"})
+	req, err := buildOmniRequest("gemini-omni-flash-preview", OmniParams{Prompt: "a red balloon"})
+	if err != nil {
+		t.Fatalf("buildOmniRequest returned error: %v", err)
+	}
 	resp, err := c.Create(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -106,7 +109,11 @@ func TestInteractionsClientCreateAPIError(t *testing.T) {
 
 	c := newTestClient(ts.URL, ts.Client())
 
-	_, err := c.Create(context.Background(), buildOmniRequest("m", OmniParams{Prompt: "x"}))
+	req, err := buildOmniRequest("m", OmniParams{Prompt: "x"})
+	if err != nil {
+		t.Fatalf("buildOmniRequest returned error: %v", err)
+	}
+	_, err = c.Create(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected an error for a 400 response, got nil")
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output.go
@@ -1,0 +1,167 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common provides shared utilities for the MCP Genmedia servers.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+)
+
+// signedURLV4MaxHours is the maximum validity for a V4 signed URL (7 days).
+const signedURLV4MaxHours = 168
+
+// MediaArtifact is a single generated media blob to persist (an image, a video,
+// an audio clip, ...). FileName is the base name including extension; it is used
+// verbatim for the local file and, prefixed by any GCS object prefix, for the
+// GCS object name.
+type MediaArtifact struct {
+	Data     []byte
+	MimeType string
+	FileName string
+}
+
+// PersistedMedia is the result of persisting one MediaArtifact. Fields are set
+// only for the destinations that were requested and succeeded. GCSError is
+// non-fatal (the local write, if any, still succeeded) and is left for the
+// caller to surface — matching the suite's established "warn but continue on
+// GCS failure" behavior.
+type PersistedMedia struct {
+	// LocalPath is the local file path written, if output_directory was set.
+	LocalPath string
+	// GCSURI is the gs:// URI uploaded, if gcs_bucket_uri was set and upload succeeded.
+	GCSURI string
+	// GCSObject is the object name (prefix + filename) used for the GCS upload.
+	GCSObject string
+	// SignedURL is a best-effort V4 signed URL for the uploaded object.
+	SignedURL string
+	// GCSError holds a non-fatal GCS upload error, if one occurred.
+	GCSError error
+}
+
+// PersistMediaOutputs writes a generated media artifact to a local directory
+// (when outputDir != "") and/or to GCS (when gcsBucketURI != ""), generating a
+// best-effort V4 signed URL when signedURLExpiry > 0.
+//
+// A local directory-creation or write failure is returned as a fatal error. A
+// GCS upload failure is non-fatal and reported via PersistedMedia.GCSError so
+// the local artifact is still usable. This centralizes the GCS upload +
+// V4-signed-URL + prefix-parsing logic that previously lived, duplicated, inside
+// individual servers (design §7.3).
+func PersistMediaOutputs(ctx context.Context, art MediaArtifact, outputDir, gcsBucketURI string, signedURLExpiry time.Duration) (PersistedMedia, error) {
+	var out PersistedMedia
+
+	if outputDir != "" {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return out, fmt.Errorf("failed to create output directory %q: %w", outputDir, err)
+		}
+		filePath := filepath.Join(outputDir, art.FileName)
+		if err := os.WriteFile(filePath, art.Data, 0644); err != nil {
+			return out, fmt.Errorf("failed to write output file %q: %w", filePath, err)
+		}
+		out.LocalPath = filePath
+	}
+
+	if gcsBucketURI != "" {
+		bucketName, objectPrefix := ParseGCSBucketAndPrefix(gcsBucketURI)
+		objectName := objectPrefix + art.FileName
+		if err := UploadToGCS(ctx, bucketName, objectName, art.MimeType, art.Data); err != nil {
+			out.GCSError = err
+			return out, nil
+		}
+		out.GCSURI = fmt.Sprintf("gs://%s/%s", bucketName, objectName)
+		out.GCSObject = objectName
+
+		// Best-effort V4 signed HTTPS URL so clients can fetch the media without
+		// the bucket being public. Non-fatal on failure.
+		if signedURLExpiry > 0 {
+			if signedURL, sErr := GenerateV4SignedURL(ctx, bucketName, objectName, signedURLExpiry); sErr != nil {
+				log.Printf("failed to generate signed URL for %s: %v", out.GCSURI, sErr)
+			} else {
+				out.SignedURL = signedURL
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// GenerateV4SignedURL creates a V4 GET signed URL for a GCS object. The signing
+// key is detected automatically from the ambient credentials (e.g. the
+// service-account JSON key referenced by GOOGLE_APPLICATION_CREDENTIALS).
+func GenerateV4SignedURL(ctx context.Context, bucketName, objectName string, expiry time.Duration) (string, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("storage.NewClient: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	return client.Bucket(bucketName).SignedURL(objectName, &storage.SignedURLOptions{
+		Scheme:  storage.SigningSchemeV4,
+		Method:  "GET",
+		Expires: time.Now().Add(expiry),
+	})
+}
+
+// ParseGCSBucketAndPrefix splits a "bucket/optional/prefix/" string (with or
+// without a leading gs:// scheme) into a bucket name and an object name prefix
+// that is guaranteed to be empty or end with a "/".
+func ParseGCSBucketAndPrefix(uri string) (bucket, prefix string) {
+	uri = strings.TrimPrefix(uri, "gs://")
+	uri = strings.TrimPrefix(uri, "/")
+	parts := strings.SplitN(uri, "/", 2)
+	bucket = parts[0]
+	if len(parts) > 1 && parts[1] != "" {
+		prefix = parts[1]
+		if !strings.HasSuffix(prefix, "/") {
+			prefix += "/"
+		}
+	}
+	return bucket, prefix
+}
+
+// SignedURLExpiryFromEnv returns the validity duration for generated V4 signed
+// URLs, read from the given environment variable (in hours). It defaults to 24
+// hours, clamps values to 168 hours (the V4 maximum), treats "0" as "disable
+// signed URLs", and falls back to the default for negative or non-numeric input.
+func SignedURLExpiryFromEnv(envVar string) time.Duration {
+	const def = 24 * time.Hour
+	v := strings.TrimSpace(os.Getenv(envVar))
+	if v == "" {
+		return def
+	}
+	h, err := strconv.Atoi(v)
+	if err != nil || h < 0 {
+		log.Printf("invalid %s=%q, using default of 24", envVar, v)
+		return def
+	}
+	if h == 0 {
+		return 0
+	}
+	if h > signedURLV4MaxHours {
+		log.Printf("%s=%d exceeds the V4 maximum of %d (7 days); clamping to %d", envVar, h, signedURLV4MaxHours, signedURLV4MaxHours)
+		h = signedURLV4MaxHours
+	}
+	return time.Duration(h) * time.Hour
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output.go
@@ -52,7 +52,12 @@ type PersistedMedia struct {
 	LocalPath string
 	// GCSURI is the gs:// URI uploaded, if gcs_bucket_uri was set and upload succeeded.
 	GCSURI string
-	// GCSObject is the object name (prefix + filename) used for the GCS upload.
+	// GCSBucket is the destination bucket name. It is populated whenever a GCS
+	// destination was requested (even if the upload later failed) so callers can
+	// log the intended bucket alongside GCSError.
+	GCSBucket string
+	// GCSObject is the object name (prefix + filename) used for the GCS upload. It
+	// is populated whenever a GCS destination was requested (even on failure).
 	GCSObject string
 	// SignedURL is a best-effort V4 signed URL for the uploaded object.
 	SignedURL string
@@ -74,11 +79,11 @@ func PersistMediaOutputs(ctx context.Context, art MediaArtifact, outputDir, gcsB
 
 	if outputDir != "" {
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
-			return out, fmt.Errorf("failed to create output directory %q: %w", outputDir, err)
+			return out, fmt.Errorf("failed to create output directory: %w", err)
 		}
 		filePath := filepath.Join(outputDir, art.FileName)
 		if err := os.WriteFile(filePath, art.Data, 0644); err != nil {
-			return out, fmt.Errorf("failed to write output file %q: %w", filePath, err)
+			return out, fmt.Errorf("failed to write output file: %w", err)
 		}
 		out.LocalPath = filePath
 	}
@@ -86,12 +91,15 @@ func PersistMediaOutputs(ctx context.Context, art MediaArtifact, outputDir, gcsB
 	if gcsBucketURI != "" {
 		bucketName, objectPrefix := ParseGCSBucketAndPrefix(gcsBucketURI)
 		objectName := objectPrefix + art.FileName
+		// Populate the destination up front so a failed upload can still be logged
+		// with its intended bucket/object (GCSURI stays empty until success).
+		out.GCSBucket = bucketName
+		out.GCSObject = objectName
 		if err := UploadToGCS(ctx, bucketName, objectName, art.MimeType, art.Data); err != nil {
 			out.GCSError = err
 			return out, nil
 		}
 		out.GCSURI = fmt.Sprintf("gs://%s/%s", bucketName, objectName)
-		out.GCSObject = objectName
 
 		// Best-effort V4 signed HTTPS URL so clients can fetch the media without
 		// the bucket being public. Non-fatal on failure.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseGCSBucketAndPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		wantBucket string
+		wantPrefix string
+	}{
+		{"bucket only", "my-bucket", "my-bucket", ""},
+		{"bucket only with gs scheme", "gs://my-bucket", "my-bucket", ""},
+		{"bucket with trailing slash", "gs://my-bucket/", "my-bucket", ""},
+		{"bucket and prefix", "gs://my-bucket/prefix", "my-bucket", "prefix/"},
+		{"bucket and prefix trailing slash preserved", "gs://my-bucket/prefix/", "my-bucket", "prefix/"},
+		{"bucket and nested prefix", "gs://my-bucket/a/b/c", "my-bucket", "a/b/c/"},
+		{"bucket and nested prefix trailing slash", "gs://my-bucket/a/b/c/", "my-bucket", "a/b/c/"},
+		{"no gs scheme with prefix", "my-bucket/spike_a", "my-bucket", "spike_a/"},
+		{"leading slash stripped", "/my-bucket/prefix", "my-bucket", "prefix/"},
+		{"gs scheme leading slash", "gs:///my-bucket/prefix", "my-bucket", "prefix/"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBucket, gotPrefix := ParseGCSBucketAndPrefix(tc.uri)
+			if gotBucket != tc.wantBucket {
+				t.Errorf("ParseGCSBucketAndPrefix(%q) bucket = %q, want %q", tc.uri, gotBucket, tc.wantBucket)
+			}
+			if gotPrefix != tc.wantPrefix {
+				t.Errorf("ParseGCSBucketAndPrefix(%q) prefix = %q, want %q", tc.uri, gotPrefix, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestSignedURLExpiryFromEnv(t *testing.T) {
+	const def = 24 * time.Hour  // default validity
+	const max = 168 * time.Hour // V4 ceiling
+	const envVar = "TEST_SIGNED_URL_EXPIRY_HOURS"
+	tests := []struct {
+		name   string
+		env    string // value to set; "" means unset/empty
+		setEnv bool
+		want   time.Duration
+	}{
+		{"unset defaults to 24h", "", false, def},
+		{"empty defaults to 24h", "", true, def},
+		{"explicit 24h", "24", true, 24 * time.Hour},
+		{"1h", "1", true, 1 * time.Hour},
+		{"exactly 168 stays 168", "168", true, max},
+		{"over 168 clamps to 168", "200", true, max},
+		{"way over clamps to 168", "100000", true, max},
+		{"zero disables", "0", true, 0},
+		{"negative -> default", "-5", true, def},
+		{"non-numeric -> default", "notanumber", true, def},
+		{"float -> default (Atoi fails)", "24.5", true, def},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv cannot truly unset; empty string is treated as unset.
+			t.Setenv(envVar, tc.env)
+			if got := SignedURLExpiryFromEnv(envVar); got != tc.want {
+				t.Errorf("SignedURLExpiryFromEnv(%q) with env=%q = %v, want %v", envVar, tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPersistMediaOutputsLocalOnly verifies the local-write path of
+// PersistMediaOutputs without touching GCS (gcsBucketURI empty).
+func TestPersistMediaOutputsLocalOnly(t *testing.T) {
+	dir := t.TempDir()
+	art := MediaArtifact{
+		Data:     []byte("hello-mp4-bytes"),
+		MimeType: "video/mp4",
+		FileName: "omni_20260101_0.mp4",
+	}
+
+	got, err := PersistMediaOutputs(context.Background(), art, dir, "", 0)
+	if err != nil {
+		t.Fatalf("PersistMediaOutputs returned fatal error: %v", err)
+	}
+	wantPath := filepath.Join(dir, art.FileName)
+	if got.LocalPath != wantPath {
+		t.Errorf("LocalPath = %q, want %q", got.LocalPath, wantPath)
+	}
+	if got.GCSURI != "" || got.SignedURL != "" || got.GCSError != nil {
+		t.Errorf("expected no GCS fields, got %+v", got)
+	}
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("reading persisted file: %v", err)
+	}
+	if string(data) != string(art.Data) {
+		t.Errorf("persisted bytes = %q, want %q", data, art.Data)
+	}
+}
+
+// TestPersistMediaOutputsNoDestinations verifies that with neither a local dir
+// nor a GCS URI the call is a no-op (no error, empty result).
+func TestPersistMediaOutputsNoDestinations(t *testing.T) {
+	got, err := PersistMediaOutputs(context.Background(), MediaArtifact{Data: []byte("x"), FileName: "f.mp4"}, "", "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.LocalPath != "" || got.GCSURI != "" || got.SignedURL != "" || got.GCSError != nil {
+		t.Errorf("expected empty result, got %+v", got)
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -479,6 +479,7 @@ func ResolveLyriaModel(modelInput string, allowUnsafe bool) (LyriaModelInfo, boo
 
 	return LyriaModelInfo{}, false
 }
+
 // --- Omni Model Configuration ---
 
 // DefaultOmniModel is the canonical default Gemini Omni model ID.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni.go
@@ -26,20 +26,49 @@ import (
 // omniVideoMimePrefix is the MIME prefix identifying a video output part.
 const omniVideoMimePrefix = "video/"
 
-// OmniParams are the inputs to a Gemini Omni video generation call. This phase
-// exposes only the text prompt and model; image/video inputs and sampling controls
-// are added in a later phase (design §5.1).
+// MaxOmniSampleCount is the maximum number of videos the Omni model produces per
+// prompt (findings §1). sample_count is clamped to this ceiling.
+const MaxOmniSampleCount = 3
+
+// OmniMediaRef is a single image or video input to an Omni generation. It is
+// either inline bytes (Data, base64-encoded onto the wire) or a gs:// URI
+// (URI) — exactly one should be set. MimeType is required for both.
+type OmniMediaRef struct {
+	// Data holds raw media bytes for an inline input part. Mutually exclusive with URI.
+	Data []byte
+	// URI is a gs:// URI for a media input part. Mutually exclusive with Data.
+	URI string
+	// MimeType is the media MIME type (e.g. "image/png", "video/mp4").
+	MimeType string
+}
+
+// OmniParams are the inputs to a Gemini Omni video generation call (design §5.1).
 type OmniParams struct {
 	// Prompt is the text prompt (required).
 	Prompt string
 	// Model is the resolved canonical model ID. If empty, the default Omni model
 	// is used (see ResolveOmniModel).
 	Model string
+	// Images are optional image inputs (image-conditioned generation).
+	Images []OmniMediaRef
+	// Videos are optional video inputs (reference / editing).
+	Videos []OmniMediaRef
+	// SampleCount is the number of videos to generate (1..MaxOmniSampleCount).
+	// Values < 1 are treated as 1; values above the max are clamped. Because the
+	// endpoint rejects generation_config.candidate_count, multiple samples are
+	// produced by issuing that many sequential interactions.
+	SampleCount int
+	// Temperature is the optional sampling temperature (0.0-2.0). Sent in
+	// generation_config only when non-nil (Q1: empirically accepted).
+	Temperature *float32
+	// TopP is the optional nucleus-sampling top_p (0.0-1.0). Sent in
+	// generation_config only when non-nil (Q1: empirically accepted).
+	TopP *float32
 }
 
 // OmniResult is the mapped output of a Gemini Omni video generation call.
 type OmniResult struct {
-	// Videos holds the decoded MP4 bytes for each returned video part (up to 3).
+	// Videos holds the decoded MP4 bytes for each returned video part.
 	Videos [][]byte
 	// VideoMimeTypes holds the MIME type for each entry in Videos (index-aligned).
 	VideoMimeTypes []string
@@ -53,51 +82,142 @@ type OmniResult struct {
 	Status string
 }
 
-// GenerateOmniVideo is the single shared entry point both mcp-omni-go and (later)
+// GenerateOmniVideo is the single shared entry point both mcp-omni-go and
 // mcp-gemini-go call, so the request/response contract can never drift. It builds
-// the Omni envelope (lowercase response_modalities), calls the Interactions client,
-// and maps steps[] -> decoded MP4 bytes + text (design §7.2).
+// the Omni envelope (lowercase response_modalities, image/video input parts,
+// optional generation_config), calls the Interactions client sample_count times,
+// and aggregates the decoded MP4 bytes + text (design §7.2).
 func GenerateOmniVideo(ctx context.Context, cfg *Config, p OmniParams) (*OmniResult, error) {
 	if strings.TrimSpace(p.Prompt) == "" {
 		return nil, fmt.Errorf("omni: prompt must be a non-empty string")
-	}
-
-	model := p.Model
-	if strings.TrimSpace(model) == "" {
-		model = DefaultOmniModel
 	}
 
 	client, err := NewInteractionsClient(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
+	return generateOmniVideoWithClient(ctx, client, p)
+}
 
-	req := buildOmniRequest(model, p)
+// generateOmniVideoWithClient runs the generation against a provided
+// InteractionsClient. It is separated from GenerateOmniVideo so the multi-sample
+// aggregation is unit-testable with a fake client (no ADC required).
+func generateOmniVideoWithClient(ctx context.Context, client InteractionsClient, p OmniParams) (*OmniResult, error) {
+	model := p.Model
+	if strings.TrimSpace(model) == "" {
+		model = DefaultOmniModel
+	}
 
-	resp, err := client.Create(ctx, req)
+	samples := clampSampleCount(p.SampleCount)
+	req, err := buildOmniRequest(model, p)
 	if err != nil {
 		return nil, err
 	}
 
-	return mapOmniResponse(resp)
+	agg := &OmniResult{}
+	for i := 0; i < samples; i++ {
+		resp, err := client.Create(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("omni: sample %d/%d failed: %w", i+1, samples, err)
+		}
+		r, err := mapOmniResponse(resp)
+		if err != nil {
+			return nil, fmt.Errorf("omni: sample %d/%d: %w", i+1, samples, err)
+		}
+		agg.Videos = append(agg.Videos, r.Videos...)
+		agg.VideoMimeTypes = append(agg.VideoMimeTypes, r.VideoMimeTypes...)
+		agg.ThoughtSteps += r.ThoughtSteps
+		if r.Text != "" {
+			if agg.Text != "" {
+				agg.Text += "\n"
+			}
+			agg.Text += r.Text
+		}
+		// Carry the last sample's status/sherlog link (representative of the batch).
+		agg.Status = r.Status
+		if r.SherlogLink != "" {
+			agg.SherlogLink = r.SherlogLink
+		}
+	}
+
+	if len(agg.Videos) == 0 {
+		return agg, fmt.Errorf("omni: no video output found in interaction response(s) (status=%q)", agg.Status)
+	}
+	return agg, nil
+}
+
+// clampSampleCount normalizes a requested sample count into [1, MaxOmniSampleCount].
+func clampSampleCount(n int) int {
+	if n < 1 {
+		return 1
+	}
+	if n > MaxOmniSampleCount {
+		return MaxOmniSampleCount
+	}
+	return n
 }
 
 // buildOmniRequest constructs the Omni interaction envelope. response_modalities
-// is lowercase ["text","video"] per the live wire (findings §3).
-func buildOmniRequest(model string, p OmniParams) *InteractionRequest {
-	return &InteractionRequest{
+// is lowercase ["text","video"] per the live wire (findings §3). Image/video
+// inputs become additional content parts; sampling controls become a
+// generation_config (only when set).
+func buildOmniRequest(model string, p OmniParams) (*InteractionRequest, error) {
+	content := []Part{{Type: "text", Text: p.Prompt}}
+
+	imageParts, err := mediaRefsToParts("image", p.Images)
+	if err != nil {
+		return nil, err
+	}
+	content = append(content, imageParts...)
+
+	videoParts, err := mediaRefsToParts("video", p.Videos)
+	if err != nil {
+		return nil, err
+	}
+	content = append(content, videoParts...)
+
+	req := &InteractionRequest{
 		Model:              model,
 		ResponseModalities: []string{"text", "video"},
 		Input: []InputItem{
-			{
-				Type: "user_input",
-				Content: []Part{
-					{Type: "text", Text: p.Prompt},
-				},
-			},
+			{Type: "user_input", Content: content},
 		},
 		Store: false,
 	}
+
+	if p.Temperature != nil || p.TopP != nil {
+		req.GenerationConfig = &GenerationConfig{Temperature: p.Temperature, TopP: p.TopP}
+	}
+
+	return req, nil
+}
+
+// mediaRefsToParts converts input media refs into interaction Parts of the given
+// type ("image" or "video"). Inline bytes are base64-encoded; gs:// refs are sent
+// by URI. Exactly one of Data/URI must be set per ref.
+func mediaRefsToParts(partType string, refs []OmniMediaRef) ([]Part, error) {
+	parts := make([]Part, 0, len(refs))
+	for i, ref := range refs {
+		switch {
+		case len(ref.Data) > 0 && ref.URI != "":
+			return nil, fmt.Errorf("omni: %s input %d has both inline data and a URI (set exactly one)", partType, i)
+		case len(ref.Data) > 0:
+			parts = append(parts, Part{
+				Type:     partType,
+				MimeType: ref.MimeType,
+				Data:     base64.StdEncoding.EncodeToString(ref.Data),
+			})
+		case ref.URI != "":
+			parts = append(parts, Part{
+				Type:     partType,
+				MimeType: ref.MimeType,
+				URI:      ref.URI,
+			})
+		default:
+			return nil, fmt.Errorf("omni: %s input %d has neither inline data nor a URI", partType, i)
+		}
+	}
+	return parts, nil
 }
 
 // mapOmniResponse walks the interaction's steps[] (falling back to outputs[]),

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_test.go
@@ -15,9 +15,14 @@
 package common
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
 	"testing"
 )
+
+// errFakeTransport is a sentinel error used by the fake Interactions client.
+var errFakeTransport = errors.New("fake transport error")
 
 // sampleMP4 is a tiny byte sequence with a valid MP4 "ftyp" box, used to verify
 // the steps[] -> decoded bytes mapping without a live call.
@@ -105,7 +110,10 @@ func TestMapOmniResponseNoVideo(t *testing.T) {
 }
 
 func TestBuildOmniRequest(t *testing.T) {
-	req := buildOmniRequest("gemini-omni-flash-preview", OmniParams{Prompt: "a red balloon"})
+	req, err := buildOmniRequest("gemini-omni-flash-preview", OmniParams{Prompt: "a red balloon"})
+	if err != nil {
+		t.Fatalf("buildOmniRequest returned error: %v", err)
+	}
 	if req.Model != "gemini-omni-flash-preview" {
 		t.Errorf("Model = %q", req.Model)
 	}
@@ -117,6 +125,134 @@ func TestBuildOmniRequest(t *testing.T) {
 	}
 	if len(req.Input[0].Content) != 1 || req.Input[0].Content[0].Text != "a red balloon" {
 		t.Errorf("Input content unexpected: %+v", req.Input[0].Content)
+	}
+	if req.GenerationConfig != nil {
+		t.Errorf("GenerationConfig should be nil when no sampling params set, got %+v", req.GenerationConfig)
+	}
+}
+
+func TestBuildOmniRequestWithInputsAndSampling(t *testing.T) {
+	temp := float32(0.7)
+	topP := float32(0.9)
+	req, err := buildOmniRequest("gemini-omni-flash-preview", OmniParams{
+		Prompt:      "animate this",
+		Images:      []OmniMediaRef{{Data: []byte("PNGDATA"), MimeType: "image/png"}},
+		Videos:      []OmniMediaRef{{URI: "gs://bucket/clip.mp4", MimeType: "video/mp4"}},
+		Temperature: &temp,
+		TopP:        &topP,
+	})
+	if err != nil {
+		t.Fatalf("buildOmniRequest returned error: %v", err)
+	}
+	content := req.Input[0].Content
+	// text + image + video = 3 parts, in that order.
+	if len(content) != 3 {
+		t.Fatalf("len(content) = %d, want 3: %+v", len(content), content)
+	}
+	if content[0].Type != "text" || content[0].Text != "animate this" {
+		t.Errorf("part[0] = %+v, want text 'animate this'", content[0])
+	}
+	if content[1].Type != "image" || content[1].MimeType != "image/png" {
+		t.Errorf("part[1] = %+v, want image/png", content[1])
+	}
+	if got := base64.StdEncoding.EncodeToString([]byte("PNGDATA")); content[1].Data != got {
+		t.Errorf("image data = %q, want base64 %q", content[1].Data, got)
+	}
+	if content[1].URI != "" {
+		t.Errorf("inline image should not set URI, got %q", content[1].URI)
+	}
+	if content[2].Type != "video" || content[2].URI != "gs://bucket/clip.mp4" || content[2].Data != "" {
+		t.Errorf("part[2] = %+v, want video by URI", content[2])
+	}
+	if req.GenerationConfig == nil || req.GenerationConfig.Temperature == nil || *req.GenerationConfig.Temperature != 0.7 {
+		t.Errorf("GenerationConfig.Temperature not set correctly: %+v", req.GenerationConfig)
+	}
+	if req.GenerationConfig.TopP == nil || *req.GenerationConfig.TopP != 0.9 {
+		t.Errorf("GenerationConfig.TopP not set correctly: %+v", req.GenerationConfig)
+	}
+}
+
+func TestMediaRefsToPartsErrors(t *testing.T) {
+	if _, err := mediaRefsToParts("image", []OmniMediaRef{{MimeType: "image/png"}}); err == nil {
+		t.Errorf("expected error for a ref with neither Data nor URI")
+	}
+	if _, err := mediaRefsToParts("image", []OmniMediaRef{{Data: []byte("x"), URI: "gs://b/o", MimeType: "image/png"}}); err == nil {
+		t.Errorf("expected error for a ref with both Data and URI")
+	}
+}
+
+func TestClampSampleCount(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{-3, 1}, {0, 1}, {1, 1}, {2, 2}, {3, 3}, {4, 3}, {100, 3},
+	}
+	for _, c := range cases {
+		if got := clampSampleCount(c.in); got != c.want {
+			t.Errorf("clampSampleCount(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// fakeInteractionsClient returns a fixed response (or error) for each Create,
+// recording how many times it was called — enough to exercise the multi-sample
+// aggregation in generateOmniVideoWithClient without ADC or a live call.
+type fakeInteractionsClient struct {
+	calls int
+	resp  *InteractionResponse
+	err   error
+}
+
+func (f *fakeInteractionsClient) Create(_ context.Context, _ *InteractionRequest) (*InteractionResponse, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+func TestGenerateOmniVideoWithClientMultiSample(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString(sampleMP4)
+	resp, err := decodeInteractionResponse([]byte(omniResponseJSON(b64)))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	fake := &fakeInteractionsClient{resp: resp}
+
+	result, err := generateOmniVideoWithClient(context.Background(), fake, OmniParams{Prompt: "x", SampleCount: 3})
+	if err != nil {
+		t.Fatalf("generateOmniVideoWithClient: %v", err)
+	}
+	if fake.calls != 3 {
+		t.Errorf("Create called %d times, want 3", fake.calls)
+	}
+	if len(result.Videos) != 3 {
+		t.Errorf("len(Videos) = %d, want 3 (one per sample)", len(result.Videos))
+	}
+	if result.ThoughtSteps != 3 {
+		t.Errorf("ThoughtSteps = %d, want 3", result.ThoughtSteps)
+	}
+	for i, v := range result.Videos {
+		if !hasFtypBox(v) {
+			t.Errorf("video %d missing ftyp box", i)
+		}
+	}
+}
+
+func TestGenerateOmniVideoWithClientClampsAndErrors(t *testing.T) {
+	// A sample count above the max is clamped to MaxOmniSampleCount calls.
+	b64 := base64.StdEncoding.EncodeToString(sampleMP4)
+	resp, _ := decodeInteractionResponse([]byte(omniResponseJSON(b64)))
+	fake := &fakeInteractionsClient{resp: resp}
+	if _, err := generateOmniVideoWithClient(context.Background(), fake, OmniParams{Prompt: "x", SampleCount: 99}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.calls != MaxOmniSampleCount {
+		t.Errorf("Create called %d times, want %d (clamped)", fake.calls, MaxOmniSampleCount)
+	}
+
+	// A transport error is surfaced with sample context.
+	failing := &fakeInteractionsClient{err: errFakeTransport}
+	if _, err := generateOmniVideoWithClient(context.Background(), failing, OmniParams{Prompt: "x", SampleCount: 2}); err == nil {
+		t.Errorf("expected error from failing client, got nil")
 	}
 }
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -22,11 +22,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -146,6 +144,7 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		}
 	}
 	gentime := time.Now().Format("20060102150405")
+	expiry := common.SignedURLExpiryFromEnv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS")
 
 	for _, candidate := range resp.Candidates {
 		for n, part := range candidate.Content.Parts {
@@ -154,46 +153,34 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 			}
 			if part.InlineData != nil {
 				log.Printf("part %d mime-type: %s", n, part.InlineData.MIMEType)
-				saved := false
 
-				if outputDir != "" {
-					if err := os.MkdirAll(outputDir, 0755); err != nil {
-						return mcp.NewToolResultError(fmt.Sprintf("failed to create output directory: %v", err)), nil
-					}
-					fileName := fmt.Sprintf("gemini_%s_%d%s", gentime, n, extForMimeType(part.InlineData.MIMEType))
-					filePath := filepath.Join(outputDir, fileName)
-					if err := os.WriteFile(filePath, part.InlineData.Data, 0644); err != nil {
-						return mcp.NewToolResultError(fmt.Sprintf("failed to write image file: %v", err)), nil
-					}
-					savedFiles = append(savedFiles, filePath)
-					saved = true
+				fileName := fmt.Sprintf("gemini_%s_%d%s", gentime, n, extForMimeType(part.InlineData.MIMEType))
+				persisted, err := common.PersistMediaOutputs(ctx, common.MediaArtifact{
+					Data:     part.InlineData.Data,
+					MimeType: part.InlineData.MIMEType,
+					FileName: fileName,
+				}, outputDir, gcsBucketURI, expiry)
+				if err != nil {
+					return mcp.NewToolResultError(fmt.Sprintf("failed to save generated image: %v", err)), nil
 				}
 
-				if gcsBucketURI != "" {
-					bucketName, objectPrefix := parseGCSBucketAndPrefix(gcsBucketURI)
-					objectName := fmt.Sprintf("%sgemini_%s_%d%s", objectPrefix, gentime, n, extForMimeType(part.InlineData.MIMEType))
-					if err := common.UploadToGCS(ctx, bucketName, objectName, part.InlineData.MIMEType, part.InlineData.Data); err != nil {
-						log.Printf("failed to upload image to gs://%s/%s: %v", bucketName, objectName, err)
-						fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated image to GCS: %v]", err)
-					} else {
-						gcsURI := fmt.Sprintf("gs://%s/%s", bucketName, objectName)
-						savedFiles = append(savedFiles, gcsURI)
-						saved = true
-
-						// Best-effort: also return a V4 signed HTTPS URL so clients
-						// (e.g. Claude) can fetch/display the image without the
-						// bucket being public. Non-fatal on failure.
-						if expiry := signedURLExpiry(); expiry > 0 {
-							if signedURL, sErr := generateSignedURL(ctx, bucketName, objectName, expiry); sErr != nil {
-								log.Printf("failed to generate signed URL for %s: %v", gcsURI, sErr)
-							} else {
-								fmt.Fprintf(&responseText, "\n\nSigned URL for %s (valid %s):\n%s", objectName, expiry, signedURL)
-							}
-						}
-					}
+				if persisted.LocalPath != "" {
+					savedFiles = append(savedFiles, persisted.LocalPath)
+				}
+				if persisted.GCSError != nil {
+					log.Printf("failed to upload image to GCS: %v", persisted.GCSError)
+					fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated image to GCS: %v]", persisted.GCSError)
+				}
+				if persisted.GCSURI != "" {
+					savedFiles = append(savedFiles, persisted.GCSURI)
+				}
+				// Best-effort V4 signed HTTPS URL so clients (e.g. Claude) can
+				// fetch/display the image without the bucket being public.
+				if persisted.SignedURL != "" {
+					fmt.Fprintf(&responseText, "\n\nSigned URL for %s (valid %s):\n%s", persisted.GCSObject, expiry, persisted.SignedURL)
 				}
 
-				if !saved {
+				if persisted.LocalPath == "" && persisted.GCSURI == "" {
 					log.Println("Received image data but no output_directory or gcs_bucket_uri was specified/valid. Image not saved.")
 				}
 			}
@@ -237,65 +224,6 @@ func inferMimeType(path string) string {
 		// A more robust solution might involve reading file headers.
 		return "image/png"
 	}
-}
-
-// signedURLExpiry returns the validity duration for generated V4 signed URLs.
-// Controlled by the NANOBANANA_SIGNED_URL_EXPIRY_HOURS env var. Defaults to
-// 24 hours. Values are clamped to 168 hours (7 days, the V4 maximum). Set to
-// "0" to disable signed URL generation entirely.
-func signedURLExpiry() time.Duration {
-	const def = 24 * time.Hour
-	v := strings.TrimSpace(os.Getenv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS"))
-	if v == "" {
-		return def
-	}
-	h, err := strconv.Atoi(v)
-	if err != nil || h < 0 {
-		log.Printf("invalid NANOBANANA_SIGNED_URL_EXPIRY_HOURS=%q, using default of 24", v)
-		return def
-	}
-	if h == 0 {
-		return 0
-	}
-	if h > 168 {
-		log.Printf("NANOBANANA_SIGNED_URL_EXPIRY_HOURS=%d exceeds the V4 maximum of 168 (7 days); clamping to 168", h)
-		h = 168
-	}
-	return time.Duration(h) * time.Hour
-}
-
-// generateSignedURL creates a V4 GET signed URL for a GCS object. The signing
-// key is detected automatically from the ambient credentials (e.g. the
-// service-account JSON key referenced by GOOGLE_APPLICATION_CREDENTIALS).
-func generateSignedURL(ctx context.Context, bucketName, objectName string, expiry time.Duration) (string, error) {
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("storage.NewClient: %w", err)
-	}
-	defer func() { _ = client.Close() }()
-
-	return client.Bucket(bucketName).SignedURL(objectName, &storage.SignedURLOptions{
-		Scheme:  storage.SigningSchemeV4,
-		Method:  "GET",
-		Expires: time.Now().Add(expiry),
-	})
-}
-
-// parseGCSBucketAndPrefix splits a "bucket/optional/prefix/" string (with or
-// without a leading gs:// scheme) into a bucket name and an object name
-// prefix that is guaranteed to be empty or end with a "/".
-func parseGCSBucketAndPrefix(uri string) (bucket, prefix string) {
-	uri = strings.TrimPrefix(uri, "gs://")
-	uri = strings.TrimPrefix(uri, "/")
-	parts := strings.SplitN(uri, "/", 2)
-	bucket = parts[0]
-	if len(parts) > 1 && parts[1] != "" {
-		prefix = parts[1]
-		if !strings.HasSuffix(prefix, "/") {
-			prefix += "/"
-		}
-	}
-	return bucket, prefix
 }
 
 // extForMimeType returns a reasonable file extension for a given image MIME type.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -161,14 +161,14 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 					FileName: fileName,
 				}, outputDir, gcsBucketURI, expiry)
 				if err != nil {
-					return mcp.NewToolResultError(fmt.Sprintf("failed to save generated image: %v", err)), nil
+					return mcp.NewToolResultError(err.Error()), nil
 				}
 
 				if persisted.LocalPath != "" {
 					savedFiles = append(savedFiles, persisted.LocalPath)
 				}
 				if persisted.GCSError != nil {
-					log.Printf("failed to upload image to GCS: %v", persisted.GCSError)
+					log.Printf("failed to upload image to gs://%s/%s: %v", persisted.GCSBucket, persisted.GCSObject, persisted.GCSError)
 					fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated image to GCS: %v]", persisted.GCSError)
 				}
 				if persisted.GCSURI != "" {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_test.go
@@ -17,38 +17,9 @@ package main
 import (
 	"testing"
 	"time"
-)
 
-func TestParseGCSBucketAndPrefix(t *testing.T) {
-	tests := []struct {
-		name       string
-		uri        string
-		wantBucket string
-		wantPrefix string
-	}{
-		{"bucket only", "my-bucket", "my-bucket", ""},
-		{"bucket only with gs scheme", "gs://my-bucket", "my-bucket", ""},
-		{"bucket with trailing slash", "gs://my-bucket/", "my-bucket", ""},
-		{"bucket and prefix", "gs://my-bucket/prefix", "my-bucket", "prefix/"},
-		{"bucket and prefix trailing slash preserved", "gs://my-bucket/prefix/", "my-bucket", "prefix/"},
-		{"bucket and nested prefix", "gs://my-bucket/a/b/c", "my-bucket", "a/b/c/"},
-		{"bucket and nested prefix trailing slash", "gs://my-bucket/a/b/c/", "my-bucket", "a/b/c/"},
-		{"no gs scheme with prefix", "my-bucket/spike_a", "my-bucket", "spike_a/"},
-		{"leading slash stripped", "/my-bucket/prefix", "my-bucket", "prefix/"},
-		{"gs scheme leading slash", "gs:///my-bucket/prefix", "my-bucket", "prefix/"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			gotBucket, gotPrefix := parseGCSBucketAndPrefix(tc.uri)
-			if gotBucket != tc.wantBucket {
-				t.Errorf("parseGCSBucketAndPrefix(%q) bucket = %q, want %q", tc.uri, gotBucket, tc.wantBucket)
-			}
-			if gotPrefix != tc.wantPrefix {
-				t.Errorf("parseGCSBucketAndPrefix(%q) prefix = %q, want %q", tc.uri, gotPrefix, tc.wantPrefix)
-			}
-		})
-	}
-}
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
+)
 
 func TestExtForMimeType(t *testing.T) {
 	tests := []struct {
@@ -72,39 +43,29 @@ func TestExtForMimeType(t *testing.T) {
 	}
 }
 
-func TestSignedURLExpiry(t *testing.T) {
-	const def = 24 * time.Hour  // default validity
-	const max = 168 * time.Hour // V4 ceiling
-	tests := []struct {
-		name   string
-		env    string // value to set; "" means unset/empty
-		setEnv bool
-		want   time.Duration
-	}{
-		{"unset defaults to 24h", "", false, def},
-		{"empty defaults to 24h", "", true, def},
-		{"explicit 24h", "24", true, 24 * time.Hour},
-		{"1h", "1", true, 1 * time.Hour},
-		{"exactly 168 stays 168", "168", true, max},
-		{"over 168 clamps to 168", "200", true, max},
-		{"way over clamps to 168", "100000", true, max},
-		{"zero disables", "0", true, 0},
-		{"negative -> default", "-5", true, def},
-		{"non-numeric -> default", "notanumber", true, def},
-		{"float -> default (Atoi fails)", "24.5", true, def},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.setEnv {
-				t.Setenv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS", tc.env)
-			} else {
-				// Ensure it is unset for this case.
-				t.Setenv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS", "")
-				// t.Setenv cannot truly unset; empty string is treated as unset by signedURLExpiry.
-			}
-			if got := signedURLExpiry(); got != tc.want {
-				t.Errorf("signedURLExpiry() with env=%q = %v, want %v", tc.env, got, tc.want)
-			}
-		})
-	}
+// TestSignedURLExpiryWiring guards the nanobanana-specific env var name that is
+// read through the shared common.SignedURLExpiryFromEnv helper. The exhaustive
+// clamp/default/disable behavior is covered by common's own tests; this only
+// asserts the wiring (correct env var, values honored) after the extraction.
+func TestSignedURLExpiryWiring(t *testing.T) {
+	const envVar = "NANOBANANA_SIGNED_URL_EXPIRY_HOURS"
+
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv(envVar, "")
+		if got := common.SignedURLExpiryFromEnv(envVar); got != 24*time.Hour {
+			t.Errorf("got %v, want 24h", got)
+		}
+	})
+	t.Run("explicit value honored", func(t *testing.T) {
+		t.Setenv(envVar, "6")
+		if got := common.SignedURLExpiryFromEnv(envVar); got != 6*time.Hour {
+			t.Errorf("got %v, want 6h", got)
+		}
+	})
+	t.Run("zero disables", func(t *testing.T) {
+		t.Setenv(envVar, "0")
+		if got := common.SignedURLExpiryFromEnv(envVar); got != 0 {
+			t.Errorf("got %v, want 0", got)
+		}
+	})
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.mod
@@ -3,7 +3,6 @@ module github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-
 go 1.26.0
 
 require (
-	cloud.google.com/go/storage v1.64.0
 	github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20260810132958-58c6df0d10a8
 	github.com/mark3labs/mcp-go v0.57.0
 	go.opentelemetry.io/otel v1.45.0
@@ -17,6 +16,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/monitoring v1.29.0 // indirect
+	cloud.google.com/go/storage v1.64.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
@@ -20,13 +20,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -34,38 +33,83 @@ import (
 	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
 )
 
-// omniVideoGenerationHandler generates video via the shared common.GenerateOmniVideo
-// entry point and persists the returned MP4 bytes locally and/or to GCS (with a
-// best-effort V4 signed URL), reusing the suite's proven output conventions.
+// maxOmniImages is the per-prompt image input limit (findings §1).
+const maxOmniImages = 10
+
+// omniVideoGenerationHandler generates one or more videos via the shared
+// common.GenerateOmniVideo entry point and persists the returned MP4 bytes
+// locally and/or to GCS (with best-effort V4 signed URLs), reusing the suite's
+// shared common.PersistMediaOutputs helper.
 func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tr := otel.Tracer(serviceName)
 	ctx, span := tr.Start(ctx, "omni_video_generation")
 	defer span.End()
 
+	args := request.GetArguments()
+
 	// --- Parameter Parsing ---
-	prompt, ok := request.GetArguments()["prompt"].(string)
+	prompt, ok := args["prompt"].(string)
 	if !ok || strings.TrimSpace(prompt) == "" {
 		return mcp.NewToolResultError("prompt must be a non-empty string and is required"), nil
 	}
 	prompt = strings.TrimSpace(prompt)
 
 	outputDir := ""
-	if dir, ok := request.GetArguments()["output_directory"].(string); ok && strings.TrimSpace(dir) != "" {
+	if dir, ok := args["output_directory"].(string); ok && strings.TrimSpace(dir) != "" {
 		outputDir = strings.TrimSpace(dir)
 	}
 
 	// gcsBucketURI: explicit "gcs_bucket_uri" takes precedence, otherwise fall
 	// back to the server-wide GENMEDIA_BUCKET default (mirrors the other tools).
 	gcsBucketURI := ""
-	if u, ok := request.GetArguments()["gcs_bucket_uri"].(string); ok && strings.TrimSpace(u) != "" {
+	if u, ok := args["gcs_bucket_uri"].(string); ok && strings.TrimSpace(u) != "" {
 		gcsBucketURI = strings.TrimSpace(u)
 	} else if appConfig != nil && appConfig.GenmediaBucket != "" {
 		gcsBucketURI = appConfig.GenmediaBucket + "/omni_outputs/"
 	}
 
+	// Model resolution (honors an optional "model" arg / alias).
+	modelArg, _ := args["model"].(string)
 	model := common.DefaultOmniModel
-	if resolved, found := common.ResolveOmniModel("", appConfig.AllowUnsafeModels); found {
+	if resolved, found := common.ResolveOmniModel(modelArg, appConfig.AllowUnsafeModels); found {
 		model = resolved.CanonicalName
+	} else if strings.TrimSpace(modelArg) != "" {
+		return mcp.NewToolResultError(fmt.Sprintf("unsupported model %q (set ALLOW_UNSAFE_MODELS=true to bypass)", modelArg)), nil
+	}
+
+	// Image / video inputs (local paths -> inline bytes; gs:// -> URI).
+	images, err := parseMediaRefs(args["images"], "image")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if len(images) > maxOmniImages {
+		return mcp.NewToolResultError(fmt.Sprintf("too many images: %d provided, the model accepts at most %d", len(images), maxOmniImages)), nil
+	}
+	videos, err := parseMediaRefs(args["videos"], "video")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// sample_count (default 1, clamped to the model max by the shared helper).
+	sampleCount := 1
+	if raw, present := args["sample_count"]; present {
+		n, convErr := toInt(raw)
+		if convErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("sample_count must be an integer: %v", convErr)), nil
+		}
+		if n >= 1 {
+			sampleCount = n
+		}
+	}
+
+	// temperature / top_p (optional; validated client-side, then sent in generation_config).
+	temperature, err := parseOptionalFloatInRange(args, "temperature", 0.0, 2.0)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	topP, err := parseOptionalFloatInRange(args, "top_p", 0.0, 1.0)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	span.SetAttributes(
@@ -73,13 +117,24 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 		attribute.String("model", model),
 		attribute.String("output_directory", outputDir),
 		attribute.String("gcs_bucket_uri", gcsBucketURI),
+		attribute.Int("images", len(images)),
+		attribute.Int("videos", len(videos)),
+		attribute.Int("sample_count", sampleCount),
 	)
 
 	// --- Shared Omni call ---
-	log.Printf("Calling GenerateOmniVideo with Model: %s, Prompt: %q", model, prompt)
+	log.Printf("Calling GenerateOmniVideo Model=%s sample_count=%d images=%d videos=%d", model, sampleCount, len(images), len(videos))
 	startTime := time.Now()
 
-	result, err := common.GenerateOmniVideo(ctx, appConfig, common.OmniParams{Prompt: prompt, Model: model})
+	result, err := common.GenerateOmniVideo(ctx, appConfig, common.OmniParams{
+		Prompt:      prompt,
+		Model:       model,
+		Images:      images,
+		Videos:      videos,
+		SampleCount: sampleCount,
+		Temperature: temperature,
+		TopP:        topP,
+	})
 
 	apiCallDuration := time.Since(startTime)
 	log.Printf("GenerateOmniVideo call took: %v", apiCallDuration)
@@ -99,11 +154,13 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 	if strings.TrimSpace(result.Text) != "" {
 		responseText.WriteString(result.Text)
 	}
+	// Surface any thought/summary reasoning as a NOTE (not as a media output).
 	if result.ThoughtSteps > 0 {
-		fmt.Fprintf(&responseText, "\n\n(model reasoning: %d step(s))", result.ThoughtSteps)
+		fmt.Fprintf(&responseText, "\n\n[Note: model returned %d reasoning (thought) step(s).]", result.ThoughtSteps)
 	}
 
 	gentime := time.Now().Format("20060102150405")
+	expiry := common.SignedURLExpiryFromEnv("OMNI_SIGNED_URL_EXPIRY_HOURS")
 	var savedFiles []string
 
 	for n, videoBytes := range result.Videos {
@@ -111,52 +168,37 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 		if n < len(result.VideoMimeTypes) && result.VideoMimeTypes[n] != "" {
 			mimeType = result.VideoMimeTypes[n]
 		}
-		saved := false
 
-		if outputDir != "" {
-			if err := os.MkdirAll(outputDir, 0755); err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("failed to create output directory: %v", err)), nil
-			}
-			fileName := fmt.Sprintf("omni_%s_%d.mp4", gentime, n)
-			filePath := filepath.Join(outputDir, fileName)
-			if err := os.WriteFile(filePath, videoBytes, 0644); err != nil {
-				return mcp.NewToolResultError(fmt.Sprintf("failed to write video file: %v", err)), nil
-			}
-			savedFiles = append(savedFiles, filePath)
-			saved = true
+		persisted, err := common.PersistMediaOutputs(ctx, common.MediaArtifact{
+			Data:     videoBytes,
+			MimeType: mimeType,
+			FileName: fmt.Sprintf("omni_%s_%d.mp4", gentime, n),
+		}, outputDir, gcsBucketURI, expiry)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to save generated video: %v", err)), nil
 		}
 
-		if gcsBucketURI != "" {
-			bucketName, objectPrefix := parseGCSBucketAndPrefix(gcsBucketURI)
-			objectName := fmt.Sprintf("%somni_%s_%d.mp4", objectPrefix, gentime, n)
-			if err := common.UploadToGCS(ctx, bucketName, objectName, mimeType, videoBytes); err != nil {
-				log.Printf("failed to upload video to gs://%s/%s: %v", bucketName, objectName, err)
-				fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated video to GCS: %v]", err)
-			} else {
-				gcsURI := fmt.Sprintf("gs://%s/%s", bucketName, objectName)
-				savedFiles = append(savedFiles, gcsURI)
-				saved = true
-
-				// Best-effort V4 signed HTTPS URL so clients can fetch the video
-				// without the bucket being public. Non-fatal on failure.
-				if expiry := signedURLExpiry(); expiry > 0 {
-					if signedURL, sErr := generateSignedURL(ctx, bucketName, objectName, expiry); sErr != nil {
-						log.Printf("failed to generate signed URL for %s: %v", gcsURI, sErr)
-					} else {
-						fmt.Fprintf(&responseText, "\n\nSigned URL for %s (valid %s):\n%s", objectName, expiry, signedURL)
-					}
-				}
-			}
+		if persisted.LocalPath != "" {
+			savedFiles = append(savedFiles, persisted.LocalPath)
 		}
-
-		if !saved {
+		if persisted.GCSError != nil {
+			log.Printf("failed to upload video to GCS: %v", persisted.GCSError)
+			fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated video to GCS: %v]", persisted.GCSError)
+		}
+		if persisted.GCSURI != "" {
+			savedFiles = append(savedFiles, persisted.GCSURI)
+		}
+		if persisted.SignedURL != "" {
+			fmt.Fprintf(&responseText, "\n\nSigned URL for %s (valid %s):\n%s", persisted.GCSObject, expiry, persisted.SignedURL)
+		}
+		if persisted.LocalPath == "" && persisted.GCSURI == "" {
 			log.Println("Received video data but no output_directory or gcs_bucket_uri was specified/valid. Video not saved.")
 		}
 	}
 
 	finalMessage := responseText.String()
 	if len(savedFiles) > 0 {
-		finalMessage += fmt.Sprintf("\n\nGenerated and saved %d video(s): %s", len(savedFiles), strings.Join(savedFiles, ", "))
+		finalMessage += fmt.Sprintf("\n\nGenerated and saved %d video(s): %s", len(result.Videos), strings.Join(savedFiles, ", "))
 	} else {
 		finalMessage += fmt.Sprintf("\n\nGenerated %d video(s) but none were saved (set output_directory or gcs_bucket_uri).", len(result.Videos))
 	}
@@ -164,59 +206,107 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 	return &mcp.CallToolResult{Content: []mcp.Content{mcp.TextContent{Type: "text", Text: strings.TrimSpace(finalMessage)}}}, nil
 }
 
-// signedURLExpiry returns the validity duration for generated V4 signed URLs.
-// Controlled by OMNI_SIGNED_URL_EXPIRY_HOURS. Defaults to 24 hours. Values are
-// clamped to 168 hours (the V4 maximum). Set to "0" to disable signed URLs.
-func signedURLExpiry() time.Duration {
-	const def = 24 * time.Hour
-	v := strings.TrimSpace(os.Getenv("OMNI_SIGNED_URL_EXPIRY_HOURS"))
-	if v == "" {
-		return def
+// parseMediaRefs converts a tool argument (expected to be an array of strings,
+// each a local file path or a gs:// URI) into common.OmniMediaRef values. Local
+// paths are read into memory; gs:// URIs are passed through by reference. kind is
+// "image" or "video" and is used only for error messages and MIME inference.
+func parseMediaRefs(arg any, kind string) ([]common.OmniMediaRef, error) {
+	if arg == nil {
+		return nil, nil
 	}
-	h, err := strconv.Atoi(v)
-	if err != nil || h < 0 {
-		log.Printf("invalid OMNI_SIGNED_URL_EXPIRY_HOURS=%q, using default of 24", v)
-		return def
+	list, ok := arg.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%ss must be an array of strings", kind)
 	}
-	if h == 0 {
-		return 0
-	}
-	if h > 168 {
-		log.Printf("OMNI_SIGNED_URL_EXPIRY_HOURS=%d exceeds the V4 maximum of 168 (7 days); clamping to 168", h)
-		h = 168
-	}
-	return time.Duration(h) * time.Hour
-}
 
-// generateSignedURL creates a V4 GET signed URL for a GCS object. The signing key
-// is detected automatically from the ambient credentials.
-func generateSignedURL(ctx context.Context, bucketName, objectName string, expiry time.Duration) (string, error) {
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return "", fmt.Errorf("storage.NewClient: %w", err)
-	}
-	defer func() { _ = client.Close() }()
-
-	return client.Bucket(bucketName).SignedURL(objectName, &storage.SignedURLOptions{
-		Scheme:  storage.SigningSchemeV4,
-		Method:  "GET",
-		Expires: time.Now().Add(expiry),
-	})
-}
-
-// parseGCSBucketAndPrefix splits a "bucket/optional/prefix/" string (with or
-// without a leading gs:// scheme) into a bucket name and an object name prefix
-// that is guaranteed to be empty or end with a "/".
-func parseGCSBucketAndPrefix(uri string) (bucket, prefix string) {
-	uri = strings.TrimPrefix(uri, "gs://")
-	uri = strings.TrimPrefix(uri, "/")
-	parts := strings.SplitN(uri, "/", 2)
-	bucket = parts[0]
-	if len(parts) > 1 && parts[1] != "" {
-		prefix = parts[1]
-		if !strings.HasSuffix(prefix, "/") {
-			prefix += "/"
+	refs := make([]common.OmniMediaRef, 0, len(list))
+	for _, item := range list {
+		path, ok := item.(string)
+		if !ok || strings.TrimSpace(path) == "" {
+			return nil, fmt.Errorf("each %s entry must be a non-empty string (local path or gs:// URI)", kind)
 		}
+		path = strings.TrimSpace(path)
+		mimeType := inferMediaMimeType(path)
+
+		if strings.HasPrefix(path, "gs://") {
+			refs = append(refs, common.OmniMediaRef{URI: path, MimeType: mimeType})
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s file %q: %w", kind, path, err)
+		}
+		refs = append(refs, common.OmniMediaRef{Data: data, MimeType: mimeType})
 	}
-	return bucket, prefix
+	return refs, nil
+}
+
+// inferMediaMimeType infers an image/video MIME type from a file extension.
+func inferMediaMimeType(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	case ".heic":
+		return "image/heic"
+	case ".heif":
+		return "image/heif"
+	case ".mp4":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	case ".webm":
+		return "video/webm"
+	case ".mpeg", ".mpg":
+		return "video/mpeg"
+	case ".flv":
+		return "video/x-flv"
+	case ".wmv":
+		return "video/wmv"
+	case ".3gp", ".3gpp":
+		return "video/3gpp"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// toInt coerces a JSON-decoded numeric tool argument to an int. MCP arguments
+// arrive as float64 for JSON numbers; a string of digits is also accepted.
+func toInt(v any) (int, error) {
+	switch n := v.(type) {
+	case float64:
+		if n != math.Trunc(n) {
+			return 0, fmt.Errorf("expected an integer, got %v", n)
+		}
+		return int(n), nil
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	default:
+		return 0, fmt.Errorf("expected a number, got %T", v)
+	}
+}
+
+// parseOptionalFloatInRange reads an optional float tool argument and validates
+// it lies within [min, max]. Returns nil when the argument is absent.
+func parseOptionalFloatInRange(args map[string]interface{}, key string, min, max float64) (*float32, error) {
+	raw, present := args[key]
+	if !present || raw == nil {
+		return nil, nil
+	}
+	f, ok := raw.(float64)
+	if !ok {
+		return nil, fmt.Errorf("%s must be a number", key)
+	}
+	if f < min || f > max {
+		return nil, fmt.Errorf("%s must be in the range [%.1f, %.1f], got %v", key, min, max, f)
+	}
+	v := float32(f)
+	return &v, nil
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
@@ -175,14 +175,14 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 			FileName: fmt.Sprintf("omni_%s_%d.mp4", gentime, n),
 		}, outputDir, gcsBucketURI, expiry)
 		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to save generated video: %v", err)), nil
+			return mcp.NewToolResultError(err.Error()), nil
 		}
 
 		if persisted.LocalPath != "" {
 			savedFiles = append(savedFiles, persisted.LocalPath)
 		}
 		if persisted.GCSError != nil {
-			log.Printf("failed to upload video to GCS: %v", persisted.GCSError)
+			log.Printf("failed to upload video to gs://%s/%s: %v", persisted.GCSBucket, persisted.GCSObject, persisted.GCSError)
 			fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated video to GCS: %v]", persisted.GCSError)
 		}
 		if persisted.GCSURI != "" {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
@@ -36,6 +36,12 @@ import (
 // maxOmniImages is the per-prompt image input limit (findings §1).
 const maxOmniImages = 10
 
+// maxInlineMediaBytes caps the size of a local media file that will be read into
+// memory and base64-inlined into the interaction request. Larger files must be
+// referenced by a gs:// URI instead (base64 inflates payloads ~33%, and the
+// Interactions request body is bounded). 20 MiB is a deliberately conservative cap.
+const maxInlineMediaBytes = 20 * 1024 * 1024
+
 // omniVideoGenerationHandler generates one or more videos via the shared
 // common.GenerateOmniVideo entry point and persists the returned MP4 bytes
 // locally and/or to GCS (with best-effort V4 signed URLs), reusing the suite's
@@ -78,12 +84,13 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 	}
 
 	// Image / video inputs (local paths -> inline bytes; gs:// -> URI).
+	// Enforce the image-count limit BEFORE parseMediaRefs reads any file into memory.
+	if imgs, ok := args["images"].([]interface{}); ok && len(imgs) > maxOmniImages {
+		return mcp.NewToolResultError(fmt.Sprintf("too many images: %d provided, the model accepts at most %d", len(imgs), maxOmniImages)), nil
+	}
 	images, err := parseMediaRefs(args["images"], "image")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
-	}
-	if len(images) > maxOmniImages {
-		return mcp.NewToolResultError(fmt.Sprintf("too many images: %d provided, the model accepts at most %d", len(images), maxOmniImages)), nil
 	}
 	videos, err := parseMediaRefs(args["videos"], "video")
 	if err != nil {
@@ -232,6 +239,15 @@ func parseMediaRefs(arg any, kind string) ([]common.OmniMediaRef, error) {
 			refs = append(refs, common.OmniMediaRef{URI: path, MimeType: mimeType})
 			continue
 		}
+		// Guard against inlining an oversized file: stat first, and reject files
+		// above the inline cap with a hint to use a gs:// URI instead.
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			return nil, fmt.Errorf("failed to read %s file %q: %w", kind, path, statErr)
+		}
+		if info.Size() > maxInlineMediaBytes {
+			return nil, fmt.Errorf("%s file %q is %d bytes, exceeding the %d-byte inline limit; upload it to GCS and pass a gs:// URI instead", kind, path, info.Size(), maxInlineMediaBytes)
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s file %q: %w", kind, path, err)
@@ -293,6 +309,24 @@ func toInt(v any) (int, error) {
 	}
 }
 
+// toFloat64 coerces a JSON-decoded numeric tool argument to a float64. MCP
+// arguments usually arrive as float64, but integer literals may surface as int /
+// int64 depending on the decoder, so those are accepted too (mirrors toInt).
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
 // parseOptionalFloatInRange reads an optional float tool argument and validates
 // it lies within [min, max]. Returns nil when the argument is absent.
 func parseOptionalFloatInRange(args map[string]interface{}, key string, min, max float64) (*float32, error) {
@@ -300,7 +334,7 @@ func parseOptionalFloatInRange(args map[string]interface{}, key string, min, max
 	if !present || raw == nil {
 		return nil, nil
 	}
-	f, ok := raw.(float64)
+	f, ok := toFloat64(raw)
 	if !ok {
 		return nil, fmt.Errorf("%s must be a number", key)
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestParseMediaRefsGCSURI verifies gs:// entries are passed through by URI (no
+// file read) with a MIME type inferred from the extension.
+func TestParseMediaRefsGCSURI(t *testing.T) {
+	refs, err := parseMediaRefs([]interface{}{"gs://bucket/cat.png"}, "image")
+	if err != nil {
+		t.Fatalf("parseMediaRefs returned error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("len(refs) = %d, want 1", len(refs))
+	}
+	if refs[0].URI != "gs://bucket/cat.png" {
+		t.Errorf("URI = %q, want gs://bucket/cat.png", refs[0].URI)
+	}
+	if len(refs[0].Data) != 0 {
+		t.Errorf("gs:// ref should carry no inline data, got %d bytes", len(refs[0].Data))
+	}
+	if refs[0].MimeType != "image/png" {
+		t.Errorf("MimeType = %q, want image/png", refs[0].MimeType)
+	}
+}
+
+// TestParseMediaRefsLocalFile verifies a local path is read into inline bytes.
+func TestParseMediaRefsLocalFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clip.mp4")
+	want := []byte("fake-mp4-bytes")
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	refs, err := parseMediaRefs([]interface{}{path}, "video")
+	if err != nil {
+		t.Fatalf("parseMediaRefs returned error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("len(refs) = %d, want 1", len(refs))
+	}
+	if string(refs[0].Data) != string(want) {
+		t.Errorf("Data = %q, want %q", refs[0].Data, want)
+	}
+	if refs[0].URI != "" {
+		t.Errorf("local ref should carry no URI, got %q", refs[0].URI)
+	}
+	if refs[0].MimeType != "video/mp4" {
+		t.Errorf("MimeType = %q, want video/mp4", refs[0].MimeType)
+	}
+}
+
+func TestParseMediaRefsErrors(t *testing.T) {
+	if _, err := parseMediaRefs("not-an-array", "image"); err == nil {
+		t.Error("expected error for a non-array argument")
+	}
+	if _, err := parseMediaRefs([]interface{}{""}, "image"); err == nil {
+		t.Error("expected error for an empty-string entry")
+	}
+	if _, err := parseMediaRefs([]interface{}{123}, "image"); err == nil {
+		t.Error("expected error for a non-string entry")
+	}
+	if _, err := parseMediaRefs([]interface{}{"/no/such/file.png"}, "image"); err == nil {
+		t.Error("expected error for an unreadable local file")
+	}
+}
+
+// TestParseMediaRefsNilYieldsNil confirms an absent argument produces no refs.
+func TestParseMediaRefsNilYieldsNil(t *testing.T) {
+	refs, err := parseMediaRefs(nil, "image")
+	if err != nil {
+		t.Fatalf("parseMediaRefs(nil) returned error: %v", err)
+	}
+	if refs != nil {
+		t.Errorf("parseMediaRefs(nil) = %v, want nil", refs)
+	}
+}
+
+func TestInferMediaMimeType(t *testing.T) {
+	cases := map[string]string{
+		"a.png":       "image/png",
+		"a.JPG":       "image/jpeg",
+		"a.jpeg":      "image/jpeg",
+		"a.webp":      "image/webp",
+		"clip.mp4":    "video/mp4",
+		"clip.mov":    "video/quicktime",
+		"clip.webm":   "video/webm",
+		"unknown.bin": "application/octet-stream",
+	}
+	for name, want := range cases {
+		if got := inferMediaMimeType(name); got != want {
+			t.Errorf("inferMediaMimeType(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestToInt(t *testing.T) {
+	if n, err := toInt(float64(3)); err != nil || n != 3 {
+		t.Errorf("toInt(3.0) = %d, %v; want 3, nil", n, err)
+	}
+	if n, err := toInt(2); err != nil || n != 2 {
+		t.Errorf("toInt(2) = %d, %v; want 2, nil", n, err)
+	}
+	if _, err := toInt(float64(2.5)); err == nil {
+		t.Error("expected error for a non-integer float")
+	}
+	if _, err := toInt("nope"); err == nil {
+		t.Error("expected error for a string argument")
+	}
+}
+
+func TestParseOptionalFloatInRange(t *testing.T) {
+	args := map[string]interface{}{
+		"temperature": float64(1.5),
+		"too_high":    float64(9),
+		"not_number":  "x",
+	}
+
+	// Absent key -> nil, no error.
+	v, err := parseOptionalFloatInRange(args, "missing", 0, 2)
+	if err != nil || v != nil {
+		t.Errorf("absent key: got %v, %v; want nil, nil", v, err)
+	}
+
+	// In-range value.
+	v, err = parseOptionalFloatInRange(args, "temperature", 0, 2)
+	if err != nil || v == nil || *v != 1.5 {
+		t.Errorf("in-range: got %v, %v; want 1.5, nil", v, err)
+	}
+
+	// Out-of-range value.
+	if _, err := parseOptionalFloatInRange(args, "too_high", 0, 2); err == nil {
+		t.Error("expected error for an out-of-range value")
+	}
+
+	// Wrong type.
+	if _, err := parseOptionalFloatInRange(args, "not_number", 0, 2); err == nil {
+		t.Error("expected error for a non-numeric value")
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -154,5 +155,60 @@ func TestParseOptionalFloatInRange(t *testing.T) {
 	// Wrong type.
 	if _, err := parseOptionalFloatInRange(args, "not_number", 0, 2); err == nil {
 		t.Error("expected error for a non-numeric value")
+	}
+}
+
+// TestParseOptionalFloatInRangeIntegers guards BOT-1: integer JSON numbers (which
+// may surface as float64, int, or int64) must be accepted for temperature/top_p,
+// not rejected as "must be a number".
+func TestParseOptionalFloatInRangeIntegers(t *testing.T) {
+	cases := map[string]interface{}{
+		"float64_int": float64(1), // JSON "1" decoded to float64
+		"int":         1,
+		"int64":       int64(1),
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			// temperature range [0,2]
+			v, err := parseOptionalFloatInRange(map[string]interface{}{"temperature": raw}, "temperature", 0, 2)
+			if err != nil {
+				t.Fatalf("integer temperature %v (%T) rejected: %v", raw, raw, err)
+			}
+			if v == nil || *v != 1 {
+				t.Fatalf("temperature = %v, want 1", v)
+			}
+			// top_p range [0,1]
+			p, err := parseOptionalFloatInRange(map[string]interface{}{"top_p": raw}, "top_p", 0, 1)
+			if err != nil {
+				t.Fatalf("integer top_p %v (%T) rejected: %v", raw, raw, err)
+			}
+			if p == nil || *p != 1 {
+				t.Fatalf("top_p = %v, want 1", p)
+			}
+		})
+	}
+}
+
+// TestParseMediaRefsOversized guards BOT-3: a local file above the inline cap is
+// rejected with a hint to use a gs:// URI, and is not read fully into memory.
+func TestParseMediaRefsOversized(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.mp4")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Sparse file just over the cap (no large allocation).
+	if err := f.Truncate(maxInlineMediaBytes + 1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+
+	_, err = parseMediaRefs([]interface{}{path}, "video")
+	if err == nil {
+		t.Fatal("expected an error for an oversized local file")
+	}
+	if !strings.Contains(err.Error(), "gs://") {
+		t.Errorf("error should suggest a gs:// URI, got: %v", err)
 	}
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/main.go
@@ -75,8 +75,18 @@ func main() {
 	s := server.NewMCPServer("Gemini Omni", version, server.WithResourceCapabilities(true, false))
 
 	tool := mcp.NewTool("omni_video_generation",
-		mcp.WithDescription("Generates video (with optional embedded audio) from a text prompt using Google's Gemini Omni model via the Vertex Interactions API. Returns MP4(s) saved locally and/or to GCS."),
+		mcp.WithDescription("Generates video (with optional embedded audio) from a text prompt, optionally conditioned on input images and/or videos, using Google's Gemini Omni model via the Vertex Interactions API. Returns MP4(s) saved locally and/or to GCS."),
 		mcp.WithString("prompt", mcp.Required(), mcp.Description("The text prompt describing the video to generate.")),
+		mcp.WithString("model", mcp.Description(common.BuildOmniModelDescription())),
+		mcp.WithArray("images",
+			mcp.Items(map[string]any{"type": "string"}),
+			mcp.Description("Optional. Up to 10 input images to condition generation on. Each entry is a local file path or a gs:// URI (image/png, image/jpeg, image/webp).")),
+		mcp.WithArray("videos",
+			mcp.Items(map[string]any{"type": "string"}),
+			mcp.Description("Optional. Input videos to reference or edit. Each entry is a local file path or a gs:// URI (e.g. video/mp4, video/webm, video/quicktime).")),
+		mcp.WithNumber("sample_count", mcp.Description("Optional. Number of videos to generate (1-3, default 1). Clamped to the model maximum of 3.")),
+		mcp.WithNumber("temperature", mcp.Description("Optional. Sampling temperature, 0.0-2.0 (higher = more varied). Sent in generation_config.")),
+		mcp.WithNumber("top_p", mcp.Description("Optional. Nucleus sampling probability mass, 0.0-1.0. Sent in generation_config.")),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save the generated video(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated video(s) (e.g., your-bucket/outputs/). Falls back to GENMEDIA_BUCKET+/omni_outputs/ if set.")),
 	)


### PR DESCRIPTION
## Summary

Phase 2a of the Gemini Omni video-generation work: extend the standalone
`mcp-omni-go` server with the full `omni_video_generation` tool surface, and
factor media persistence into a shared `mcp-common` helper reused by both
`omni` and `nanobanana`.

### `omni_video_generation` tool surface
- **`images`** — up to 10 image inputs (local paths → inline bytes, or `gs://` URIs) for image-conditioned generation.
- **`videos`** — video inputs (local paths or `gs://` URIs) for reference/editing.
- **`sample_count`** — 1–3 (clamped to the model max of 3). Multiple samples are produced by issuing that many **sequential interactions**, because the endpoint rejects `generation_config.candidate_count` (see Q1 below).
- **`temperature`** (0.0–2.0) and **`top_p`** (0.0–1.0) — sent in `generation_config`; the Interactions endpoint parses and range-validates them (confirmed empirically).
- **`model`** — selectable/aliased, described via `common.BuildOmniModelDescription()`.
- All returned videos are persisted (local + GCS + best-effort V4 signed URL). Any model reasoning ("thought") steps are surfaced as a NOTE in the result text, not as media output.

### Shared `common.PersistMediaOutputs` (design §7.3)
- Extract the duplicated GCS upload + V4-signed-URL + `gs://` prefix-parsing + signed-URL-expiry-from-env logic out of `mcp-nanobanana-go` into `mcp-common`.
- Switch **both** `nanobanana` (behavior-preserving) and `omni` onto it.

### Q1 (resolved empirically)
- `generation_config` `{temperature, top_p}` — **ACCEPTED** (HTTP 200; temperature range-validated to [0.0, 2.0]). Shipped as gated/validated params.
- `generation_config.candidate_count` — **REJECTED** (HTTP 400). Deliberately not modeled; multi-sample is done via sequential interactions instead.

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` green per module (go.work) and in CI-style standalone builds (each module with `go.work` removed).
- **LIVE** (project `ghchinoy-genai-sa`, bucket `gs://ghchinoy-genai-sa-omni/`):
  - image-conditioned single: valid MP4 (ftyp OK), ~3.06 MB, GCS upload OK, V4 signed URL → HTTP 200.
  - `sample_count=2`: 2 valid MP4s (ftyp OK), ~2.65 / ~2.63 MB, both to GCS, both V4 signed URLs → HTTP 200.
  - nanobanana no-regression: live `gemini-3.1-flash-image` run, PNG → GCS, V4 signed URL → HTTP 200; result text format preserved.

## Scope notes
- Does **not** touch the Interactions transport/seam or `Api-Revision` pinning.
- Phase 2b (`mcp-gemini-go`), 2c (contract tests) and release wiring are separate later dispatches — not in this PR.