### PR TITLE
feat(mcp): add omni_video_generation to mcp-gemini-go + Omni contract/drift tests

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output.go
@@ -32,6 +32,16 @@ import (
 // signedURLV4MaxHours is the maximum validity for a V4 signed URL (7 days).
 const signedURLV4MaxHours = 168
 
+// uploadToGCSFn and generateV4SignedURLFn are indirections over the real GCS
+// upload and V4-signing helpers so the GCS branch of PersistMediaOutputs can be
+// unit-tested without a live bucket or credentials. They default to the real
+// implementations (UploadToGCS / GenerateV4SignedURL) — production behavior is
+// unchanged — and are only reassigned by tests, which restore them afterwards.
+var (
+	uploadToGCSFn         = UploadToGCS
+	generateV4SignedURLFn = GenerateV4SignedURL
+)
+
 // MediaArtifact is a single generated media blob to persist (an image, a video,
 // an audio clip, ...). FileName is the base name including extension; it is used
 // verbatim for the local file and, prefixed by any GCS object prefix, for the
@@ -95,7 +105,7 @@ func PersistMediaOutputs(ctx context.Context, art MediaArtifact, outputDir, gcsB
 		// with its intended bucket/object (GCSURI stays empty until success).
 		out.GCSBucket = bucketName
 		out.GCSObject = objectName
-		if err := UploadToGCS(ctx, bucketName, objectName, art.MimeType, art.Data); err != nil {
+		if err := uploadToGCSFn(ctx, bucketName, objectName, art.MimeType, art.Data); err != nil {
 			out.GCSError = err
 			return out, nil
 		}
@@ -104,7 +114,7 @@ func PersistMediaOutputs(ctx context.Context, art MediaArtifact, outputDir, gcsB
 		// Best-effort V4 signed HTTPS URL so clients can fetch the media without
 		// the bucket being public. Non-fatal on failure.
 		if signedURLExpiry > 0 {
-			if signedURL, sErr := GenerateV4SignedURL(ctx, bucketName, objectName, signedURLExpiry); sErr != nil {
+			if signedURL, sErr := generateV4SignedURLFn(ctx, bucketName, objectName, signedURLExpiry); sErr != nil {
 				log.Printf("failed to generate signed URL for %s: %v", out.GCSURI, sErr)
 			} else {
 				out.SignedURL = signedURL

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/media_output_test.go
@@ -16,11 +16,224 @@ package common
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+// withFakeGCS swaps the GCS upload + V4-signing seams for the duration of a test
+// and restores them afterwards, so the GCS branch of PersistMediaOutputs can be
+// exercised without a live bucket or credentials (NIT-3). It returns the real
+// implementations for tests that only want to override one of the two.
+func withFakeGCS(t *testing.T, upload func(ctx context.Context, bucket, object, contentType string, data []byte) error, sign func(ctx context.Context, bucket, object string, expiry time.Duration) (string, error)) {
+	t.Helper()
+	origUpload := uploadToGCSFn
+	origSign := generateV4SignedURLFn
+	if upload != nil {
+		uploadToGCSFn = upload
+	}
+	if sign != nil {
+		generateV4SignedURLFn = sign
+	}
+	t.Cleanup(func() {
+		uploadToGCSFn = origUpload
+		generateV4SignedURLFn = origSign
+	})
+}
+
+// TestPersistMediaOutputsGCSSuccess verifies the GCS+signed-URL branch: the
+// artifact is uploaded to the parsed bucket/object, a V4 signed URL is generated,
+// and every GCS field on PersistedMedia is populated correctly. Uses fake seams
+// so no live bucket is required.
+func TestPersistMediaOutputsGCSSuccess(t *testing.T) {
+	var gotBucket, gotObject, gotContentType string
+	var gotData []byte
+	var signBucket, signObject string
+	var signExpiry time.Duration
+
+	withFakeGCS(t,
+		func(_ context.Context, bucket, object, contentType string, data []byte) error {
+			gotBucket, gotObject, gotContentType, gotData = bucket, object, contentType, data
+			return nil
+		},
+		func(_ context.Context, bucket, object string, expiry time.Duration) (string, error) {
+			signBucket, signObject, signExpiry = bucket, object, expiry
+			return "https://signed.example/" + object, nil
+		},
+	)
+
+	art := MediaArtifact{
+		Data:     []byte("mp4-bytes"),
+		MimeType: "video/mp4",
+		FileName: "omni_20260101_0.mp4",
+	}
+	const expiry = 24 * time.Hour
+
+	got, err := PersistMediaOutputs(context.Background(), art, "", "gs://my-bucket/omni_outputs/", expiry)
+	if err != nil {
+		t.Fatalf("PersistMediaOutputs returned fatal error: %v", err)
+	}
+
+	// Upload received the bucket/object parsed from the URI + the filename.
+	if gotBucket != "my-bucket" {
+		t.Errorf("upload bucket = %q, want %q", gotBucket, "my-bucket")
+	}
+	if gotObject != "omni_outputs/omni_20260101_0.mp4" {
+		t.Errorf("upload object = %q, want %q", gotObject, "omni_outputs/omni_20260101_0.mp4")
+	}
+	if gotContentType != "video/mp4" {
+		t.Errorf("upload contentType = %q, want video/mp4", gotContentType)
+	}
+	if string(gotData) != "mp4-bytes" {
+		t.Errorf("upload data = %q, want %q", gotData, "mp4-bytes")
+	}
+
+	// PersistedMedia carries the URI, bucket, object, and signed URL.
+	if got.GCSURI != "gs://my-bucket/omni_outputs/omni_20260101_0.mp4" {
+		t.Errorf("GCSURI = %q", got.GCSURI)
+	}
+	if got.GCSBucket != "my-bucket" || got.GCSObject != "omni_outputs/omni_20260101_0.mp4" {
+		t.Errorf("GCSBucket/GCSObject = %q/%q", got.GCSBucket, got.GCSObject)
+	}
+	if got.GCSError != nil {
+		t.Errorf("GCSError = %v, want nil", got.GCSError)
+	}
+	if got.SignedURL != "https://signed.example/omni_outputs/omni_20260101_0.mp4" {
+		t.Errorf("SignedURL = %q", got.SignedURL)
+	}
+
+	// The signer was called with the same bucket/object and the requested expiry.
+	if signBucket != "my-bucket" || signObject != "omni_outputs/omni_20260101_0.mp4" {
+		t.Errorf("signer bucket/object = %q/%q", signBucket, signObject)
+	}
+	if signExpiry != expiry {
+		t.Errorf("signer expiry = %v, want %v", signExpiry, expiry)
+	}
+}
+
+// TestPersistMediaOutputsGCSAndLocal verifies that when both a local dir and a
+// GCS URI are set, the artifact is written locally and uploaded, and both
+// LocalPath and GCSURI are populated.
+func TestPersistMediaOutputsGCSAndLocal(t *testing.T) {
+	withFakeGCS(t,
+		func(_ context.Context, _, _, _ string, _ []byte) error { return nil },
+		func(_ context.Context, _, object string, _ time.Duration) (string, error) {
+			return "https://signed.example/" + object, nil
+		},
+	)
+
+	dir := t.TempDir()
+	art := MediaArtifact{Data: []byte("v"), MimeType: "video/mp4", FileName: "clip.mp4"}
+
+	got, err := PersistMediaOutputs(context.Background(), art, dir, "gs://b/prefix", time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.LocalPath != filepath.Join(dir, "clip.mp4") {
+		t.Errorf("LocalPath = %q", got.LocalPath)
+	}
+	if got.GCSURI != "gs://b/prefix/clip.mp4" {
+		t.Errorf("GCSURI = %q", got.GCSURI)
+	}
+	if got.SignedURL == "" {
+		t.Errorf("SignedURL should be set")
+	}
+	if _, statErr := os.Stat(got.LocalPath); statErr != nil {
+		t.Errorf("local file not written: %v", statErr)
+	}
+}
+
+// TestPersistMediaOutputsGCSNoSignedURLWhenExpiryZero verifies that a zero
+// expiry uploads to GCS but does NOT generate a signed URL (the signer is not
+// even invoked).
+func TestPersistMediaOutputsGCSNoSignedURLWhenExpiryZero(t *testing.T) {
+	signerCalled := false
+	withFakeGCS(t,
+		func(_ context.Context, _, _, _ string, _ []byte) error { return nil },
+		func(_ context.Context, _, _ string, _ time.Duration) (string, error) {
+			signerCalled = true
+			return "should-not-be-used", nil
+		},
+	)
+
+	got, err := PersistMediaOutputs(context.Background(),
+		MediaArtifact{Data: []byte("v"), MimeType: "video/mp4", FileName: "c.mp4"}, "", "gs://b", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.GCSURI != "gs://b/c.mp4" {
+		t.Errorf("GCSURI = %q", got.GCSURI)
+	}
+	if signerCalled {
+		t.Errorf("signer should not be called when expiry is 0")
+	}
+	if got.SignedURL != "" {
+		t.Errorf("SignedURL = %q, want empty when expiry is 0", got.SignedURL)
+	}
+}
+
+// TestPersistMediaOutputsGCSSignedURLFailureNonFatal verifies that a signing
+// failure is non-fatal: the upload still succeeds (GCSURI set) and only the
+// SignedURL is left empty.
+func TestPersistMediaOutputsGCSSignedURLFailureNonFatal(t *testing.T) {
+	withFakeGCS(t,
+		func(_ context.Context, _, _, _ string, _ []byte) error { return nil },
+		func(_ context.Context, _, _ string, _ time.Duration) (string, error) {
+			return "", errors.New("iam signBlob denied")
+		},
+	)
+
+	got, err := PersistMediaOutputs(context.Background(),
+		MediaArtifact{Data: []byte("v"), MimeType: "video/mp4", FileName: "c.mp4"}, "", "gs://b", time.Hour)
+	if err != nil {
+		t.Fatalf("signing failure must be non-fatal, got error: %v", err)
+	}
+	if got.GCSURI != "gs://b/c.mp4" {
+		t.Errorf("GCSURI = %q, want upload to have succeeded", got.GCSURI)
+	}
+	if got.SignedURL != "" {
+		t.Errorf("SignedURL = %q, want empty after signing failure", got.SignedURL)
+	}
+}
+
+// TestPersistMediaOutputsGCSUploadFailureNonFatal verifies that an upload
+// failure is non-fatal (no fatal error returned), leaves GCSURI empty, reports
+// the error via GCSError, and still populates the intended bucket/object so the
+// caller can log them.
+func TestPersistMediaOutputsGCSUploadFailureNonFatal(t *testing.T) {
+	wantErr := errors.New("bucket not found")
+	signerCalled := false
+	withFakeGCS(t,
+		func(_ context.Context, _, _, _ string, _ []byte) error { return wantErr },
+		func(_ context.Context, _, _ string, _ time.Duration) (string, error) {
+			signerCalled = true
+			return "x", nil
+		},
+	)
+
+	got, err := PersistMediaOutputs(context.Background(),
+		MediaArtifact{Data: []byte("v"), MimeType: "video/mp4", FileName: "c.mp4"}, "", "gs://my-bucket/p", time.Hour)
+	if err != nil {
+		t.Fatalf("upload failure must be non-fatal, got error: %v", err)
+	}
+	if !errors.Is(got.GCSError, wantErr) {
+		t.Errorf("GCSError = %v, want %v", got.GCSError, wantErr)
+	}
+	if got.GCSURI != "" {
+		t.Errorf("GCSURI = %q, want empty after upload failure", got.GCSURI)
+	}
+	if got.GCSBucket != "my-bucket" || got.GCSObject != "p/c.mp4" {
+		t.Errorf("bucket/object for logging = %q/%q, want my-bucket/p/c.mp4", got.GCSBucket, got.GCSObject)
+	}
+	if signerCalled {
+		t.Errorf("signer should not run after an upload failure")
+	}
+	if got.SignedURL != "" {
+		t.Errorf("SignedURL = %q, want empty after upload failure", got.SignedURL)
+	}
+}
 
 func TestParseGCSBucketAndPrefix(t *testing.T) {
 	tests := []struct {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_contract_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_contract_test.go
@@ -1,0 +1,259 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+// Contract tests for the Omni path. Unlike omni_test.go (which unmarshals wire
+// bodies through the suite's own decodeInteractionResponse), these tests drive
+// canned, representative Interactions JSON THROUGH the real seam — the adopted
+// github.com/ghchinoy/cloud-interactions-go transport behind the
+// InteractionsClient interface — via an httptest server, and assert the full
+// pipeline end to end: library HTTP + JSON decode -> fromLibResponse ->
+// mapOmniResponse -> generateOmniVideoWithClient aggregation. This is the check that
+// would catch a library bump silently changing the wire contract, and it proves
+// the observed live drift (findings §3) survives the concrete transport, not just
+// the suite's structs. No live API call is made.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	interactions "github.com/ghchinoy/cloud-interactions-go"
+)
+
+// newSeamAgainst builds the production libInteractionsClient (the concrete
+// transport behind the InteractionsClient seam) pointed at a test server. It
+// mirrors NewInteractionsClient exactly except that it injects the httptest
+// client instead of an ADC-backed oauth2 client, so no credentials are needed.
+func newSeamAgainst(server *httptest.Server, userProject string) InteractionsClient {
+	client := interactions.NewClient(server.URL)
+	client.HTTPClient = server.Client()
+	client.WithUserProject(userProject)
+	client.WithAPIRevision(DefaultInteractionsAPIRevision)
+	return &libInteractionsClient{inner: client}
+}
+
+// omniOutputsJSON is a variant of the Omni response that places results in
+// outputs[] rather than steps[] (the Lyria-style shape), to prove the seam
+// recovers video from either location.
+func omniOutputsJSON(b64video string) string {
+	return `{
+		"id": "out-1",
+		"object": "interaction",
+		"status": "completed",
+		"outputs": [
+			{"type": "model_output", "content": [
+				{"type": "text", "text": "from outputs"},
+				{"type": "video", "mime_type": "video/mp4", "data": "` + b64video + `"}
+			]}
+		]
+	}`
+}
+
+// omniHeavyDriftJSON is a deliberately drift-heavy body: lowercase status, a
+// thought step whose "summary" is an ARRAY (not a string) plus a "signature",
+// created/updated timestamps (the wire names, not the library's create_time/
+// update_time), and unknown fields at the top level, the step level, and inside
+// content parts. A tolerant decode must ignore every unknown field and still map
+// the video bytes, the text, and the single thought step.
+func omniHeavyDriftJSON(b64video string) string {
+	return `{
+		"id": "drift-1",
+		"object": "interaction",
+		"status": "completed",
+		"role": "model",
+		"created": "2026-08-10T14:41:24Z",
+		"updated": "2026-08-10T14:41:25Z",
+		"some_unknown_top_field": {"nested": [1, 2, 3]},
+		"steps": [
+			{"type": "thought", "signature": "AbC123==", "summary": [{"type": "text", "text": "planning the shot"}, {"type": "text", "text": "and the motion"}]},
+			{"type": "model_output", "future_field": "ignore-me", "content": [
+				{"type": "text", "text": "done", "extra_part_field": 7},
+				{"type": "video", "mime_type": "video/mp4", "data": "` + b64video + `", "another_unknown": true}
+			]}
+		],
+		"usage": {"total_tokens": 100, "brand_new_metric": 42}
+	}`
+}
+
+// TestOmniContractThroughSeam_StepsHappyPath drives the drift-bearing steps[]
+// body (from omni_test.go) through the real transport and asserts the mapped
+// result plus the request the seam actually sent (lowercase response_modalities,
+// pinned Api-Revision, x-goog-user-project, POST).
+func TestOmniContractThroughSeam_StepsHappyPath(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString(sampleMP4)
+
+	var gotMethod, gotAPIRev, gotUserProject string
+	var gotModalities []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAPIRev = r.Header.Get("Api-Revision")
+		gotUserProject = r.Header.Get("x-goog-user-project")
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			ResponseModalities []string `json:"response_modalities"`
+		}
+		_ = json.Unmarshal(body, &req)
+		gotModalities = req.ResponseModalities
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, omniResponseJSON(b64))
+	}))
+	defer srv.Close()
+
+	seam := newSeamAgainst(srv, "test-project")
+	result, err := generateOmniVideoWithClient(context.Background(), seam, OmniParams{Prompt: "a red balloon"})
+	if err != nil {
+		t.Fatalf("generateOmniVideoWithClient through seam: %v", err)
+	}
+
+	// Response mapping.
+	if len(result.Videos) != 1 {
+		t.Fatalf("len(Videos) = %d, want 1", len(result.Videos))
+	}
+	if string(result.Videos[0]) != string(sampleMP4) {
+		t.Errorf("decoded video bytes do not match the source bytes")
+	}
+	if !hasFtypBox(result.Videos[0]) {
+		t.Errorf("decoded video missing ftyp box")
+	}
+	if result.Text != "Here is your video." {
+		t.Errorf("Text = %q", result.Text)
+	}
+	if result.ThoughtSteps != 1 {
+		t.Errorf("ThoughtSteps = %d, want 1", result.ThoughtSteps)
+	}
+	if result.Status != "completed" {
+		t.Errorf("Status = %q, want completed (lowercase preserved)", result.Status)
+	}
+	if len(result.VideoMimeTypes) != 1 || result.VideoMimeTypes[0] != "video/mp4" {
+		t.Errorf("VideoMimeTypes = %v", result.VideoMimeTypes)
+	}
+
+	// Request the seam actually sent.
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotAPIRev != DefaultInteractionsAPIRevision {
+		t.Errorf("Api-Revision = %q, want %q", gotAPIRev, DefaultInteractionsAPIRevision)
+	}
+	if gotUserProject != "test-project" {
+		t.Errorf("x-goog-user-project = %q, want test-project", gotUserProject)
+	}
+	if len(gotModalities) != 2 || gotModalities[0] != "text" || gotModalities[1] != "video" {
+		t.Errorf("response_modalities on the wire = %v, want lowercase [text video]", gotModalities)
+	}
+}
+
+// TestOmniContractThroughSeam_HeavyDrift proves the concrete transport tolerates
+// the aggressive drift body (unknown fields everywhere, array thought summary,
+// created/updated) and still recovers the video + text + thought count.
+func TestOmniContractThroughSeam_HeavyDrift(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString(sampleMP4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, omniHeavyDriftJSON(b64))
+	}))
+	defer srv.Close()
+
+	seam := newSeamAgainst(srv, "p")
+	result, err := generateOmniVideoWithClient(context.Background(), seam, OmniParams{Prompt: "x"})
+	if err != nil {
+		t.Fatalf("heavy-drift body failed through seam: %v", err)
+	}
+	if len(result.Videos) != 1 || !hasFtypBox(result.Videos[0]) {
+		t.Fatalf("video not recovered from heavy-drift body: %+v", result.Videos)
+	}
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want %q", result.Text, "done")
+	}
+	if result.ThoughtSteps != 1 {
+		t.Errorf("ThoughtSteps = %d, want 1 (array-summary thought step still counted)", result.ThoughtSteps)
+	}
+	if result.Status != "completed" {
+		t.Errorf("Status = %q, want completed", result.Status)
+	}
+}
+
+// TestOmniContractThroughSeam_OutputsShape proves the seam recovers video when
+// the API returns results in outputs[] instead of steps[].
+func TestOmniContractThroughSeam_OutputsShape(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString(sampleMP4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, omniOutputsJSON(b64))
+	}))
+	defer srv.Close()
+
+	seam := newSeamAgainst(srv, "p")
+	result, err := generateOmniVideoWithClient(context.Background(), seam, OmniParams{Prompt: "x"})
+	if err != nil {
+		t.Fatalf("outputs[] body failed through seam: %v", err)
+	}
+	if len(result.Videos) != 1 || !hasFtypBox(result.Videos[0]) {
+		t.Fatalf("video not recovered from outputs[] body: %+v", result.Videos)
+	}
+	if result.Text != "from outputs" {
+		t.Errorf("Text = %q", result.Text)
+	}
+}
+
+// TestOmniContractThroughSeam_MultiSample proves the multi-sample loop issues one
+// POST per sample through the real transport and aggregates the videos.
+func TestOmniContractThroughSeam_MultiSample(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString(sampleMP4)
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = io.WriteString(w, omniResponseJSON(b64))
+	}))
+	defer srv.Close()
+
+	seam := newSeamAgainst(srv, "p")
+	result, err := generateOmniVideoWithClient(context.Background(), seam, OmniParams{Prompt: "x", SampleCount: 2})
+	if err != nil {
+		t.Fatalf("multi-sample through seam: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("server received %d POSTs, want 2 (one per sample)", calls)
+	}
+	if len(result.Videos) != 2 {
+		t.Errorf("len(Videos) = %d, want 2", len(result.Videos))
+	}
+	if result.ThoughtSteps != 2 {
+		t.Errorf("ThoughtSteps = %d, want 2", result.ThoughtSteps)
+	}
+}
+
+// TestOmniContractThroughSeam_APIError proves a 4xx from the endpoint is surfaced
+// as an error (with the verbatim body) rather than a decode of an empty result.
+func TestOmniContractThroughSeam_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"response_modalities must be lowercase"}}`)
+	}))
+	defer srv.Close()
+
+	seam := newSeamAgainst(srv, "p")
+	_, err := generateOmniVideoWithClient(context.Background(), seam, OmniParams{Prompt: "x"})
+	if err == nil {
+		t.Fatalf("expected an error for a 400 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "response_modalities must be lowercase") {
+		t.Errorf("error %q does not surface the verbatim API body", err.Error())
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -158,6 +158,30 @@ func main() {
 	s.AddTool(ttsTool, geminiAudioTTSHandler)
 	// --- End of TTS Tools ---
 
+	// --- Register Gemini Omni Video Tool ---
+	// Same param surface as the standalone mcp-omni-go server; the handler is a
+	// thin wrapper over the shared common.GenerateOmniVideo entry point, so the
+	// two servers can never drift. No second client is created on this binary —
+	// the Interactions path is fully encapsulated in mcp-common.
+	omniTool := mcp.NewTool("omni_video_generation",
+		mcp.WithDescription("Generates video (with optional embedded audio) from a text prompt, optionally conditioned on input images and/or videos, using Google's Gemini Omni model via the Vertex Interactions API. Returns MP4(s) saved locally and/or to GCS."),
+		mcp.WithString("prompt", mcp.Required(), mcp.Description("The text prompt describing the video to generate.")),
+		mcp.WithString("model", mcp.Description(common.BuildOmniModelDescription())),
+		mcp.WithArray("images",
+			mcp.Items(map[string]any{"type": "string"}),
+			mcp.Description("Optional. Up to 10 input images to condition generation on. Each entry is a local file path or a gs:// URI (image/png, image/jpeg, image/webp).")),
+		mcp.WithArray("videos",
+			mcp.Items(map[string]any{"type": "string"}),
+			mcp.Description("Optional. Input videos to reference or edit. Each entry is a local file path or a gs:// URI (e.g. video/mp4, video/webm, video/quicktime).")),
+		mcp.WithNumber("sample_count", mcp.Description("Optional. Number of videos to generate (1-3, default 1). Clamped to the model maximum of 3.")),
+		mcp.WithNumber("temperature", mcp.Description("Optional. Sampling temperature, 0.0-2.0 (higher = more varied). Sent in generation_config.")),
+		mcp.WithNumber("top_p", mcp.Description("Optional. Nucleus sampling probability mass, 0.0-1.0. Sent in generation_config.")),
+		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save the generated video(s) to.")),
+		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated video(s) (e.g., your-bucket/outputs/). Falls back to GENMEDIA_BUCKET+/omni_outputs/ if set.")),
+	)
+	s.AddTool(omniTool, omniVideoGenerationHandler)
+	// --- End of Gemini Omni Video Tool ---
+
 	// --- Register Gemini Resources ---
 	s.AddResource(mcp.NewResource(
 		"gemini://language_codes",

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
@@ -188,7 +188,7 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 		persisted, err := common.PersistMediaOutputs(ctx, common.MediaArtifact{
 			Data:     videoBytes,
 			MimeType: mimeType,
-			FileName: fmt.Sprintf("omni_%s_%d.mp4", gentime, n),
+			FileName: fmt.Sprintf("omni_%s_%d%s", gentime, n, videoExtForMimeType(mimeType)),
 		}, outputDir, gcsBucketURI, expiry)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
@@ -254,6 +254,9 @@ func parseMediaRefs(arg any, kind string) ([]common.OmniMediaRef, error) {
 		if statErr != nil {
 			return nil, fmt.Errorf("failed to read %s file %q: %w", kind, path, statErr)
 		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("%s path %q is a directory, not a file (expected a local media file or a gs:// URI)", kind, path)
+		}
 		if info.Size() > maxInlineMediaBytes {
 			return nil, fmt.Errorf("%s file %q is %d bytes, exceeding the %d-byte inline limit; upload it to GCS and pass a gs:// URI instead", kind, path, info.Size(), maxInlineMediaBytes)
 		}
@@ -297,6 +300,30 @@ func inferMediaMimeType(path string) string {
 		return "video/3gpp"
 	default:
 		return "application/octet-stream"
+	}
+}
+
+// videoExtForMimeType returns a file extension for a generated video MIME type,
+// defaulting to ".mp4" (the Omni model's output format) for unknown or empty
+// types so the saved filename's extension matches the actual bytes.
+func videoExtForMimeType(mimeType string) string {
+	switch strings.ToLower(strings.TrimSpace(mimeType)) {
+	case "video/mp4":
+		return ".mp4"
+	case "video/webm":
+		return ".webm"
+	case "video/quicktime":
+		return ".mov"
+	case "video/mpeg":
+		return ".mpeg"
+	case "video/3gpp":
+		return ".3gp"
+	case "video/x-flv":
+		return ".flv"
+	case "video/wmv", "video/x-ms-wmv":
+		return ".wmv"
+	default:
+		return ".mp4"
 	}
 }
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
@@ -328,7 +328,9 @@ func videoExtForMimeType(mimeType string) string {
 }
 
 // toInt coerces a JSON-decoded numeric tool argument to an int. MCP arguments
-// arrive as float64 for JSON numbers; a string of digits is also accepted.
+// arrive as float64 for JSON numbers, but integer literals may surface as int /
+// int64 depending on the decoder, so those are accepted too. A non-integral
+// float64 or any non-numeric value is rejected with an error.
 func toInt(v any) (int, error) {
 	switch n := v.(type) {
 	case float64:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
@@ -1,0 +1,355 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main implements an MCP server for Google's Gemini models.
+//
+// This file adds the Gemini Omni video-generation capability to the all-in-one
+// mcp-gemini-go server. Omni (gemini-omni-flash-preview) is reachable only
+// through the Vertex Interactions API, so the handler is a THIN wrapper around
+// the shared common.GenerateOmniVideo / common.PersistMediaOutputs helpers — the
+// identical calls mcp-omni-go's standalone handler makes. There is deliberately
+// no second client on this binary: the Interactions path is fully encapsulated in
+// mcp-common, so the gemini-go and omni-go request/response contracts cannot drift.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
+)
+
+// maxOmniImages is the per-prompt image input limit (findings §1).
+const maxOmniImages = 10
+
+// maxInlineMediaBytes caps the size of a local media file that will be read into
+// memory and base64-inlined into the interaction request. Larger files must be
+// referenced by a gs:// URI instead (base64 inflates payloads ~33%, and the
+// Interactions request body is bounded). 20 MiB is a deliberately conservative cap.
+const maxInlineMediaBytes = 20 * 1024 * 1024
+
+// omniVideoGenerationHandler generates one or more videos via the shared
+// common.GenerateOmniVideo entry point and persists the returned MP4 bytes
+// locally and/or to GCS (with best-effort V4 signed URLs), reusing the suite's
+// shared common.PersistMediaOutputs helper. It mirrors mcp-omni-go's standalone
+// handler exactly so the two servers never diverge.
+func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	tr := otel.Tracer(serviceName)
+	ctx, span := tr.Start(ctx, "omni_video_generation")
+	defer span.End()
+
+	args := request.GetArguments()
+
+	// --- Parameter Parsing ---
+	prompt, ok := args["prompt"].(string)
+	if !ok || strings.TrimSpace(prompt) == "" {
+		return mcp.NewToolResultError("prompt must be a non-empty string and is required"), nil
+	}
+	prompt = strings.TrimSpace(prompt)
+
+	outputDir := ""
+	if dir, ok := args["output_directory"].(string); ok && strings.TrimSpace(dir) != "" {
+		outputDir = strings.TrimSpace(dir)
+	}
+
+	// gcsBucketURI: explicit "gcs_bucket_uri" takes precedence, otherwise fall
+	// back to the server-wide GENMEDIA_BUCKET default (mirrors the other tools).
+	gcsBucketURI := ""
+	if u, ok := args["gcs_bucket_uri"].(string); ok && strings.TrimSpace(u) != "" {
+		gcsBucketURI = strings.TrimSpace(u)
+	} else if appConfig != nil && appConfig.GenmediaBucket != "" {
+		gcsBucketURI = appConfig.GenmediaBucket + "/omni_outputs/"
+	}
+
+	// Model resolution (honors an optional "model" arg / alias).
+	modelArg, _ := args["model"].(string)
+	model := common.DefaultOmniModel
+	if resolved, found := common.ResolveOmniModel(modelArg, appConfig.AllowUnsafeModels); found {
+		model = resolved.CanonicalName
+	} else if strings.TrimSpace(modelArg) != "" {
+		return mcp.NewToolResultError(fmt.Sprintf("unsupported model %q (set ALLOW_UNSAFE_MODELS=true to bypass)", modelArg)), nil
+	}
+
+	// Image / video inputs (local paths -> inline bytes; gs:// -> URI).
+	// Enforce the image-count limit BEFORE parseMediaRefs reads any file into memory.
+	if imgs, ok := args["images"].([]interface{}); ok && len(imgs) > maxOmniImages {
+		return mcp.NewToolResultError(fmt.Sprintf("too many images: %d provided, the model accepts at most %d", len(imgs), maxOmniImages)), nil
+	}
+	images, err := parseMediaRefs(args["images"], "image")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	videos, err := parseMediaRefs(args["videos"], "video")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// sample_count (default 1, clamped to the model max by the shared helper).
+	sampleCount := 1
+	if raw, present := args["sample_count"]; present {
+		n, convErr := toInt(raw)
+		if convErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("sample_count must be an integer: %v", convErr)), nil
+		}
+		if n >= 1 {
+			sampleCount = n
+		}
+	}
+
+	// temperature / top_p (optional; validated client-side, then sent in generation_config).
+	temperature, err := parseOptionalFloatInRange(args, "temperature", 0.0, 2.0)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	topP, err := parseOptionalFloatInRange(args, "top_p", 0.0, 1.0)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	span.SetAttributes(
+		attribute.String("prompt", prompt),
+		attribute.String("model", model),
+		attribute.String("output_directory", outputDir),
+		attribute.String("gcs_bucket_uri", gcsBucketURI),
+		attribute.Int("images", len(images)),
+		attribute.Int("videos", len(videos)),
+		attribute.Int("sample_count", sampleCount),
+	)
+
+	// --- Shared Omni call ---
+	log.Printf("Calling GenerateOmniVideo Model=%s sample_count=%d images=%d videos=%d", model, sampleCount, len(images), len(videos))
+	startTime := time.Now()
+
+	result, err := common.GenerateOmniVideo(ctx, appConfig, common.OmniParams{
+		Prompt:      prompt,
+		Model:       model,
+		Images:      images,
+		Videos:      videos,
+		SampleCount: sampleCount,
+		Temperature: temperature,
+		TopP:        topP,
+	})
+
+	apiCallDuration := time.Since(startTime)
+	log.Printf("GenerateOmniVideo call took: %v", apiCallDuration)
+	span.SetAttributes(attribute.Float64("duration_ms", float64(apiCallDuration.Milliseconds())))
+
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(fmt.Sprintf("error generating Omni video: %v", err)), nil
+	}
+	span.SetAttributes(attribute.Int("video_count", len(result.Videos)))
+
+	// --- Process / persist output ---
+	var responseText strings.Builder
+	if result.SherlogLink != "" {
+		fmt.Fprintf(&responseText, "Optional header capture: %s\n\n", result.SherlogLink)
+	}
+	if strings.TrimSpace(result.Text) != "" {
+		responseText.WriteString(result.Text)
+	}
+	// Surface any thought/summary reasoning as a NOTE (not as a media output).
+	if result.ThoughtSteps > 0 {
+		fmt.Fprintf(&responseText, "\n\n[Note: model returned %d reasoning (thought) step(s).]", result.ThoughtSteps)
+	}
+
+	gentime := time.Now().Format("20060102150405")
+	expiry := common.SignedURLExpiryFromEnv("OMNI_SIGNED_URL_EXPIRY_HOURS")
+	var savedFiles []string
+
+	for n, videoBytes := range result.Videos {
+		mimeType := "video/mp4"
+		if n < len(result.VideoMimeTypes) && result.VideoMimeTypes[n] != "" {
+			mimeType = result.VideoMimeTypes[n]
+		}
+
+		persisted, err := common.PersistMediaOutputs(ctx, common.MediaArtifact{
+			Data:     videoBytes,
+			MimeType: mimeType,
+			FileName: fmt.Sprintf("omni_%s_%d.mp4", gentime, n),
+		}, outputDir, gcsBucketURI, expiry)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		if persisted.LocalPath != "" {
+			savedFiles = append(savedFiles, persisted.LocalPath)
+		}
+		if persisted.GCSError != nil {
+			log.Printf("failed to upload video to gs://%s/%s: %v", persisted.GCSBucket, persisted.GCSObject, persisted.GCSError)
+			fmt.Fprintf(&responseText, "\n\n[Warning: failed to upload generated video to GCS: %v]", persisted.GCSError)
+		}
+		if persisted.GCSURI != "" {
+			savedFiles = append(savedFiles, persisted.GCSURI)
+		}
+		if persisted.SignedURL != "" {
+			fmt.Fprintf(&responseText, "\n\nSigned URL for %s (valid %s):\n%s", persisted.GCSObject, expiry, persisted.SignedURL)
+		}
+		if persisted.LocalPath == "" && persisted.GCSURI == "" {
+			log.Println("Received video data but no output_directory or gcs_bucket_uri was specified/valid. Video not saved.")
+		}
+	}
+
+	finalMessage := responseText.String()
+	if len(savedFiles) > 0 {
+		finalMessage += fmt.Sprintf("\n\nGenerated and saved %d video(s): %s", len(result.Videos), strings.Join(savedFiles, ", "))
+	} else {
+		finalMessage += fmt.Sprintf("\n\nGenerated %d video(s) but none were saved (set output_directory or gcs_bucket_uri).", len(result.Videos))
+	}
+
+	return &mcp.CallToolResult{Content: []mcp.Content{mcp.TextContent{Type: "text", Text: strings.TrimSpace(finalMessage)}}}, nil
+}
+
+// parseMediaRefs converts a tool argument (expected to be an array of strings,
+// each a local file path or a gs:// URI) into common.OmniMediaRef values. Local
+// paths are read into memory; gs:// URIs are passed through by reference. kind is
+// "image" or "video" and is used only for error messages and MIME inference.
+func parseMediaRefs(arg any, kind string) ([]common.OmniMediaRef, error) {
+	if arg == nil {
+		return nil, nil
+	}
+	list, ok := arg.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%ss must be an array of strings", kind)
+	}
+
+	refs := make([]common.OmniMediaRef, 0, len(list))
+	for _, item := range list {
+		path, ok := item.(string)
+		if !ok || strings.TrimSpace(path) == "" {
+			return nil, fmt.Errorf("each %s entry must be a non-empty string (local path or gs:// URI)", kind)
+		}
+		path = strings.TrimSpace(path)
+		mimeType := inferMediaMimeType(path)
+
+		if strings.HasPrefix(path, "gs://") {
+			refs = append(refs, common.OmniMediaRef{URI: path, MimeType: mimeType})
+			continue
+		}
+		// Guard against inlining an oversized file: stat first, and reject files
+		// above the inline cap with a hint to use a gs:// URI instead.
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			return nil, fmt.Errorf("failed to read %s file %q: %w", kind, path, statErr)
+		}
+		if info.Size() > maxInlineMediaBytes {
+			return nil, fmt.Errorf("%s file %q is %d bytes, exceeding the %d-byte inline limit; upload it to GCS and pass a gs:// URI instead", kind, path, info.Size(), maxInlineMediaBytes)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s file %q: %w", kind, path, err)
+		}
+		refs = append(refs, common.OmniMediaRef{Data: data, MimeType: mimeType})
+	}
+	return refs, nil
+}
+
+// inferMediaMimeType infers an image/video MIME type from a file extension.
+func inferMediaMimeType(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	case ".heic":
+		return "image/heic"
+	case ".heif":
+		return "image/heif"
+	case ".mp4":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	case ".webm":
+		return "video/webm"
+	case ".mpeg", ".mpg":
+		return "video/mpeg"
+	case ".flv":
+		return "video/x-flv"
+	case ".wmv":
+		return "video/wmv"
+	case ".3gp", ".3gpp":
+		return "video/3gpp"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// toInt coerces a JSON-decoded numeric tool argument to an int. MCP arguments
+// arrive as float64 for JSON numbers; a string of digits is also accepted.
+func toInt(v any) (int, error) {
+	switch n := v.(type) {
+	case float64:
+		if n != math.Trunc(n) {
+			return 0, fmt.Errorf("expected an integer, got %v", n)
+		}
+		return int(n), nil
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	default:
+		return 0, fmt.Errorf("expected a number, got %T", v)
+	}
+}
+
+// toFloat64 coerces a JSON-decoded numeric tool argument to a float64. MCP
+// arguments usually arrive as float64, but integer literals may surface as int /
+// int64 depending on the decoder, so those are accepted too (mirrors toInt).
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// parseOptionalFloatInRange reads an optional float tool argument and validates
+// it lies within [min, max]. Returns nil when the argument is absent.
+func parseOptionalFloatInRange(args map[string]interface{}, key string, min, max float64) (*float32, error) {
+	raw, present := args[key]
+	if !present || raw == nil {
+		return nil, nil
+	}
+	f, ok := toFloat64(raw)
+	if !ok {
+		return nil, fmt.Errorf("%s must be a number", key)
+	}
+	if f < min || f > max {
+		return nil, fmt.Errorf("%s must be in the range [%.1f, %.1f], got %v", key, min, max, f)
+	}
+	v := float32(f)
+	return &v, nil
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
@@ -319,7 +319,9 @@ func videoExtForMimeType(mimeType string) string {
 }
 
 // toInt coerces a JSON-decoded numeric tool argument to an int. MCP arguments
-// arrive as float64 for JSON numbers; a string of digits is also accepted.
+// arrive as float64 for JSON numbers, but integer literals may surface as int /
+// int64 depending on the decoder, so those are accepted too. A non-integral
+// float64 or any non-numeric value is rejected with an error.
 func toInt(v any) (int, error) {
 	switch n := v.(type) {
 	case float64:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/handlers.go
@@ -179,7 +179,7 @@ func omniVideoGenerationHandler(ctx context.Context, request mcp.CallToolRequest
 		persisted, err := common.PersistMediaOutputs(ctx, common.MediaArtifact{
 			Data:     videoBytes,
 			MimeType: mimeType,
-			FileName: fmt.Sprintf("omni_%s_%d.mp4", gentime, n),
+			FileName: fmt.Sprintf("omni_%s_%d%s", gentime, n, videoExtForMimeType(mimeType)),
 		}, outputDir, gcsBucketURI, expiry)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
@@ -245,6 +245,9 @@ func parseMediaRefs(arg any, kind string) ([]common.OmniMediaRef, error) {
 		if statErr != nil {
 			return nil, fmt.Errorf("failed to read %s file %q: %w", kind, path, statErr)
 		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("%s path %q is a directory, not a file (expected a local media file or a gs:// URI)", kind, path)
+		}
 		if info.Size() > maxInlineMediaBytes {
 			return nil, fmt.Errorf("%s file %q is %d bytes, exceeding the %d-byte inline limit; upload it to GCS and pass a gs:// URI instead", kind, path, info.Size(), maxInlineMediaBytes)
 		}
@@ -288,6 +291,30 @@ func inferMediaMimeType(path string) string {
 		return "video/3gpp"
 	default:
 		return "application/octet-stream"
+	}
+}
+
+// videoExtForMimeType returns a file extension for a generated video MIME type,
+// defaulting to ".mp4" (the Omni model's output format) for unknown or empty
+// types so the saved filename's extension matches the actual bytes.
+func videoExtForMimeType(mimeType string) string {
+	switch strings.ToLower(strings.TrimSpace(mimeType)) {
+	case "video/mp4":
+		return ".mp4"
+	case "video/webm":
+		return ".webm"
+	case "video/quicktime":
+		return ".mov"
+	case "video/mpeg":
+		return ".mpeg"
+	case "video/3gpp":
+		return ".3gp"
+	case "video/x-flv":
+		return ".flv"
+	case "video/wmv", "video/x-ms-wmv":
+		return ".wmv"
+	default:
+		return ".mp4"
 	}
 }
 


### PR DESCRIPTION
## Summary
Omni **Phase 2b + 2c** (follow-up to #1613 P1 and #1615 P2a). Additive only; no seam/transport changes.

**Phase 2b — incorporate Gemini Omni into the all-in-one `mcp-gemini-go`:**
- New `mcp-gemini-go/omni_handlers.go`: the `omni_video_generation` handler is a **thin wrapper** over the shared `common.GenerateOmniVideo` + `common.PersistMediaOutputs` helpers, mirroring the standalone `mcp-omni-go` handler exactly. **No second client** — the Interactions path stays fully encapsulated in `mcp-common`, so the two servers cannot drift.
- Registered the tool in `mcp-gemini-go/main.go` with the **same param surface** as `mcp-omni-go` (`model`/`prompt`/`output_directory`/`gcs_bucket_uri`/`images`/`videos`/`sample_count`/`temperature`/`top_p`).
- `cloud-interactions-go` remains an **indirect** dep (from #1613); `go.mod`/`go.sum` are tidy for the standalone (no-`go.work`) CI build.

**Phase 2c — strengthen coverage:**
- `mcp-common/omni_contract_test.go` (**NEW**): contract + drift tests that drive canned, representative Interactions JSON **through the real seam** — the adopted `cloud-interactions-go` transport behind `InteractionsClient` — via `httptest`, asserting the full pipeline end to end (library HTTP + JSON decode → `fromLibResponse` → `mapOmniResponse` → multi-sample aggregation) and the request the seam actually sends (lowercase `response_modalities`, pinned `Api-Revision`, `x-goog-user-project`, POST). **Drift cases:** array thought-summary, `created`/`updated` timestamps, lowercase status, unknown fields at every level, `outputs[]` shape, multi-sample, and verbatim 4xx surfacing. No live call.
- **NIT-3** (from the P2a review): `PersistMediaOutputs`' GCS + V4-signed-URL branch is now **unit-tested** via a small function-variable seam over the GCS upload + signing (defaults to the real implementations; only tests override — live behavior unchanged). Covers success, local+GCS, `expiry=0`, signing failure, and upload failure — all previously uncovered.
- Table tests for `ResolveOmniModel` were already added in P2a and remain.

## Live validation (mcp-gemini-go Omni path, project `ghchinoy-genai-sa`)
One `omni_video_generation` call **via the gemini-go binary over stdio MCP**:
- Latency **33.5s**; 1 thought step surfaced as a NOTE.
- Local MP4 **2,525,655 bytes**, valid `ftyp`/`isom` box.
- Uploaded to `gs://ghchinoy-genai-sa-omni/omni_p2bc_validation/omni_20260810170151_0.mp4` (same size).
- V4 signed URL → **HTTP 200**, byte-identical to the local file.

## Gates
- `go build ./...` + `go vet ./...` + `go test ./...` clean under `go.work` **and** in CI-style standalone mode (`GOWORK=off`) for `mcp-common`, `mcp-gemini-go`, `mcp-omni-go`, and `mcp-nanobanana-go` (nanobanana no-regression after the seam change).
- New contract/drift + GCS-branch tests genuinely execute and pass.

## Not in scope
Release wiring (CHANGELOG/VERSION/tags/release-please) is Phase 3 — untouched.
