### PR TITLE
fix(mcp): incorporate cloud-interactions-go v0.2.0 (carry flat media + sherlog through mcp-common seam)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
@@ -52,8 +52,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	cloud.google.com/go/storage v1.64.0
-	github.com/ghchinoy/cloud-interactions-go v0.1.5
+	github.com/ghchinoy/cloud-interactions-go v0.2.0
 	github.com/joho/godotenv v1.5.1
 	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569
 	go.opentelemetry.io/otel v1.45.0

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/go.sum
@@ -46,8 +46,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions.go
@@ -113,12 +113,11 @@ type InteractionResponse struct {
 	Usage   *InteractionUsage `json:"usage,omitempty"`
 	Error   *InteractionError `json:"error,omitempty"`
 
-	// SherlogLink is populated from the x-goog-sherlog-link response header when
-	// optional header capture is enabled. It is not part of the JSON body.
-	//
-	// NOTE (v0.2.0 lib gap): the adopted library's non-streaming Create does not
-	// surface response headers, so this stays empty on the Create path. Flagged in
-	// impl/p1-result.md for the library owner.
+	// SherlogLink is populated from the x-goog-sherlog-link response header. It is
+	// not part of the JSON body. Since cloud-interactions-go v0.2.0 the adopted
+	// library surfaces this header on the non-streaming Create path
+	// (interactions.InteractionResponse.SherlogLink), and fromLibResponse copies it
+	// through, so it is populated on Create.
 	SherlogLink string `json:"-"`
 }
 
@@ -261,11 +260,12 @@ func fromLibResponse(resp *interactions.InteractionResponse) *InteractionRespons
 	}
 
 	out := &InteractionResponse{
-		ID:      resp.ID,
-		Object:  resp.Object,
-		Status:  resp.Status,
-		Steps:   fromLibContents(resp.Steps),
-		Outputs: fromLibContents(resp.Outputs),
+		ID:          resp.ID,
+		Object:      resp.Object,
+		Status:      resp.Status,
+		Steps:       fromLibContents(resp.Steps),
+		Outputs:     fromLibContents(resp.Outputs),
+		SherlogLink: resp.SherlogLink,
 	}
 	if resp.Usage != nil {
 		out.Usage = &InteractionUsage{
@@ -286,15 +286,17 @@ func fromLibResponse(resp *interactions.InteractionResponse) *InteractionRespons
 }
 
 // fromLibContents maps a slice of library Content (a step/output entry) into the
-// suite's Step slice, copying nested content parts. Thought steps carry no parts;
-// they are preserved by Type so GenerateOmniVideo can count them.
+// suite's Step slice, copying nested content parts as well as the flat media
+// fields (MimeType/Data) the library exposes since v0.2.0 for Lyria-style flat
+// outputs[]/steps[]. Thought steps carry no parts; they are preserved by Type so
+// GenerateOmniVideo can count them.
 func fromLibContents(in []interactions.Content) []Step {
 	if in == nil {
 		return nil
 	}
 	steps := make([]Step, 0, len(in))
 	for _, c := range in {
-		s := Step{Type: c.Type, Text: c.Text}
+		s := Step{Type: c.Type, Text: c.Text, MimeType: c.MimeType, Data: c.Data}
 		for _, p := range c.Content {
 			s.Content = append(s.Content, Part{
 				Type:     p.Type,

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions_test.go
@@ -151,6 +151,7 @@ func TestFlatMediaAndSherlogThroughSeam(t *testing.T) {
 
 	// Blocker A: flat audio survives the mapping in both collections.
 	assertFlatAudio := func(where string, steps []Step) {
+		t.Helper()
 		if len(steps) != 1 {
 			t.Fatalf("%s: len = %d, want 1", where, len(steps))
 		}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/interactions_test.go
@@ -98,6 +98,73 @@ func TestInteractionsClientCreate(t *testing.T) {
 	}
 }
 
+// TestFlatMediaAndSherlogThroughSeam proves the v0.2.0 consumer-side incorporation:
+// a Lyria-style flat outputs[]/steps[] entry ({type:"audio", mime_type, data}) and
+// an x-goog-sherlog-link response header are carried through the mcp-common mapping
+// (fromLibContents/fromLibResponse) to Step.MimeType/Step.Data and
+// InteractionResponse.SherlogLink on the non-streaming Create path.
+//
+// This asserts at the seam/mapping level, NOT via GenerateOmniVideo (which is
+// video-only and errors on 0 videos). It fails against v0.1.5 / before the field
+// copies (SherlogLink stays empty; the flat audio Data/MimeType are dropped) and
+// passes with the mapping change.
+func TestFlatMediaAndSherlogThroughSeam(t *testing.T) {
+	const (
+		wantMime    = "audio/wav"
+		wantData    = "SGVsbG8=" // base64("Hello")
+		wantSherlog = "https://sherlog.example/xyz"
+	)
+
+	// Flat audio in BOTH outputs[] (Lyria's live shape) and steps[], so the test
+	// documents that fromLibContents copies the flat fields for either collection.
+	respJSON := `{
+		"id": "lyria-1",
+		"object": "interaction",
+		"status": "completed",
+		"role": "model",
+		"outputs": [{"type": "audio", "mime_type": "` + wantMime + `", "data": "` + wantData + `"}],
+		"steps": [{"type": "audio", "mime_type": "` + wantMime + `", "data": "` + wantData + `"}]
+	}`
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-goog-sherlog-link", wantSherlog)
+		_, _ = io.WriteString(w, respJSON)
+	}))
+	defer ts.Close()
+
+	baseURL := ts.URL + "/v1beta1/projects/test-project/locations/global/interactions"
+	c := newTestClient(baseURL, ts.Client())
+
+	resp, err := c.Create(context.Background(), &InteractionRequest{
+		Model: "lyria-002",
+		Input: []InputItem{{Type: "text", Text: "a calm piano melody"}},
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	// Blocker B: sherlog link surfaces on the Create path.
+	if resp.SherlogLink != wantSherlog {
+		t.Errorf("SherlogLink = %q, want %q (Blocker B: sherlog must flow through the seam on Create)", resp.SherlogLink, wantSherlog)
+	}
+
+	// Blocker A: flat audio survives the mapping in both collections.
+	assertFlatAudio := func(where string, steps []Step) {
+		if len(steps) != 1 {
+			t.Fatalf("%s: len = %d, want 1", where, len(steps))
+		}
+		if steps[0].MimeType != wantMime {
+			t.Errorf("%s[0].MimeType = %q, want %q (Blocker A: flat media dropped)", where, steps[0].MimeType, wantMime)
+		}
+		if steps[0].Data != wantData {
+			t.Errorf("%s[0].Data = %q, want %q (Blocker A: flat media dropped)", where, steps[0].Data, wantData)
+		}
+	}
+	assertFlatAudio("Outputs", resp.Outputs)
+	assertFlatAudio("Steps", resp.Steps)
+}
+
 // TestInteractionsClientCreateAPIError verifies a 4xx body is surfaced verbatim by
 // the adopted library and preserved through the seam.
 func TestInteractionsClientCreateAPIError(t *testing.T) {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.sum
@@ -52,8 +52,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.sum
@@ -52,8 +52,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -167,8 +167,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
 google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.mod
@@ -3,7 +3,6 @@ module github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-
 go 1.26.0
 
 require (
-	cloud.google.com/go/storage v1.64.0
 	github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common v0.0.0-20260810132958-58c6df0d10a8
 	github.com/mark3labs/mcp-go v0.57.0
 	go.opentelemetry.io/otel v1.45.0
@@ -18,6 +17,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/monitoring v1.29.0 // indirect
+	cloud.google.com/go/storage v1.64.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 // indirect
@@ -27,7 +27,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.1.5 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.1.5 h1:ioAa0w/WAxRTbedVwpkh8bQV5JIxUTEMwMa48pStNxY=
-github.com/ghchinoy/cloud-interactions-go v0.1.5/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
+github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## What

Consumer-side incorporation of the already-released, already-reviewed **cloud-interactions-go v0.2.0** (upstream commit `004a97c4`) into `mcp-common`. v0.2.0 fixed the two library gaps we filed (upstream #1/#2): flat media now rides on `Content.MimeType`/`Content.Data` (both `outputs[]` and `steps[]`), and the non-streaming `Create`/`do` path now exposes `InteractionResponse.SherlogLink` + `.ResponseHeaders`.

The library fix alone is necessary-but-not-sufficient: `mcp-common` decodes via the library into its **own** types and did not copy the new fields, so bumping the pin alone still dropped the data at the shared Interactions seam. This PR adds the mapping.

## Changes

- **Bump the pin** `github.com/ghchinoy/cloud-interactions-go` `v0.1.5` → `v0.2.0` in `mcp-common/go.mod` (+ `go mod tidy`).
- **`fromLibContents`** (`mcp-common/interactions.go`): copy `c.MimeType`/`c.Data` onto `common.Step` so a Lyria-style flat `outputs[]`/`steps[]` entry (`{type:"audio", mime_type, data}`) survives the mapping. Closes **Blocker A** on the Create path. (`common.Step` already declared these fields — copy only, no type change.)
- **`fromLibResponse`**: copy `resp.SherlogLink` onto `common.InteractionResponse` so the `x-goog-sherlog-link` header surfaces on the Create path. Closes **Blocker B**. (`common.InteractionResponse.SherlogLink` already existed.)
- **Fix the now-stale comment** in `interactions.go` that claimed the "v0.2.0 lib gap" left `SherlogLink` empty on Create. (The separate comment about dropped `create_time`/`update_time` timestamps is unrelated and still stands — v0.2.0 did not add timestamp handling — and is left untouched.)
- **New seam-level unit test** `TestFlatMediaAndSherlogThroughSeam` drives the decode path via `InteractionsClient`/`httptest`: a flat audio `outputs[]` and `steps[]` entry plus an `x-goog-sherlog-link` response header now surface as `Step.Data`/`Step.MimeType` + `InteractionResponse.SherlogLink`. It asserts at the mapping level (not through `GenerateOmniVideo`, which is video-only and errors on 0 videos). Verified it **fails without** the field copies and **passes with** them.

No changes to transport / `Api-Revision` / the `InteractionsClient` interface beyond the field copies. No server handlers or `mcp-lyria-go` code touched.

### Note on the multi-module go.mod/go.sum churn

The pin lives in `mcp-common`, which every sibling module consumes via a local `replace => ../mcp-common`. CI removes `go.work` and builds each module **standalone**, so MVS forces `cloud-interactions-go v0.2.0` into every consumer. Each module's `go.mod`/`go.sum` is therefore tidied to the v0.2.0 pin so it builds in isolation. These are mechanical `go mod tidy` results — **no code changes** in any dependent module (including `mcp-lyria-go`, whose refactor is a separate later follow-up).

## Verification

- `go build ./...` + `go vet ./...` + `go test ./...` green for `mcp-common` under **go.work AND standalone (`GOWORK=off`)**.
- All sibling modules build+vet clean under go.work and standalone (`mcp-avtool-go` tests require `ffmpeg`/`ffprobe`, installed in CI).
- New test guards the fix (fails pre-mapping-change, passes post).
- No hand-edited VERSION/CHANGELOG/manifest; no tag pushed; no release-please PR touched.

Closes #1621
