### PR TITLE
docs: note Terraform state isolation for multi-project deploys

### DIFF
--- a/docs-site/src/content/docs/core/installation/terraform.md
+++ b/docs-site/src/content/docs/core/installation/terraform.md
@@ -16,3 +16,15 @@ terraform init
 terraform plan
 terraform apply
 ```
+
+## Deploying to multiple projects / environments
+
+Service accounts are created at **project scope**, so the same `account_id` (e.g. `service-creative-studio`) yields a distinct SA per project — there is no cross-project name collision at the GCP level. What must be isolated is **Terraform state**.
+
+The GCS backend in `backend.tf` uses a fixed `prefix = "creative-studio/prod"`. If you reuse the same state bucket **and** prefix for two projects, both deployments share state and one will apply against the other project's resources (for example, an `iam.serviceaccounts.actAs` denial referencing an SA in a different project).
+
+To deploy into multiple projects, isolate the state per environment using any one of:
+
+- a **different state bucket** per project (`terraform init -backend-config="bucket=..."`), or
+- a **different `prefix`** per project (`terraform init -backend-config="prefix=creative-studio/<env>"`), or
+- separate `terraform workspace`s (`terraform workspace new <env>`).

--- a/docs-site/src/content/docs/core/installation/terraform.md
+++ b/docs-site/src/content/docs/core/installation/terraform.md
@@ -19,12 +19,12 @@ terraform apply
 
 ## Deploying to multiple projects / environments
 
-Service accounts are created at **project scope**, so the same `account_id` (e.g. `service-creative-studio`) yields a distinct SA per project — there is no cross-project name collision at the GCP level. What must be isolated is **Terraform state**.
+Service accounts are created at **project scope**, so the same `account_id` (e.g., `service-creative-studio`) yields a distinct SA per project — there is no cross-project name collision at the GCP level. What must be isolated is **Terraform state**.
 
 The GCS backend in `backend.tf` uses a fixed `prefix = "creative-studio/prod"`. If you reuse the same state bucket **and** prefix for two projects, both deployments share state and one will apply against the other project's resources (for example, an `iam.serviceaccounts.actAs` denial referencing an SA in a different project).
 
 To deploy into multiple projects, isolate the state per environment using any one of:
 
-- a **different state bucket** per project (`terraform init -backend-config="bucket=..."`), or
-- a **different `prefix`** per project (`terraform init -backend-config="prefix=creative-studio/<env>"`), or
-- separate `terraform workspace`s (`terraform workspace new <env>`).
+- A **different state bucket** per project (`terraform init -backend-config="bucket=..."`), or
+- A **different `prefix`** per project (`terraform init -backend-config="prefix=creative-studio/<env>"`), or
+- Separate **Terraform workspaces** (`terraform workspace new <env>`).


### PR DESCRIPTION
## What

Adds a short "Deploying to multiple projects / environments" subsection to the Terraform Installation page.

## Why

Follows up on #808. The service account is created at project scope, so the SA name does not collide across projects — the real requirement when deploying into multiple projects is **Terraform state isolation**. The `backend.tf` GCS backend uses a fixed `prefix = "creative-studio/prod"`; reusing the same bucket + prefix for two projects shares state and produces errors like `iam.serviceaccounts.actAs` denied referencing another project's SA.

## Change

Documents the three isolation options: a different state bucket, a different `prefix` per project, or separate `terraform workspace`s. ~13 lines, matching the page's existing style. Docs-only; no version bump.
