### PR TITLE
feat(mcp-genmedia): add output_filename with deterministic suffixing (nanobanana slice)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/naming.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/naming.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common provides shared utilities for the MCP Genmedia servers.
+
+package common
+
+import (
+	"fmt"
+	"mime"
+	"path"
+	"strings"
+)
+
+// BuildOutputFilenames returns deterministic output file names for a generation
+// that produced `count` artifacts, honoring the client base name and forcing the
+// extension to the true media type (design #842 §4b, §4c).
+//
+//	base     the client-supplied output_filename (stem + optional ext). REQUIRED non-empty.
+//	count    number of artifacts (>= 1).
+//	mimeType the model's output MIME (e.g. "image/png", "audio/wav", "video/mp4").
+//
+// Rules: stem = SanitizeBaseFilename(base) with any client extension stripped;
+// ext = ExtensionForMIMEType(mimeType).
+//
+//	count == 1 -> ["<stem><ext>"]
+//	count  > 1 -> ["<stem>_1<ext>", ..., "<stem>_N<ext>"] (1-based, no zero-pad,
+//	              contiguous, in generation order, suffix inserted before the extension)
+//
+// Returns an error if count < 1 or the base sanitizes to empty. It is never
+// invoked when output_filename is unset — callers keep their existing default
+// naming scheme in that case (preserving byte-for-byte current behavior).
+func BuildOutputFilenames(base string, count int, mimeType string) ([]string, error) {
+	if count < 1 {
+		return nil, fmt.Errorf("count must be >= 1, got %d", count)
+	}
+
+	stem := SanitizeBaseFilename(base)
+	// Strip any client-supplied extension; the extension is forced to the true
+	// media type below (§4b).
+	stem = strings.TrimSuffix(stem, path.Ext(stem))
+	stem = strings.TrimSpace(stem)
+	if stem == "" {
+		return nil, fmt.Errorf("output filename %q sanitizes to an empty base name", base)
+	}
+
+	ext := ExtensionForMIMEType(mimeType)
+
+	names := make([]string, count)
+	if count == 1 {
+		names[0] = stem + ext
+		return names, nil
+	}
+	for i := 0; i < count; i++ {
+		names[i] = fmt.Sprintf("%s_%d%s", stem, i+1, ext)
+	}
+	return names, nil
+}
+
+// SanitizeBaseFilename reduces a client-supplied name to a safe single path
+// component: it strips control characters, normalizes Windows separators, reduces
+// the value to its final path component (dropping directory parts and traversal
+// such as "../../etc/passwd" -> "passwd"), and trims. It returns "" when nothing
+// safe remains (e.g. "", ".", "..") so the caller can treat that as an error and
+// fall back to its default scheme. This is a security-relevant control against
+// path traversal / separator injection in both local paths and GCS object names,
+// not a cosmetic one.
+func SanitizeBaseFilename(name string) string {
+	name = strings.TrimSpace(name)
+
+	// Strip control characters (including DEL).
+	name = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, name)
+
+	// Normalize Windows separators so path.Base reliably drops directory parts
+	// even on non-Windows hosts (where '\\' is not a path separator).
+	name = strings.ReplaceAll(name, "\\", "/")
+
+	// Reduce to the final path component (defense against traversal).
+	name = path.Base(name)
+	name = strings.TrimSpace(name)
+
+	// path.Base yields "." for empty/dot-only inputs and ".." for parent refs; a
+	// name that is only dots is not a usable file name.
+	if strings.Trim(name, ".") == "" {
+		return ""
+	}
+	return name
+}
+
+// ExtensionForMIMEType generalizes ImageExtensionForMIMEType to audio and video.
+// image/* MIME types delegate to the existing ImageExtensionForMIMEType (no
+// behavior change / no duplication for existing image callers). Unknown types
+// fall back to mime.ExtensionsByType, else "".
+func ExtensionForMIMEType(mimeType string) string {
+	m := strings.ToLower(strings.TrimSpace(mimeType))
+	if strings.HasPrefix(m, "image/") {
+		return ImageExtensionForMIMEType(mimeType)
+	}
+	switch m {
+	case "audio/mpeg", "audio/mp3":
+		return ".mp3"
+	case "audio/wav", "audio/x-wav", "audio/l16":
+		return ".wav"
+	case "audio/ogg":
+		return ".ogg"
+	case "video/mp4":
+		return ".mp4"
+	case "video/webm":
+		return ".webm"
+	}
+	if exts, err := mime.ExtensionsByType(m); err == nil && len(exts) > 0 {
+		return exts[0]
+	}
+	return ""
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/naming_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/naming_test.go
@@ -1,0 +1,253 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBuildOutputFilenames(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		count    int
+		mimeType string
+		want     []string
+		wantErr  bool
+	}{
+		{
+			name:     "single no suffix",
+			base:     "foo.png",
+			count:    1,
+			mimeType: "image/png",
+			want:     []string{"foo.png"},
+		},
+		{
+			name:     "multiple gets 1-based contiguous suffix",
+			base:     "foo.png",
+			count:    3,
+			mimeType: "image/png",
+			want:     []string{"foo_1.png", "foo_2.png", "foo_3.png"},
+		},
+		{
+			name:     "no extension input gets forced extension",
+			base:     "foo",
+			count:    1,
+			mimeType: "image/jpeg",
+			want:     []string{"foo.jpg"},
+		},
+		{
+			name:     "wrong extension is forced to true MIME",
+			base:     "foo.jpeg",
+			count:    1,
+			mimeType: "image/png",
+			want:     []string{"foo.png"},
+		},
+		{
+			name:     "wrong extension forced across multiple",
+			base:     "hero.gif",
+			count:    2,
+			mimeType: "image/png",
+			want:     []string{"hero_1.png", "hero_2.png"},
+		},
+		{
+			name:     "audio wav multiple",
+			base:     "track",
+			count:    2,
+			mimeType: "audio/wav",
+			want:     []string{"track_1.wav", "track_2.wav"},
+		},
+		{
+			name:     "video mp4 single",
+			base:     "clip",
+			count:    1,
+			mimeType: "video/mp4",
+			want:     []string{"clip.mp4"},
+		},
+		{
+			name:     "no zero padding across order of magnitude",
+			base:     "img",
+			count:    10,
+			mimeType: "image/png",
+			want: []string{
+				"img_1.png", "img_2.png", "img_3.png", "img_4.png", "img_5.png",
+				"img_6.png", "img_7.png", "img_8.png", "img_9.png", "img_10.png",
+			},
+		},
+		{
+			name:     "traversal base is sanitized before naming",
+			base:     "../../etc/passwd",
+			count:    1,
+			mimeType: "image/png",
+			want:     []string{"passwd.png"},
+		},
+		{
+			name:     "count zero is an error",
+			base:     "foo.png",
+			count:    0,
+			mimeType: "image/png",
+			wantErr:  true,
+		},
+		{
+			name:     "negative count is an error",
+			base:     "foo.png",
+			count:    -1,
+			mimeType: "image/png",
+			wantErr:  true,
+		},
+		{
+			name:     "empty base is an error",
+			base:     "",
+			count:    1,
+			mimeType: "image/png",
+			wantErr:  true,
+		},
+		{
+			name:     "dot-only base sanitizes to empty and errors",
+			base:     "..",
+			count:    2,
+			mimeType: "image/png",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := BuildOutputFilenames(tc.base, tc.count, tc.mimeType)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("BuildOutputFilenames(%q, %d, %q) = %v, want error", tc.base, tc.count, tc.mimeType, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildOutputFilenames(%q, %d, %q) unexpected error: %v", tc.base, tc.count, tc.mimeType, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("BuildOutputFilenames(%q, %d, %q) = %v, want %v", tc.base, tc.count, tc.mimeType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildOutputFilenamesOrdering asserts contiguity and generation order
+// independent of the table above.
+func TestBuildOutputFilenamesOrdering(t *testing.T) {
+	got, err := BuildOutputFilenames("scene.png", 4, "image/png")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"scene_1.png", "scene_2.png", "scene_3.png", "scene_4.png"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ordering/contiguity mismatch: got %v want %v", got, want)
+	}
+}
+
+func TestSanitizeBaseFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain name", "hero.png", "hero.png"},
+		{"parent traversal", "../../etc/passwd", "passwd"},
+		{"leading slash absolute", "/etc/passwd", "passwd"},
+		{"embedded separators reduced to last component", "a/b/c.png", "c.png"},
+		{"windows separators", "..\\..\\secret.txt", "secret.txt"},
+		{"single dot", ".", ""},
+		{"double dot", "..", ""},
+		{"dot-only run", "...", ""},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"control chars stripped", "he\x00ro\x1f.png", "hero.png"},
+		{"trims surrounding whitespace", "  hero.png  ", "hero.png"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SanitizeBaseFilename(tc.in); got != tc.want {
+				t.Errorf("SanitizeBaseFilename(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeBaseFilenameHasNoSeparators is a security invariant: the output
+// must never contain a path separator, so it can never escape a target directory
+// or GCS prefix.
+func TestSanitizeBaseFilenameHasNoSeparators(t *testing.T) {
+	inputs := []string{
+		"../../etc/passwd",
+		"/absolute/path/file.png",
+		"..\\..\\windows\\file.png",
+		"a/b/c/d.png",
+		"nested/dir/",
+	}
+	for _, in := range inputs {
+		got := SanitizeBaseFilename(in)
+		if strings.ContainsAny(got, `/\`) {
+			t.Errorf("SanitizeBaseFilename(%q) = %q, contains a path separator", in, got)
+		}
+	}
+}
+
+func TestExtensionForMIMEType(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		want     string
+	}{
+		// images delegate to ImageExtensionForMIMEType
+		{"image/png", ".png"},
+		{"image/jpeg", ".jpg"},
+		{"image/webp", ".webp"},
+		{"image/gif", ".gif"},
+		{"image/unknown", ".png"}, // image/* default via ImageExtensionForMIMEType
+		{"IMAGE/JPEG", ".jpg"},    // case-insensitive
+		// audio
+		{"audio/mpeg", ".mp3"},
+		{"audio/mp3", ".mp3"},
+		{"audio/wav", ".wav"},
+		{"audio/x-wav", ".wav"},
+		{"audio/L16", ".wav"},
+		{"audio/ogg", ".ogg"},
+		// video
+		{"video/mp4", ".mp4"},
+		{"video/webm", ".webm"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.mimeType, func(t *testing.T) {
+			if got := ExtensionForMIMEType(tc.mimeType); got != tc.want {
+				t.Errorf("ExtensionForMIMEType(%q) = %q, want %q", tc.mimeType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtensionForMIMETypeFallback covers the mime.ExtensionsByType fallback path
+// and the empty/unknown -> "" behavior.
+func TestExtensionForMIMETypeFallback(t *testing.T) {
+	// A registered non-image/audio/video type should resolve via the stdlib.
+	if got := ExtensionForMIMEType("application/json"); got == "" {
+		t.Errorf("ExtensionForMIMEType(application/json) = \"\", want a stdlib-provided extension")
+	}
+	// A clearly bogus type has no extension.
+	if got := ExtensionForMIMEType("not-a-real/mime-type-xyz"); got != "" {
+		t.Errorf("ExtensionForMIMEType(bogus) = %q, want empty", got)
+	}
+	if got := ExtensionForMIMEType(""); got != "" {
+		t.Errorf("ExtensionForMIMEType(empty) = %q, want empty", got)
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -146,6 +146,35 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 	gentime := time.Now().Format("20060102150405")
 	expiry := common.SignedURLExpiryFromEnv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS")
 
+	// First pass: count the generated image artifacts (and capture the MIME type
+	// of the first one) so the total count is known before naming — required for
+	// deterministic _1..n suffixing when output_filename is set.
+	imageCount := 0
+	firstImageMime := ""
+	for _, candidate := range resp.Candidates {
+		for _, part := range candidate.Content.Parts {
+			if part.InlineData != nil {
+				if imageCount == 0 {
+					firstImageMime = part.InlineData.MIMEType
+				}
+				imageCount++
+			}
+		}
+	}
+
+	// When output_filename is set, precompute client-predictable names via the
+	// shared helper (extension forced to the true MIME, deterministic suffixing).
+	// When unset, names is nil and each image keeps the default per-part scheme —
+	// byte-for-byte unchanged legacy behavior.
+	base := clientOutputFilename(request.GetArguments())
+	names, err := buildImageFilenames(base, imageCount, firstImageMime)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Second pass: preserve the original text/image interleaving exactly and
+	// persist each image through the shared seam.
+	imgIdx := 0
 	for _, candidate := range resp.Candidates {
 		for n, part := range candidate.Content.Parts {
 			if part.Text != "" {
@@ -154,7 +183,22 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 			if part.InlineData != nil {
 				log.Printf("part %d mime-type: %s", n, part.InlineData.MIMEType)
 
-				fileName := fmt.Sprintf("gemini_%s_%d%s", gentime, n, extForMimeType(part.InlineData.MIMEType))
+				var fileName string
+				if names != nil {
+					fileName = names[imgIdx]
+				} else {
+					fileName = defaultImageFilename(gentime, n, part.InlineData.MIMEType)
+				}
+				imgIdx++
+
+				// Collision policy: overwrite with a warning (design §4e). Surface
+				// a local collision before the shared seam truncates the file.
+				if outputDir != "" {
+					if _, statErr := os.Stat(filepath.Join(outputDir, fileName)); statErr == nil {
+						log.Printf("Warning: output file %q already exists in %s; overwriting (collision policy).", fileName, outputDir)
+					}
+				}
+
 				persisted, err := common.PersistMediaOutputs(ctx, common.MediaArtifact{
 					Data:     part.InlineData.Data,
 					MimeType: part.InlineData.MIMEType,
@@ -224,6 +268,42 @@ func inferMimeType(path string) string {
 		// A more robust solution might involve reading file headers.
 		return "image/png"
 	}
+}
+
+// clientOutputFilename returns the client-supplied base output name.
+// output_filename is the canonical parameter and always wins. nanobanana carries
+// no legacy naming parameter of its own (per the #842 design's Path-A table), so
+// no alias is wired into its tool schema; the variadic legacyKeys argument
+// implements the shared accept-and-alias precedence contract (output_filename >
+// legacy > default) that the fan-out servers (e.g. lyria file_name) reuse.
+func clientOutputFilename(args map[string]any, legacyKeys ...string) string {
+	if v, ok := args["output_filename"].(string); ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	for _, k := range legacyKeys {
+		if v, ok := args[k].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// buildImageFilenames returns the persisted file names for `count` image
+// artifacts of the given MIME type. When the client supplied output_filename
+// (base != ""), names are client-predictable and deterministically suffixed via
+// the shared common helper. Otherwise it returns nil so the caller falls back to
+// its default per-part scheme (byte-for-byte unchanged legacy behavior).
+func buildImageFilenames(base string, count int, mimeType string) ([]string, error) {
+	if strings.TrimSpace(base) == "" || count < 1 {
+		return nil, nil
+	}
+	return common.BuildOutputFilenames(base, count, mimeType)
+}
+
+// defaultImageFilename is nanobanana's legacy naming scheme, used when
+// output_filename is unset. Preserved verbatim to guarantee zero regression.
+func defaultImageFilename(gentime string, partIndex int, mimeType string) string {
+	return fmt.Sprintf("gemini_%s_%d%s", gentime, partIndex, extForMimeType(mimeType))
 }
 
 // extForMimeType returns a reasonable file extension for a given image MIME type.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -38,6 +39,167 @@ func TestExtForMimeType(t *testing.T) {
 		t.Run(tc.mimeType, func(t *testing.T) {
 			if got := extForMimeType(tc.mimeType); got != tc.want {
 				t.Errorf("extForMimeType(%q) = %q, want %q", tc.mimeType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClientOutputFilename covers the accept-and-alias precedence contract:
+// output_filename wins, then any legacy alias, then "" (default scheme).
+func TestClientOutputFilename(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       map[string]any
+		legacyKeys []string
+		want       string
+	}{
+		{
+			name: "output_filename honored",
+			args: map[string]any{"output_filename": "hero.png"},
+			want: "hero.png",
+		},
+		{
+			name: "output_filename trimmed",
+			args: map[string]any{"output_filename": "  hero.png  "},
+			want: "hero.png",
+		},
+		{
+			name:       "legacy alias used when output_filename unset (back-compat)",
+			args:       map[string]any{"file_name": "legacy.png"},
+			legacyKeys: []string{"file_name"},
+			want:       "legacy.png",
+		},
+		{
+			name:       "output_filename wins on conflict with legacy alias",
+			args:       map[string]any{"output_filename": "new.png", "file_name": "legacy.png"},
+			legacyKeys: []string{"file_name"},
+			want:       "new.png",
+		},
+		{
+			name: "none set returns empty (default scheme)",
+			args: map[string]any{},
+			want: "",
+		},
+		{
+			name: "blank output_filename ignored",
+			args: map[string]any{"output_filename": "   "},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientOutputFilename(tc.args, tc.legacyKeys...); got != tc.want {
+				t.Errorf("clientOutputFilename(%v, %v) = %q, want %q", tc.args, tc.legacyKeys, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildImageFilenames covers the nanobanana naming decision: unset -> nil
+// (default scheme), n==1 -> foo.png, n>1 -> foo_1.png..foo_n.png, extension
+// forced to the real MIME type.
+func TestBuildImageFilenames(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		count    int
+		mimeType string
+		want     []string
+		wantErr  bool
+	}{
+		{
+			name:     "unset base returns nil (default scheme / back-compat)",
+			base:     "",
+			count:    2,
+			mimeType: "image/png",
+			want:     nil,
+		},
+		{
+			name:     "blank base returns nil",
+			base:     "   ",
+			count:    1,
+			mimeType: "image/png",
+			want:     nil,
+		},
+		{
+			name:     "single image no suffix",
+			base:     "foo.png",
+			count:    1,
+			mimeType: "image/png",
+			want:     []string{"foo.png"},
+		},
+		{
+			name:     "multiple images suffixed",
+			base:     "foo.png",
+			count:    3,
+			mimeType: "image/png",
+			want:     []string{"foo_1.png", "foo_2.png", "foo_3.png"},
+		},
+		{
+			name:     "extension forced to real MIME (single)",
+			base:     "foo.jpeg",
+			count:    1,
+			mimeType: "image/png",
+			want:     []string{"foo.png"},
+		},
+		{
+			name:     "extension forced to real MIME (multiple)",
+			base:     "foo.jpeg",
+			count:    2,
+			mimeType: "image/png",
+			want:     []string{"foo_1.png", "foo_2.png"},
+		},
+		{
+			name:     "missing extension gets forced",
+			base:     "foo",
+			count:    1,
+			mimeType: "image/jpeg",
+			want:     []string{"foo.jpg"},
+		},
+		{
+			name:     "traversal base sanitized",
+			base:     "../../hero.png",
+			count:    1,
+			mimeType: "image/png",
+			want:     []string{"hero.png"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildImageFilenames(tc.base, tc.count, tc.mimeType)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("buildImageFilenames(%q, %d, %q) = %v, want error", tc.base, tc.count, tc.mimeType, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildImageFilenames(%q, %d, %q) unexpected error: %v", tc.base, tc.count, tc.mimeType, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("buildImageFilenames(%q, %d, %q) = %v, want %v", tc.base, tc.count, tc.mimeType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultImageFilename locks the legacy default naming scheme byte-for-byte,
+// so the unset-output_filename path is guaranteed to be a zero regression.
+func TestDefaultImageFilename(t *testing.T) {
+	tests := []struct {
+		gentime   string
+		partIndex int
+		mimeType  string
+		want      string
+	}{
+		{"20260811120000", 0, "image/png", "gemini_20260811120000_0.png"},
+		{"20260811120000", 1, "image/jpeg", "gemini_20260811120000_1.jpg"},
+		{"20260811120000", 2, "", "gemini_20260811120000_2.png"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := defaultImageFilename(tc.gentime, tc.partIndex, tc.mimeType); got != tc.want {
+				t.Errorf("defaultImageFilename(%q, %d, %q) = %q, want %q", tc.gentime, tc.partIndex, tc.mimeType, got, tc.want)
 			}
 		})
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -106,6 +106,7 @@ func main() {
 		mcp.WithArray("images", mcp.Description("Optional. A list of local file paths or GCS URIs for input media (images, videos, or PDFs)."), mcp.Items(map[string]any{"type": "string"})),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save generated image(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated images (e.g., your-bucket/outputs/).")),
+		mcp.WithString("output_filename", mcp.Description("Optional. Client-predictable base name for the generated file(s). The extension is forced to the true output media type (e.g. .png). When a single image is produced the name is used as-is (e.g. 'hero.png'); when multiple images are produced they are suffixed '_1', '_2', ... before the extension (e.g. 'hero_1.png', 'hero_2.png'). An existing file/object of the same name is overwritten.")),
 		mcp.WithNumber("seed", mcp.Description("Optional. Non-negative integer seed for best-effort reproducible image generation.")),
 	)
 


### PR DESCRIPTION
## Summary

Phase 1 (gating vertical slice) of #842 — an optional, consistently-named `output_filename` for media MCP tools, with deterministic `_1..n` suffixing. This PR lands the **shared `mcp-common` naming helpers** and wires **one** server end to end — **nanobanana** — to prove the contract before any fan-out.

Implements the locked Phase-0 decisions and the Phase-1 section of the #842 design.

## Changes

**`mcp-common` (new `naming.go` + `naming_test.go`):**
- `BuildOutputFilenames(base, count, mimeType)` — 1-based, no zero-pad, **no suffix when `count==1`**, `_1..._n` inserted before the extension when `count>1`; extension **forced** to the true media MIME (§4b/§4c). Errors on `count<1` or a base that sanitizes to empty.
- `SanitizeBaseFilename(name)` — reduces a client name to a safe single path component, stripping directory parts, `..` traversal, and control chars (defense-in-depth for both local paths and GCS object names).
- `ExtensionForMIMEType(mimeType)` — generalizes the existing `ImageExtensionForMIMEType` to audio/video with a `mime.ExtensionsByType` fallback.

**nanobanana (`main.go`, `handlers.go`):**
- New optional `output_filename` tool parameter, routed through `BuildOutputFilenames` into `MediaArtifact.FileName` via the existing `PersistMediaOutputs` seam (inline / local `output_directory` / GCS).
- `output_filename` takes precedence over any legacy alias (nanobanana carries no legacy naming param of its own; the accept-and-alias precedence is implemented for fan-out to reuse).
- **Unset `output_filename` → byte-for-byte unchanged** legacy naming (`gemini_<ts>_<n>.<ext>`).
- Collision policy: overwrite with a warning log (§4e).

## Behavior

- `output_filename="hero.png"`, 1 image → `hero.png`
- `output_filename="hero.png"`, n images → `hero_1.png … hero_n.png`
- Wrong/missing extension is forced to the real output MIME (`hero.jpeg` on a PNG → `hero.png`).

## Tests

- `mcp-common`: `BuildOutputFilenames` (count==1 vs count>1, extension forcing/override, empty/illegal/traversal base, ordering/contiguity, no zero-pad), `SanitizeBaseFilename` (traversal, separators, control chars, dot-only, no-separator invariant), `ExtensionForMIMEType` (image/audio/video + fallback).
- nanobanana: `output_filename` precedence + legacy-alias back-compat, `n==1`→`foo.png`, `n>1`→`foo_1.png..foo_n.png`, extension forced to real MIME, and the default (unset) scheme locked byte-for-byte.
- `go build`, `go vet`, and `go test` pass for both modules **standalone** (`GOWORK=off`) and under the workspace `go.work`.

## Scope / notes

- Phase 1 only — no other servers touched (fan-out is later phases, conditional on this gate).
- **`VERSION` untouched** — release-please owns the bump (this `feat` is a MINOR).
- Not for merge yet: gated by owner/coordinator review.

Refs #842
