### PR TITLE
feat(mcp-genmedia): output_filename for imagen via GCS copy-rename (imagen slice)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename.go
@@ -50,9 +50,13 @@ type Rename struct{ Src, Dst string }
 // RenameGCSObject copies srcObject to dstObject within the same bucket
 // (server-side, no download) and deletes the source. Per design #842 §4d:
 //
-//   - Copy failure is FATAL: any partial destination is best-effort removed so
-//     no orphaned destination is left behind, the source is left intact, and a
-//     fatal error naming both src and dst is returned.
+//   - Copy failure is FATAL: any destination this copy could have created is
+//     best-effort removed so no orphaned destination is left behind, the source
+//     is left intact, and a fatal error naming both src and dst is returned. A
+//     destination that PRE-EXISTED (collision/overwrite intent) is left untouched
+//     on copy failure — cleanup must never delete a prior good object the copy did
+//     not create. (GCS object copy is atomic per object, so a failed copy never
+//     leaves a partial dst; there is nothing to clean up unless dst is fresh.)
 //   - Delete failure is NON-FATAL: the desired object (dst) exists and is valid,
 //     so a warning is logged and nil is returned — a leftover source object is
 //     cosmetic, not a data error.
@@ -77,18 +81,27 @@ func RenameGCSObject(ctx context.Context, bucket, srcObject, dstObject string) e
 	}
 
 	// Collision (§4e): overwrite, but make it observable. A best-effort existence
-	// probe only drives the warning log — it never blocks the rename.
+	// probe only drives the warning log — it never blocks the rename. Its result is
+	// also reused below so copy-failure cleanup never deletes a pre-existing object.
+	dstPreExisted := false
 	if exists, existsErr := gcsObjectExistsFn(ctx, bucket, dstObject); existsErr != nil {
 		log.Printf("RenameGCSObject: could not check whether destination gs://%s/%s exists (continuing): %v", bucket, dstObject, existsErr)
 	} else if exists {
+		dstPreExisted = true
 		log.Printf("RenameGCSObject: destination gs://%s/%s already exists; overwriting", bucket, dstObject)
 	}
 
 	if err := copyGCSObjectFn(ctx, bucket, srcObject, dstObject); err != nil {
-		// Copy failed. Best-effort remove any partial destination so no orphan is
-		// left, leave the source untouched, and return a fatal error.
-		if delErr := deleteGCSObjectFn(ctx, bucket, dstObject); delErr != nil && !errors.Is(delErr, storage.ErrObjectNotExist) {
-			log.Printf("RenameGCSObject: copy gs://%s/%s -> gs://%s/%s failed and cleanup of any partial destination also failed: %v", bucket, srcObject, bucket, dstObject, delErr)
+		// Copy failed. Only remove a destination THIS copy could have created: if
+		// dst pre-existed (collision/overwrite), a failed copy leaves the prior good
+		// object intact and cleanup must not delete it. GCS copy is atomic per
+		// object, so a failed copy never leaves a partial dst — the only thing worth
+		// cleaning up is a dst that did not exist before this call. Either way the
+		// source is left untouched and a fatal error is returned.
+		if !dstPreExisted {
+			if delErr := deleteGCSObjectFn(ctx, bucket, dstObject); delErr != nil && !errors.Is(delErr, storage.ErrObjectNotExist) {
+				log.Printf("RenameGCSObject: copy gs://%s/%s -> gs://%s/%s failed and cleanup of any partial destination also failed: %v", bucket, srcObject, bucket, dstObject, delErr)
+			}
 		}
 		return fmt.Errorf("RenameGCSObject: copy gs://%s/%s -> gs://%s/%s failed: %w", bucket, srcObject, bucket, dstObject, err)
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common provides shared utilities for the MCP Genmedia servers.
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"cloud.google.com/go/storage"
+)
+
+// GCS has no atomic rename. For the "API-controls-GCS" servers (imagen/veo) the
+// model writes objects into a prefix and names them itself (sample_0.png, ...).
+// To honor a client-supplied output_filename those objects are copied to the
+// desired name and the originals deleted. The exact copy-fatal / delete-nonfatal
+// contract is design #842 §4d.
+
+// copyGCSObjectFn, deleteGCSObjectFn and gcsObjectExistsFn indirect over the
+// real server-side GCS copy, delete and existence-check so the copy-fatal /
+// delete-nonfatal / collision branches of the rename helpers are unit-testable
+// without a live bucket or credentials. They default to the real
+// implementations (production behavior is unchanged) and are only reassigned by
+// tests, which restore them afterwards — mirroring the uploadToGCSFn /
+// generateV4SignedURLFn indirection in media_output.go.
+var (
+	copyGCSObjectFn   = copyGCSObject
+	deleteGCSObjectFn = deleteGCSObject
+	gcsObjectExistsFn = gcsObjectExists
+)
+
+// Rename is a single source→destination object rename within one bucket.
+type Rename struct{ Src, Dst string }
+
+// RenameGCSObject copies srcObject to dstObject within the same bucket
+// (server-side, no download) and deletes the source. Per design #842 §4d:
+//
+//   - Copy failure is FATAL: any partial destination is best-effort removed so
+//     no orphaned destination is left behind, the source is left intact, and a
+//     fatal error naming both src and dst is returned.
+//   - Delete failure is NON-FATAL: the desired object (dst) exists and is valid,
+//     so a warning is logged and nil is returned — a leftover source object is
+//     cosmetic, not a data error.
+//   - A pre-existing destination is overwritten with a warning (§4e). Server-side
+//     copy overwrites by default; the warning just makes it observable.
+//
+// A src == dst rename is a no-op and returns nil.
+//
+// Latency note: a same-bucket, same-region copy is a metadata operation (fast);
+// cross-region or very large objects add copy latency proportional to size. This
+// runs after generation and before the tool returns, so the client sees it as
+// added tool latency.
+func RenameGCSObject(ctx context.Context, bucket, srcObject, dstObject string) error {
+	if bucket == "" {
+		return fmt.Errorf("RenameGCSObject: bucket must not be empty")
+	}
+	if srcObject == "" || dstObject == "" {
+		return fmt.Errorf("RenameGCSObject: src (%q) and dst (%q) must both be non-empty", srcObject, dstObject)
+	}
+	if srcObject == dstObject {
+		return nil // nothing to do
+	}
+
+	// Collision (§4e): overwrite, but make it observable. A best-effort existence
+	// probe only drives the warning log — it never blocks the rename.
+	if exists, existsErr := gcsObjectExistsFn(ctx, bucket, dstObject); existsErr != nil {
+		log.Printf("RenameGCSObject: could not check whether destination gs://%s/%s exists (continuing): %v", bucket, dstObject, existsErr)
+	} else if exists {
+		log.Printf("RenameGCSObject: destination gs://%s/%s already exists; overwriting", bucket, dstObject)
+	}
+
+	if err := copyGCSObjectFn(ctx, bucket, srcObject, dstObject); err != nil {
+		// Copy failed. Best-effort remove any partial destination so no orphan is
+		// left, leave the source untouched, and return a fatal error.
+		if delErr := deleteGCSObjectFn(ctx, bucket, dstObject); delErr != nil && !errors.Is(delErr, storage.ErrObjectNotExist) {
+			log.Printf("RenameGCSObject: copy gs://%s/%s -> gs://%s/%s failed and cleanup of any partial destination also failed: %v", bucket, srcObject, bucket, dstObject, delErr)
+		}
+		return fmt.Errorf("RenameGCSObject: copy gs://%s/%s -> gs://%s/%s failed: %w", bucket, srcObject, bucket, dstObject, err)
+	}
+
+	// Copy succeeded; the desired object now exists. Deleting the source is
+	// housekeeping — a failure leaves a cosmetic leftover, not a data error.
+	if err := deleteGCSObjectFn(ctx, bucket, srcObject); err != nil {
+		log.Printf("RenameGCSObject: could not remove API-original gs://%s/%s after successful copy to %s (non-fatal): %v", bucket, srcObject, dstObject, err)
+	}
+	return nil
+}
+
+// RenameGCSObjects renames a batch of objects within one bucket, sequentially.
+// On the first copy failure it stops and returns the destination names already
+// renamed plus a fatal error that names the source object left behind. Already
+// renamed objects are valid outputs the client asked for and are NOT rolled back
+// (design #842 §4d) — rolling back would delete correctly-named media. On full
+// success every source object has been removed.
+func RenameGCSObjects(ctx context.Context, bucket string, renames []Rename) (renamed []string, err error) {
+	for _, r := range renames {
+		if rErr := RenameGCSObject(ctx, bucket, r.Src, r.Dst); rErr != nil {
+			return renamed, fmt.Errorf("RenameGCSObjects: renamed %d of %d before failing on gs://%s/%s (source left in place): %w", len(renamed), len(renames), bucket, r.Src, rErr)
+		}
+		renamed = append(renamed, r.Dst)
+	}
+	return renamed, nil
+}
+
+// copyGCSObject performs a server-side copy of srcObject to dstObject within the
+// same bucket (no download). GCS object copy is atomic per object: the
+// destination either exists fully or not at all.
+func copyGCSObject(ctx context.Context, bucket, srcObject, dstObject string) error {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storage.NewClient: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	src := client.Bucket(bucket).Object(srcObject)
+	dst := client.Bucket(bucket).Object(dstObject)
+	if _, err := dst.CopierFrom(src).Run(ctx); err != nil {
+		return fmt.Errorf("CopierFrom(%q).Run to %q: %w", srcObject, dstObject, err)
+	}
+	return nil
+}
+
+// deleteGCSObject deletes a single object.
+func deleteGCSObject(ctx context.Context, bucket, object string) error {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storage.NewClient: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if err := client.Bucket(bucket).Object(object).Delete(ctx); err != nil {
+		return fmt.Errorf("Object(%q).Delete: %w", object, err)
+	}
+	return nil
+}
+
+// gcsObjectExists reports whether an object exists. A not-found result is
+// returned as (false, nil); any other error is surfaced to the caller.
+func gcsObjectExists(ctx context.Context, bucket, object string) (bool, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return false, fmt.Errorf("storage.NewClient: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = client.Bucket(bucket).Object(object).Attrs(ctx)
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename_test.go
@@ -122,6 +122,34 @@ func TestRenameGCSObjectCopyFailNoOrphan(t *testing.T) {
 	}
 }
 
+// TestRenameGCSObjectPreexistingDstCopyFailPreservesPrior: destination
+// PRE-EXISTS (collision/overwrite intent) and the copy fails → fatal error, but
+// the prior good object MUST be left intact. Copy-failure cleanup must never
+// delete a destination it did not create (design #842 §4d; veo's declarative
+// re-run workflow makes this collision path common).
+func TestRenameGCSObjectPreexistingDstCopyFailPreservesPrior(t *testing.T) {
+	f := newFakeGCS("out/sample_0.png", "out/hero.png") // dst already exists
+	f.copyErrOn = "out/hero.png"                        // the overwrite copy fails
+	f.install(t)
+
+	err := RenameGCSObject(context.Background(), "bkt", "out/sample_0.png", "out/hero.png")
+	if err == nil {
+		t.Fatal("expected a fatal error on copy failure, got nil")
+	}
+	// The pre-existing destination must NOT be deleted by cleanup.
+	if !f.objects["out/hero.png"] {
+		t.Errorf("a failed overwrite must preserve the PRIOR destination object; objects=%v", f.list())
+	}
+	// The source is left intact so a re-run can recover.
+	if !f.objects["out/sample_0.png"] {
+		t.Errorf("copy failure must leave the source intact; objects=%v", f.list())
+	}
+	// Cleanup must not run for a pre-existing dst (nothing this copy created).
+	if f.deletes != 0 {
+		t.Errorf("cleanup must NOT delete a pre-existing destination; deletes=%d", f.deletes)
+	}
+}
+
 // TestRenameGCSObjectDeleteFailNonFatal: copy succeeds, delete of source fails →
 // nil returned (non-fatal), destination present.
 func TestRenameGCSObjectDeleteFailNonFatal(t *testing.T) {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/gcs_rename_test.go
@@ -1,0 +1,261 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fakeGCS is an in-memory stand-in for a GCS bucket used to exercise the
+// rename helpers without a live bucket or credentials. copyErrOn / deleteErrOn
+// let a test inject a failure on a specific object.
+type fakeGCS struct {
+	objects     map[string]bool
+	copyErrOn   string // if a copy targets this dst, fail
+	deleteErr   error  // returned by every delete when non-nil
+	deleteErrOn string // if a delete targets this object, fail with deleteErr
+	copies      int
+	deletes     int
+}
+
+func newFakeGCS(existing ...string) *fakeGCS {
+	f := &fakeGCS{objects: map[string]bool{}}
+	for _, o := range existing {
+		f.objects[o] = true
+	}
+	return f
+}
+
+// install swaps the package-level seams to route through this fake and restores
+// them when the test ends.
+func (f *fakeGCS) install(t *testing.T) {
+	t.Helper()
+	origCopy, origDelete, origExists := copyGCSObjectFn, deleteGCSObjectFn, gcsObjectExistsFn
+	copyGCSObjectFn = func(_ context.Context, _ /*bucket*/, src, dst string) error {
+		f.copies++
+		if f.copyErrOn != "" && dst == f.copyErrOn {
+			return fmt.Errorf("injected copy failure for %s", dst)
+		}
+		if !f.objects[src] {
+			return fmt.Errorf("source %s does not exist", src)
+		}
+		f.objects[dst] = true
+		return nil
+	}
+	deleteGCSObjectFn = func(_ context.Context, _ /*bucket*/, obj string) error {
+		f.deletes++
+		if f.deleteErr != nil && (f.deleteErrOn == "" || obj == f.deleteErrOn) {
+			return f.deleteErr
+		}
+		delete(f.objects, obj)
+		return nil
+	}
+	gcsObjectExistsFn = func(_ context.Context, _ /*bucket*/, obj string) (bool, error) {
+		return f.objects[obj], nil
+	}
+	t.Cleanup(func() {
+		copyGCSObjectFn, deleteGCSObjectFn, gcsObjectExistsFn = origCopy, origDelete, origExists
+	})
+}
+
+func (f *fakeGCS) list() []string {
+	out := make([]string, 0, len(f.objects))
+	for o := range f.objects {
+		out = append(out, o)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestRenameGCSObjectSuccess: copy+delete both succeed → dst present, src gone.
+func TestRenameGCSObjectSuccess(t *testing.T) {
+	f := newFakeGCS("out/sample_0.png")
+	f.install(t)
+
+	if err := RenameGCSObject(context.Background(), "bkt", "out/sample_0.png", "out/hero.png"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.objects["out/sample_0.png"] {
+		t.Errorf("source object should have been deleted; objects=%v", f.list())
+	}
+	if !f.objects["out/hero.png"] {
+		t.Errorf("destination object missing; objects=%v", f.list())
+	}
+}
+
+// TestRenameGCSObjectCopyFailNoOrphan: copy fails → fatal error, source intact,
+// no orphaned destination (cleanup delete of dst attempted).
+func TestRenameGCSObjectCopyFailNoOrphan(t *testing.T) {
+	f := newFakeGCS("out/sample_0.png")
+	f.copyErrOn = "out/hero.png"
+	f.install(t)
+
+	err := RenameGCSObject(context.Background(), "bkt", "out/sample_0.png", "out/hero.png")
+	if err == nil {
+		t.Fatal("expected a fatal error on copy failure, got nil")
+	}
+	if f.objects["out/hero.png"] {
+		t.Errorf("copy failure must leave NO orphaned destination; objects=%v", f.list())
+	}
+	if !f.objects["out/sample_0.png"] {
+		t.Errorf("copy failure must leave the source intact; objects=%v", f.list())
+	}
+	if f.deletes == 0 {
+		t.Errorf("expected a best-effort cleanup delete of the partial destination")
+	}
+}
+
+// TestRenameGCSObjectDeleteFailNonFatal: copy succeeds, delete of source fails →
+// nil returned (non-fatal), destination present.
+func TestRenameGCSObjectDeleteFailNonFatal(t *testing.T) {
+	f := newFakeGCS("out/sample_0.png")
+	f.deleteErr = errors.New("injected delete failure")
+	f.install(t)
+
+	if err := RenameGCSObject(context.Background(), "bkt", "out/sample_0.png", "out/hero.png"); err != nil {
+		t.Fatalf("delete failure must be non-fatal, got error: %v", err)
+	}
+	if !f.objects["out/hero.png"] {
+		t.Errorf("destination object must be present after a non-fatal delete failure; objects=%v", f.list())
+	}
+	// The source remains (delete failed) — that is the accepted cosmetic leftover.
+	if !f.objects["out/sample_0.png"] {
+		t.Errorf("expected the source to remain after the delete failed; objects=%v", f.list())
+	}
+}
+
+// TestRenameGCSObjectCollisionOverwrite: destination already exists → overwrite
+// (no error). The pre-existing object is replaced by the copy.
+func TestRenameGCSObjectCollisionOverwrite(t *testing.T) {
+	f := newFakeGCS("out/sample_0.png", "out/hero.png")
+	f.install(t)
+
+	if err := RenameGCSObject(context.Background(), "bkt", "out/sample_0.png", "out/hero.png"); err != nil {
+		t.Fatalf("collision should overwrite without error, got: %v", err)
+	}
+	if !f.objects["out/hero.png"] {
+		t.Errorf("destination should exist after overwrite; objects=%v", f.list())
+	}
+	if f.objects["out/sample_0.png"] {
+		t.Errorf("source should be gone after overwrite; objects=%v", f.list())
+	}
+}
+
+// TestRenameGCSObjectSrcEqualsDst: a no-op rename returns nil and touches nothing.
+func TestRenameGCSObjectSrcEqualsDst(t *testing.T) {
+	f := newFakeGCS("out/hero.png")
+	f.install(t)
+	if err := RenameGCSObject(context.Background(), "bkt", "out/hero.png", "out/hero.png"); err != nil {
+		t.Fatalf("src==dst should be a no-op, got: %v", err)
+	}
+	if f.copies != 0 || f.deletes != 0 {
+		t.Errorf("src==dst should not copy or delete; copies=%d deletes=%d", f.copies, f.deletes)
+	}
+}
+
+func TestRenameGCSObjectValidation(t *testing.T) {
+	if err := RenameGCSObject(context.Background(), "", "s", "d"); err == nil {
+		t.Error("expected error for empty bucket")
+	}
+	if err := RenameGCSObject(context.Background(), "bkt", "", "d"); err == nil {
+		t.Error("expected error for empty src")
+	}
+	if err := RenameGCSObject(context.Background(), "bkt", "s", ""); err == nil {
+		t.Error("expected error for empty dst")
+	}
+}
+
+// TestRenameGCSObjectsBatchSuccess: all sample_* renamed, originals gone.
+func TestRenameGCSObjectsBatchSuccess(t *testing.T) {
+	f := newFakeGCS("out/sample_0.png", "out/sample_1.png", "out/sample_2.png", "out/sample_3.png")
+	f.install(t)
+
+	renames := []Rename{
+		{Src: "out/sample_0.png", Dst: "out/hero_1.png"},
+		{Src: "out/sample_1.png", Dst: "out/hero_2.png"},
+		{Src: "out/sample_2.png", Dst: "out/hero_3.png"},
+		{Src: "out/sample_3.png", Dst: "out/hero_4.png"},
+	}
+	renamed, err := RenameGCSObjects(context.Background(), "bkt", renames)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(renamed) != 4 {
+		t.Fatalf("expected 4 renamed, got %d (%v)", len(renamed), renamed)
+	}
+	for _, o := range f.list() {
+		if o == "out/sample_0.png" || o == "out/sample_1.png" || o == "out/sample_2.png" || o == "out/sample_3.png" {
+			t.Errorf("all sample_* originals must be gone after a successful batch; found %s", o)
+		}
+	}
+	want := []string{"out/hero_1.png", "out/hero_2.png", "out/hero_3.png", "out/hero_4.png"}
+	if got := f.list(); !equalStrings(got, want) {
+		t.Errorf("final objects = %v, want %v", got, want)
+	}
+}
+
+// TestRenameGCSObjectsBatchPartialFailureNoRollback: a mid-batch copy failure
+// returns the already-renamed dst names plus a fatal error, and does NOT roll
+// back the already-renamed valid outputs.
+func TestRenameGCSObjectsBatchPartialFailureNoRollback(t *testing.T) {
+	f := newFakeGCS("out/sample_0.png", "out/sample_1.png", "out/sample_2.png")
+	f.copyErrOn = "out/hero_2.png" // fail on the second rename
+	f.install(t)
+
+	renames := []Rename{
+		{Src: "out/sample_0.png", Dst: "out/hero_1.png"},
+		{Src: "out/sample_1.png", Dst: "out/hero_2.png"}, // fails here
+		{Src: "out/sample_2.png", Dst: "out/hero_3.png"},
+	}
+	renamed, err := RenameGCSObjects(context.Background(), "bkt", renames)
+	if err == nil {
+		t.Fatal("expected a fatal error on mid-batch copy failure")
+	}
+	if len(renamed) != 1 || renamed[0] != "out/hero_1.png" {
+		t.Fatalf("expected renamed-so-far = [out/hero_1.png], got %v", renamed)
+	}
+	// No rollback: the first, already-renamed valid output stays.
+	if !f.objects["out/hero_1.png"] {
+		t.Errorf("already-renamed valid output must NOT be rolled back; objects=%v", f.list())
+	}
+	// The failed artifact's source remains (named in the error for the caller).
+	if !f.objects["out/sample_1.png"] {
+		t.Errorf("failed artifact source should remain; objects=%v", f.list())
+	}
+	// The batch stopped: sample_2 was never processed.
+	if !f.objects["out/sample_2.png"] {
+		t.Errorf("batch should stop at first failure; sample_2 should be untouched; objects=%v", f.list())
+	}
+	if !strings.Contains(err.Error(), "out/sample_1.png") {
+		t.Errorf("error should name the source left behind, got: %v", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -63,11 +63,13 @@ func init() {
 	flag.StringVar(&transport, "transport", "stdio", "Transport type (stdio, sse, or http)")
 	flag.IntVar(&port, "p", 0, "Port for SSE/HTTP server (defaults to PORT env var or 8080/8081)")
 	flag.IntVar(&port, "port", 0, "Port for SSE/HTTP server (defaults to PORT env var or 8080/8081)")
-	flag.Parse()
 }
 
 // main is the entry point for the mcp-imagen-go service.
 func main() {
+	// Parse flags here (not in init) so `go test` flags are not consumed at
+	// package init, matching the sibling genmedia servers.
+	flag.Parse()
 
 	var cleanup func()
 	appConfig, cleanup = common.Init(serviceName, version)
@@ -145,6 +147,7 @@ func main() {
 		),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store the generated images (e.g., your-bucket/outputs/ or gs://your-bucket/outputs/).")),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save the generated image(s) to.")),
+		mcp.WithString("output_filename", mcp.Description("Optional. Base name for the output file(s). The extension is forced to the true image type (e.g. .png). For a single image the name is used as-is (foo.png); for multiple images a 1-based suffix is inserted before the extension (foo_1.png, foo_2.png, ...). For GCS output the API-written objects are copy-renamed to this name after generation (adds a short GCS copy latency).")),
 	)
 
 	handlerWithClient := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -257,6 +260,50 @@ func contains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+// imagenOutputNames returns the deterministic per-image output file names when a
+// client output_filename is set (extension forced to the true image MIME, 1-based
+// suffixing for count > 1 per design #842 §4b/§4c). It returns nil when
+// output_filename is unset or cannot be applied, so the handler falls back to its
+// existing default naming scheme (byte-for-byte legacy behavior).
+func imagenOutputNames(outputFilename string, count int, mimeType string) []string {
+	if strings.TrimSpace(outputFilename) == "" {
+		return nil
+	}
+	names, err := common.BuildOutputFilenames(outputFilename, count, mimeType)
+	if err != nil {
+		log.Printf("output_filename %q could not be applied (%v); falling back to default naming", outputFilename, err)
+		return nil
+	}
+	return names
+}
+
+// buildImagenRenamePlan maps the API-written GCS objects (Path C: imagen lets
+// Vertex name the objects sample_k under the output prefix) to the client-desired
+// names. It returns the bucket, the ordered src→dst renames, and the resulting
+// gs:// URIs (aligned with srcURIs order). names are the output of
+// imagenOutputNames; when names is empty it returns nil (default API names kept).
+func buildImagenRenamePlan(gcsOutputURI string, srcURIs, names []string) (bucket string, renames []common.Rename, dstURIs []string) {
+	if len(names) == 0 || len(srcURIs) == 0 {
+		return "", nil, nil
+	}
+	bucket, prefix := common.ParseGCSBucketAndPrefix(gcsOutputURI)
+	n := len(srcURIs)
+	if len(names) < n {
+		n = len(names)
+	}
+	for i := 0; i < n; i++ {
+		_, srcObject, err := common.ParseGCSPath(srcURIs[i])
+		if err != nil {
+			log.Printf("skipping GCS rename for unparseable URI %q: %v", srcURIs[i], err)
+			continue
+		}
+		dstObject := prefix + names[i]
+		renames = append(renames, common.Rename{Src: srcObject, Dst: dstObject})
+		dstURIs = append(dstURIs, common.BuildGCSURI(bucket, dstObject))
+	}
+	return bucket, renames, dstURIs
 }
 
 func imagenGenerationHandler(client *genai.Client, ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -435,6 +482,22 @@ func imagenGenerationHandler(client *genai.Client, ctx context.Context, request 
 	returnImageDataInResponse := gcsOutputURI == "" && !attemptLocalSave
 	log.Printf("Will return image data in response: %t", returnImageDataInResponse)
 
+	// Resolve an optional client-supplied output_filename (design #842). When set,
+	// outputNames holds the deterministic per-image names (extension forced to the
+	// true image MIME, 1-based suffix for >1 image); when unset it is nil and the
+	// handler keeps its existing default naming scheme (byte-for-byte legacy
+	// behavior). The MIME is taken from the first image (imagen returns a
+	// homogeneous batch); default image/png.
+	outputFilename := common.ResolveOutputFilename(request.GetArguments())
+	firstMimeType := "image/png"
+	for _, gi := range response.GeneratedImages {
+		if gi.Image != nil && gi.Image.MIMEType != "" {
+			firstMimeType = gi.Image.MIMEType
+			break
+		}
+	}
+	outputNames := imagenOutputNames(outputFilename, len(response.GeneratedImages), firstMimeType)
+
 	for n, genImg := range response.GeneratedImages {
 		var imageData []byte
 		imageMimeType := "image/png"
@@ -464,14 +527,21 @@ func imagenGenerationHandler(client *genai.Client, ctx context.Context, request 
 		}
 
 		if attemptLocalSave {
-			localFilename := fmt.Sprintf("imagen-%s-%s-%d", model, time.Now().Format("20060102-150405"), n)
-			switch imageMimeType {
-			case "image/jpeg":
-				localFilename += ".jpg"
-			case "image/webp":
-				localFilename += ".webp"
-			default:
-				localFilename += ".png"
+			var localFilename string
+			if outputNames != nil {
+				// Client output_filename: use the deterministic name (extension
+				// already forced to the true media MIME).
+				localFilename = outputNames[n]
+			} else {
+				localFilename = fmt.Sprintf("imagen-%s-%s-%d", model, time.Now().Format("20060102-150405"), n)
+				switch imageMimeType {
+				case "image/jpeg":
+					localFilename += ".jpg"
+				case "image/webp":
+					localFilename += ".webp"
+				default:
+					localFilename += ".png"
+				}
 			}
 			actualSavePath := filepath.Join(outputDir, localFilename)
 			actualSavePath = filepath.Clean(actualSavePath)
@@ -521,6 +591,28 @@ func imagenGenerationHandler(client *genai.Client, ctx context.Context, request 
 		}
 	}
 
+	// Path C copy-rename (design #842 §4d): imagen lets Vertex name the GCS objects
+	// itself (sample_k) under the output prefix. When output_filename is set, copy-
+	// rename those API-written objects to the client-desired names and delete the
+	// originals. Already-renamed valid outputs are not rolled back on a partial
+	// failure; the reported URIs reflect the successfully-renamed objects.
+	var renameNote string
+	if outputNames != nil && len(gcsSavedURIs) > 0 {
+		renameBucket, renames, dstURIs := buildImagenRenamePlan(gcsOutputURI, gcsSavedURIs, outputNames)
+		if len(renames) > 0 {
+			renamed, rErr := common.RenameGCSObjects(ctx, renameBucket, renames)
+			for i := 0; i < len(renamed) && i < len(dstURIs); i++ {
+				gcsSavedURIs[i] = dstURIs[i]
+			}
+			if rErr != nil {
+				renameNote = fmt.Sprintf("Note: renaming generated GCS object(s) to match output_filename '%s' partially failed (some API-original sample_* objects may remain): %v", outputFilename, rErr)
+				log.Print(renameNote)
+			} else {
+				log.Printf("Renamed %d generated GCS object(s) to match output_filename '%s'.", len(renamed), outputFilename)
+			}
+		}
+	}
+
 	var resultText string
 	var saveMessageParts []string
 
@@ -535,6 +627,9 @@ func imagenGenerationHandler(client *genai.Client, ctx context.Context, request 
 			saveMessageParts = append(saveMessageParts, fmt.Sprintf("GCS output was requested to '%s', but API did not return GCS URIs for the generated images.", config.OutputGCSURI))
 		} else {
 			saveMessageParts = append(saveMessageParts, fmt.Sprintf("GCS output was requested to '%s', but no images with GCS URIs were returned by the API.", config.OutputGCSURI))
+		}
+		if renameNote != "" {
+			saveMessageParts = append(saveMessageParts, renameNote)
 		}
 	}
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
+)
+
+// TestImagenOutputNames locks the output_filename → per-image name mapping,
+// including the num_images=4 case, extension forcing, and the unset back-compat
+// path (nil → handler keeps its default naming scheme).
+func TestImagenOutputNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputName string
+		count      int
+		mimeType   string
+		want       []string
+	}{
+		{"unset returns nil (back-compat default naming)", "", 4, "image/png", nil},
+		{"whitespace-only returns nil", "   ", 2, "image/png", nil},
+		{"single image, no suffix", "hero.png", 1, "image/png", []string{"hero.png"}},
+		{"four images, 1-based suffix", "hero.png", 4, "image/png", []string{"hero_1.png", "hero_2.png", "hero_3.png", "hero_4.png"}},
+		{"extension forced to true MIME", "hero.jpeg", 1, "image/png", []string{"hero.png"}},
+		{"jpeg output", "shot", 2, "image/jpeg", []string{"shot_1.jpg", "shot_2.jpg"}},
+		{"path traversal sanitized", "../../etc/passwd", 1, "image/png", []string{"passwd.png"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := imagenOutputNames(tc.outputName, tc.count, tc.mimeType)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("imagenOutputNames(%q, %d, %q) = %v, want %v", tc.outputName, tc.count, tc.mimeType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildImagenRenamePlan verifies the Path-C plan that maps the API-written
+// sample_k objects to the client-desired names: num_images=4 + gcs +
+// output_filename="hero.png" ⇒ sample_0..3 → hero_1..4.png under the same prefix,
+// same bucket, with correct gs:// URIs. Feeding the returned renames to
+// common.RenameGCSObjects (unit-tested in mcp-common) removes the originals.
+func TestBuildImagenRenamePlan(t *testing.T) {
+	gcsOutputURI := "gs://mybucket/imagen_outputs/"
+	srcURIs := []string{
+		"gs://mybucket/imagen_outputs/sample_0.png",
+		"gs://mybucket/imagen_outputs/sample_1.png",
+		"gs://mybucket/imagen_outputs/sample_2.png",
+		"gs://mybucket/imagen_outputs/sample_3.png",
+	}
+	names := imagenOutputNames("hero.png", 4, "image/png")
+
+	bucket, renames, dstURIs := buildImagenRenamePlan(gcsOutputURI, srcURIs, names)
+
+	if bucket != "mybucket" {
+		t.Errorf("bucket = %q, want mybucket", bucket)
+	}
+	wantRenames := []common.Rename{
+		{Src: "imagen_outputs/sample_0.png", Dst: "imagen_outputs/hero_1.png"},
+		{Src: "imagen_outputs/sample_1.png", Dst: "imagen_outputs/hero_2.png"},
+		{Src: "imagen_outputs/sample_2.png", Dst: "imagen_outputs/hero_3.png"},
+		{Src: "imagen_outputs/sample_3.png", Dst: "imagen_outputs/hero_4.png"},
+	}
+	if !reflect.DeepEqual(renames, wantRenames) {
+		t.Errorf("renames = %v, want %v", renames, wantRenames)
+	}
+	wantURIs := []string{
+		"gs://mybucket/imagen_outputs/hero_1.png",
+		"gs://mybucket/imagen_outputs/hero_2.png",
+		"gs://mybucket/imagen_outputs/hero_3.png",
+		"gs://mybucket/imagen_outputs/hero_4.png",
+	}
+	if !reflect.DeepEqual(dstURIs, wantURIs) {
+		t.Errorf("dstURIs = %v, want %v", dstURIs, wantURIs)
+	}
+}
+
+// TestBuildImagenRenamePlanSingle: n==1 ⇒ no suffix (hero.png), bucket-root prefix.
+func TestBuildImagenRenamePlanSingle(t *testing.T) {
+	names := imagenOutputNames("hero.png", 1, "image/png")
+	bucket, renames, dstURIs := buildImagenRenamePlan("gs://mybucket/", []string{"gs://mybucket/sample_0.png"}, names)
+	if bucket != "mybucket" {
+		t.Errorf("bucket = %q, want mybucket", bucket)
+	}
+	if len(renames) != 1 || renames[0] != (common.Rename{Src: "sample_0.png", Dst: "hero.png"}) {
+		t.Errorf("renames = %v, want [{sample_0.png hero.png}]", renames)
+	}
+	if len(dstURIs) != 1 || dstURIs[0] != "gs://mybucket/hero.png" {
+		t.Errorf("dstURIs = %v, want [gs://mybucket/hero.png]", dstURIs)
+	}
+}
+
+// TestBuildImagenRenamePlanBackCompat: no output_filename ⇒ nil plan, so the
+// handler leaves the API-written object names untouched (byte-for-byte legacy).
+func TestBuildImagenRenamePlanBackCompat(t *testing.T) {
+	names := imagenOutputNames("", 4, "image/png") // nil
+	bucket, renames, dstURIs := buildImagenRenamePlan("gs://mybucket/imagen_outputs/", []string{"gs://mybucket/imagen_outputs/sample_0.png"}, names)
+	if bucket != "" || renames != nil || dstURIs != nil {
+		t.Errorf("expected empty plan for unset output_filename, got bucket=%q renames=%v dstURIs=%v", bucket, renames, dstURIs)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3a of #842 (standardized optional `output_filename`). This is the **Path-C GATE**: it adds the shared GCS copy-rename helpers to `mcp-common` and wires `output_filename` into **imagen only**. The rename helper + error contract established here will be reused by veo in Phase 3b. Builds on the merged Phase 1 (#1628) + Phase 2 (#1630) naming helpers.

Path C context: imagen lets the Vertex API write the GCS objects itself (`sample_0.png`, ...) under the provided prefix. To honor `output_filename` we **copy-rename** those objects in GCS after generation.

## `mcp-common` — GCS rename helpers (design §4d)

- `RenameGCSObject(ctx, bucket, src, dst) error` — server-side copy + delete:
  - **Copy failure = FATAL** and leaves **no orphaned destination** (best-effort cleanup of any partial dst; source left intact).
  - **Delete failure = NON-FATAL** (dst exists and is valid; warn and return nil).
  - Pre-existing dst = **overwrite with a warning** (§4e).
- `RenameGCSObjects(ctx, bucket, []Rename) (renamed, err)` — sequential batch; on a mid-batch copy failure returns the already-renamed dst names + a fatal error naming the source left behind, and does **not roll back** already-renamed valid outputs.
- **Testable seam**: copy/delete/exists are behind package-level function vars (mirroring `uploadToGCSFn`), so every branch is unit-tested **without a live bucket**.

## imagen wiring

- Optional `output_filename` (via `common.ResolveOutputFilename` + `BuildOutputFilenames`, extension **forced** to the true image MIME).
- `n==1` → `foo.png`; `n>1` → `foo_1..n.png`. GCS objects copy-renamed from the API `sample_*` names; local downloads saved under the same names. Text summary preserved (additive). Unset → **byte-for-byte legacy naming**.
- `flag.Parse()` moved `init()`→`main()` so `go test` flags aren't consumed (matches sibling servers already changed in Phase 2).

## Tests

- `mcp-common`: rename success; copy-fail → error + no orphan dst + source intact; delete-fail → success + dst present (non-fatal); batch success (all `sample_*` gone); batch partial-failure → renamed-so-far returned + no rollback + error names the leftover source; collision overwrite; src==dst no-op; validation.
- `mcp-imagen-go`: `num_images=4` + gcs + `output_filename=hero.png` → `sample_0..3` → `hero_1..4.png` (correct src→dst plan + gs:// URIs); n==1 no-suffix; extension forcing; traversal sanitized; back-compat (unset → nil plan, default naming).
- Green **standalone (`GOWORK=off`) and under `go.work`**; gofmt clean.

Live-GCS integration (project `ghchinoy-genai-sa`) not required for this gate — the network-free seam unit tests cover the rename contract end to end.

## Scope / constraints

- **imagen ONLY** + the shared rename helpers. veo and Path-A/B servers untouched.
- `VERSION` untouched (release-please owns the bump). No new dependencies (`cloud.google.com/go/storage` already direct).
- New `.go` files under `mcp-*-go/` were `git add -f`'d (source/tests only) per the repo `.gitignore **/mcp-*-go` gotcha.

Do not merge — coordinator gates merges.