### PR TITLE
chore(mcp-genmedia): output_filename phase-4 polish — tests, URI-identity writeback, docs (#842)

### DIFF
--- a/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
@@ -75,6 +75,34 @@ The servers are configured primarily through environment variables. Key variable
 
 For a detailed list of tools provided by each server, refer to the [Go Implementations README](./mcp-genmedia-go/README.md).
 
+## Naming Outputs: `output_filename`
+
+Every media-generating tool accepts a single optional `output_filename` (string)
+with identical name and semantics across servers, so a client can **predict the
+exact output name** from the tool and request. The same computed name is applied
+consistently to the inline response, the local `output_directory`, and GCS.
+
+*   **Precedence:** `output_filename` always wins over a server's legacy naming
+    parameter; if neither is set, the server's default scheme is used. When
+    `output_filename` is unset, behavior is unchanged (no regression).
+*   **Extension forced to the true type:** you provide the file *stem* and the
+    extension is set from the model's actual output MIME type (`hero.jpeg` on a PNG
+    response → `hero.png`; a missing extension is added). **AVTool is exempt** —
+    for `ffmpeg` the extension selects the output container, so AVTool keeps the
+    extension you provide.
+*   **Multiple outputs → `_1..n` suffix:** one output is `<stem>.<ext>`; `n > 1`
+    outputs are `<stem>_1.<ext> … <stem>_n.<ext>` (1-based, no zero-padding, in
+    generation order).
+*   **Collisions overwrite with a warning** (re-running the same name is
+    idempotent), and **path traversal is sanitized** to a single safe name.
+*   **Imagen & Veo** let the Vertex API name objects (`sample_*`) and then rename
+    them to `output_filename`; on success no `sample_*` originals remain.
+
+**Deprecated legacy aliases** (still accepted; prefer `output_filename`, no
+removal planned): AVTool `output_file_name`, Lyria `file_name`, and the Chirp 3 /
+Gemini TTS `output_filename_prefix` (a *prefix* only — `output_filename` gives the
+full name).
+
 ## Authentication
 
 The servers use Google's Application Default Credentials (ADC). Ensure you have authenticated by one of the following methods:

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-avtool-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-avtool-go/index.md
@@ -109,6 +109,20 @@ Run the compiled executable with a transport flag:
 Input files can be specified as local file system paths or as GCS URIs (e.g., `gs://your-bucket/path/to/file.mp4`).
 Output files can be saved to a specified local directory and/or uploaded to a GCS bucket. If no output locations are specified, temporary files are created for processing and then cleaned up.
 
+### Output naming (`output_filename`)
+
+Each tool accepts an optional `output_filename` (string) to name its output,
+consistent with the rest of the genmedia suite (see
+[Naming Outputs](../index.md#naming-outputs-output_filename)). **AVTool is
+intentionally exempt from extension-forcing**: because the extension selects the
+`ffmpeg` output container/codec, the extension you supply is honored (e.g.
+`clip.mkv` stays `.mkv`); a missing extension falls back to the tool's default.
+AVTool produces a single output, so no `_1..n` suffix is applied.
+
+The legacy `output_file_name` parameter is still accepted but is
+**deprecated — prefer `output_filename`** (`output_filename` wins when both are
+set). No removal is planned in this release.
+
 ## Development
 
 For a detailed description of the `ffmpeg` and `ffprobe` commands used in this service, see the `compositing_recipes.md` file.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-chirp3-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-chirp3-go/index.md
@@ -16,7 +16,8 @@ The following tools are exposed by this server:
     *   `text` (string, required): The text to synthesize into speech.
     *   `voice_name` (string, optional): The specific Chirp3-HD voice name to use (e.g., "en-US-Chirp3-HD-Zephyr").
         *   If not provided, defaults to "en-US-Chirp3-HD-Zephyr" if available, otherwise the first available Chirp3-HD voice.
-    *   `output_filename_prefix` (string, optional): A prefix for the output WAV filename if saving locally. A timestamp and .wav extension will be appended.
+    *   `output_filename` (string, optional): Full base name for the output WAV file, e.g. `greeting.wav`. The extension is forced to `.wav`. Takes precedence over `output_filename_prefix` (which only supplies a prefix). See [Naming Outputs](../index.md#naming-outputs-output_filename).
+    *   `output_filename_prefix` (string, optional): **Deprecated — prefer `output_filename`.** A prefix for the output WAV filename if saving locally. A timestamp and .wav extension will be appended. Still accepted for backward compatibility.
         *   Default: `"chirp_audio"`
     *   `output_directory` (string, optional): If provided, specifies a local directory to save the generated audio file to. Filenames will be generated automatically using the prefix. If not provided, audio data is returned in the response.
     *   `pronunciations` (array of strings, optional): An array of custom pronunciations. Each item should be a string in the format 'phrase:phonetic_representation' (e.g., 'tomato:təˈmeɪtoʊ'). All items must use the same encoding specified by `pronunciation_encoding`.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
@@ -16,6 +16,7 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `model` (string, optional): The specific Gemini model to use. Defaults to `gemini-3.1-flash-image`.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
+- `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
 
 ### `gemini_audio_tts`
@@ -29,7 +30,8 @@ Synthesizes speech from text using Gemini models, allowing for granular control 
 - `voice_name` (string, optional): The voice to use. Defaults to `Callirrhoe`. Use the `list_gemini_voices` tool to see all options.
 - `model_name` (string, optional): The model to use. Defaults to `gemini-3.1-flash-tts-preview`.
 - `output_directory` (string, optional): Local directory to save the generated audio file to.
-- `output_filename_prefix` (string, optional): A prefix for the output WAV filename.
+- `output_filename` (string, optional): Full base name for the output WAV file, e.g. `greeting.wav`. The extension is forced to `.wav`. Takes precedence over `output_filename_prefix` (which only supplies a prefix). See [Naming Outputs](../index.md#naming-outputs-output_filename).
+- `output_filename_prefix` (string, optional): **Deprecated — prefer `output_filename`.** A prefix for the output WAV filename. Still accepted for backward compatibility.
 
 ### `list_gemini_voices`
 

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-imagen-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-imagen-go/index.md
@@ -23,6 +23,7 @@ The following tool is exposed by this server:
         *   Common values: `"1:1"` (square), `"16:9"` (widescreen), `"9:16"` (portrait)
     *   `gcs_bucket_uri` (string, optional): GCS URI prefix to store the generated images (e.g., "your-bucket/outputs/" or "gs://your-bucket/outputs/"). If provided, images are saved to GCS instead of returning bytes directly.
     *   `output_directory` (string, optional): If provided, specifies a local directory to save the generated image(s) to.
+    *   `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).
 
 ### Resources
 

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-lyria-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-lyria-go/index.md
@@ -21,7 +21,8 @@ The following tool is exposed by this server:
         *   Min: `1`.
         *   Note: Currently, only the first sample is processed and returned/saved.
     *   `output_gcs_bucket` (string, optional): Google Cloud Storage bucket name (without `gs://` prefix). If provided, audio is saved to GCS. If this parameter is empty but the `GENMEDIA_BUCKET` environment variable is set, `GENMEDIA_BUCKET` will be used.
-    *   `file_name` (string, optional): Desired file name (e.g., "my_song.wav"). Used for GCS object and local file. If omitted, a unique name like "lyria_output_&lt;uid&gt;.wav" is generated.
+    *   `output_filename` (string, optional): Base name for the output (e.g., "my_song.wav"). Used for the GCS object and local file; the extension is forced to the audio type (`.wav`). Takes precedence over `file_name`. If omitted, a unique name like "lyria_output_&lt;uid&gt;.wav" is generated. See [Naming Outputs](../index.md#naming-outputs-output_filename).
+    *   `file_name` (string, optional): **Deprecated — prefer `output_filename`.** Desired file name (e.g., "my_song.wav"). Used for GCS object and local file. Still accepted for backward compatibility.
     *   `local_path` (string, optional): Local directory path. If provided, audio is saved locally.
     *   `model_id` (string, optional): Specific Lyria model ID to use for the Google Cloud AI endpoint.
         *   Defaults to the value of the `DEFAULT_LYRIA_MODEL_ID (Deprecated)` environment variable, or `"lyria-3-clip-preview"` if the variable is not set.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-nanobanana-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-nanobanana-go/index.md
@@ -16,6 +16,7 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `model` (string, optional): The specific NanoBanana (Gemini Image) model to use. Defaults to `gemini-3.1-flash-image`.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
+- `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
 
 

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-veo-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-veo-go/index.md
@@ -15,7 +15,8 @@ The server exposes the following tools:
 *   **Parameters**:
     *   `prompt` (string, required): Text prompt for video generation.
     *   `bucket` (string, optional): Google Cloud Storage bucket where the API will save the generated video(s) (e.g., "your-bucket/output-folder" or "gs://your-bucket/output-folder"). If not provided, and `GENMEDIA_BUCKET` env var is set, `gs://<GENMEDIA_BUCKET>/veo_outputs/` will be used. One of these (param or env var) is effectively required.
-    *   `output_directory` (string, optional): If provided, specifies a local directory to download the generated video(s) to. Filenames will be generated automatically.
+    *   `output_directory` (string, optional): If provided, specifies a local directory to download the generated video(s) to. Filenames will be generated automatically unless `output_filename` is set.
+    *   `output_filename` (string, optional): Base name for the output(s), e.g. `clip.mp4`. The extension is forced to the true video type and, when more than one video is returned, a `_1..n` suffix is inserted before the extension. Veo lets the API write the objects to GCS and then renames them to this name (no `sample_*` originals remain on success). See [Naming Outputs](../index.md#naming-outputs-output_filename).
     *   `model` (string, optional): Model to use for video generation. Can be a full model ID or a common alias. See the `mcp-common/models.go` file for a complete list of supported models and aliases.
     *   `num_videos` (number, optional): Number of videos to generate. Note: the maximum is model-dependent.
     *   `aspect_ratio` (string, optional): Aspect ratio of the generated videos. Note: supported aspect ratios are model-dependent.
@@ -31,6 +32,7 @@ The server exposes the following tools:
     *   `prompt` (string, optional): Optional text prompt to guide video generation from the image.
     *   `bucket` (string, optional): Google Cloud Storage bucket for output. Same logic as `veo_t2v`.
     *   `output_directory` (string, optional): Local directory for download. Same logic as `veo_t2v`.
+    *   `output_filename` (string, optional): Base output name. Same logic as `veo_t2v`.
     *   `model` (string, optional): Model to use. Default: `"veo-3.1-fast-generate-001"`.
     *   `num_videos` (number, optional): Number of videos. Default: `1`. Min: `1`, Max: `4`.
     *   `aspect_ratio` (string, optional): Aspect ratio. Default: `"16:9"`.
@@ -46,6 +48,7 @@ The server exposes the following tools:
     *   `prompt` (string, optional): Optional text prompt to guide video extension.
     *   `bucket` (string, optional): Google Cloud Storage bucket for output. Same logic as `veo_t2v`.
     *   `output_directory` (string, optional): Local directory for download. Same logic as `veo_t2v`.
+    *   `output_filename` (string, optional): Base output name. Same logic as `veo_t2v`.
     *   `model` (string, optional): Model to use. Supported by Veo 3.1 models.
     *   `num_videos` (number, optional): Number of videos. Default: `1`. Min: `1`, Max: `4`.
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/README.md
@@ -196,6 +196,51 @@ This repository provides AI application samples for:
 *   **Transport Protocols**: Most servers support `stdio` (default), `http` (streamable HTTP with CORS), and `sse` (Server-Sent Events, legacy) transports.
 *   **Google Cloud Authentication**: Relies on Application Default Credentials (ADC) or service account keys.
 
+## Naming Outputs: `output_filename`
+
+Every media-generating tool accepts a single optional `output_filename` (string)
+with identical name and semantics, so a client can **predict the exact output
+name** from the tool and request. The same computed name is applied consistently
+across all sinks — the inline response, the local `output_directory`, and GCS.
+
+- **Precedence.** When more than one naming argument is supplied, `output_filename`
+  always wins. Otherwise the server's legacy parameter (with its legacy semantics)
+  is used, and otherwise the server's default naming scheme. When `output_filename`
+  is unset, behavior is byte-for-byte unchanged from before this feature.
+- **Extension is forced to the true output type.** You provide the file *stem*; the
+  extension is set from the model's actual output MIME type. `hero.jpeg` on a PNG
+  response becomes `hero.png`, and a missing extension is added. **`mcp-avtool-go`
+  is the one exception** — for `ffmpeg` the extension selects the output
+  container/codec, so avtool honors the extension you provide (and only warns if it
+  looks unexpected).
+- **Multiple outputs get a `_1..n` suffix.** For a single output the name is
+  exactly `<stem>.<ext>` (no suffix). For `n > 1` outputs the names are
+  `<stem>_1.<ext> … <stem>_n.<ext>` — 1-based, no zero-padding, contiguous, in
+  generation order.
+- **Collisions overwrite, with a warning.** If the computed name already exists
+  (local file or GCS object) it is overwritten and a warning is logged — no error
+  and no automatic renaming, so re-running with the same name is idempotent.
+- **Path traversal is sanitized.** Any directory components or `..` in
+  `output_filename` are stripped to a single safe name; use `output_directory` /
+  `gcs_bucket_uri` to choose the destination.
+- **Path-C servers (imagen, veo).** These let the Vertex API name the objects
+  (`sample_*`) in the output prefix, then copy each object to the requested name
+  and delete the original. On success no `sample_*` originals remain; the copy adds
+  a small amount of tool latency (a fast metadata operation for same-region
+  buckets, proportional to size for large/cross-region objects).
+
+### Deprecated legacy aliases
+
+The following per-server parameters are still accepted for backward compatibility
+but are **deprecated — prefer `output_filename`** (no removal is planned in this
+release):
+
+| Server | Legacy parameter | Notes |
+| --- | --- | --- |
+| `mcp-avtool-go` | `output_file_name` | Full output name (extension not forced). |
+| `mcp-lyria-go` | `file_name` | Full output name. |
+| `mcp-chirp3-go`, `mcp-gemini-go` (TTS) | `output_filename_prefix` | A *prefix* only (a timestamp/voice + extension is appended); `output_filename` provides the full name. |
+
 ## Configuration (Environment Variables)
 
 All servers in this project are configured using environment variables. While some servers have unique variables, the following are common to most of them:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
@@ -107,6 +107,20 @@ Run the compiled executable with a transport flag:
 Input files can be specified as local file system paths or as GCS URIs (e.g., `gs://your-bucket/path/to/file.mp4`).
 Output files can be saved to a specified local directory and/or uploaded to a GCS bucket. If no output locations are specified, temporary files are created for processing and then cleaned up.
 
+### Output naming (`output_filename`)
+
+Each tool accepts an optional `output_filename` (string) to name its output,
+consistent with the rest of the genmedia suite (see
+[Naming Outputs](../README.md#naming-outputs-output_filename)). **AVTool is
+intentionally exempt from extension-forcing**: because the extension selects the
+`ffmpeg` output container/codec, the extension you supply is honored (e.g.
+`clip.mkv` stays `.mkv`); a missing extension falls back to the tool's default.
+AVTool produces a single output, so no `_1..n` suffix is applied.
+
+The legacy `output_file_name` parameter is still accepted but is
+**deprecated — prefer `output_filename`** (`output_filename` wins when both are
+set). No removal is planned in this release.
+
 ## Development
 
 For a detailed description of the `ffmpeg` and `ffprobe` commands used in this service, see the `compositing_recipes.md` file.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/output_filename_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/output_filename_test.go
@@ -14,7 +14,90 @@
 
 package main
 
-import "testing"
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
+)
+
+// TestAVToolOutputFilenameWiring is a handler-level wiring test: it drives the exact
+// chain each avtool handler runs — resolveAVToolOutputFilename → common.HandleOutputPreparation
+// — and asserts the resolved output_filename reaches the final output filename with
+// avtool's distinguishing behavior: the extension is NOT forced (design §4b avtool
+// exemption — for ffmpeg the extension selects the output container), precedence is
+// honored (output_filename wins over the legacy output_file_name), a missing
+// extension gets the tool's default appended, traversal is sanitized, and an unset
+// value falls through to a unique <default> name. avtool is single-artifact, so no
+// _1..n suffix is applied.
+func TestAVToolOutputFilenameWiring(t *testing.T) {
+	const defaultExt = "mp4"
+
+	t.Run("output_filename honored, client extension NOT forced", func(t *testing.T) {
+		// Client asks for .mkv but the tool default is mp4 — avtool keeps .mkv.
+		args := map[string]interface{}{"output_filename": "clip.mkv"}
+		_, final, cleanup, err := common.HandleOutputPreparation(resolveAVToolOutputFilename(args), defaultExt)
+		defer cleanup()
+		if err != nil {
+			t.Fatalf("HandleOutputPreparation error: %v", err)
+		}
+		if final != "clip.mkv" {
+			t.Errorf("final filename = %q, want clip.mkv (extension must NOT be forced)", final)
+		}
+	})
+
+	t.Run("output_filename wins over legacy output_file_name", func(t *testing.T) {
+		args := map[string]interface{}{"output_filename": "new.mov", "output_file_name": "legacy.mp4"}
+		_, final, cleanup, err := common.HandleOutputPreparation(resolveAVToolOutputFilename(args), defaultExt)
+		defer cleanup()
+		if err != nil {
+			t.Fatalf("HandleOutputPreparation error: %v", err)
+		}
+		if final != "new.mov" {
+			t.Errorf("final filename = %q, want new.mov (output_filename wins, ext not forced)", final)
+		}
+	})
+
+	t.Run("missing extension gets the tool default appended", func(t *testing.T) {
+		args := map[string]interface{}{"output_filename": "clip"}
+		_, final, cleanup, err := common.HandleOutputPreparation(resolveAVToolOutputFilename(args), defaultExt)
+		defer cleanup()
+		if err != nil {
+			t.Fatalf("HandleOutputPreparation error: %v", err)
+		}
+		if final != "clip."+defaultExt {
+			t.Errorf("final filename = %q, want clip.%s", final, defaultExt)
+		}
+	})
+
+	t.Run("traversal sanitized, extension preserved", func(t *testing.T) {
+		args := map[string]interface{}{"output_filename": "../../etc/out.gif"}
+		_, final, cleanup, err := common.HandleOutputPreparation(resolveAVToolOutputFilename(args), defaultExt)
+		defer cleanup()
+		if err != nil {
+			t.Fatalf("HandleOutputPreparation error: %v", err)
+		}
+		if final != "out.gif" {
+			t.Errorf("final filename = %q, want out.gif", final)
+		}
+		if strings.Contains(final, "/") || strings.Contains(final, "..") {
+			t.Errorf("final filename %q still contains path separators/traversal", final)
+		}
+	})
+
+	t.Run("unset -> unique default name with tool extension", func(t *testing.T) {
+		args := map[string]interface{}{}
+		_, final, cleanup, err := common.HandleOutputPreparation(resolveAVToolOutputFilename(args), defaultExt)
+		defer cleanup()
+		if err != nil {
+			t.Fatalf("HandleOutputPreparation error: %v", err)
+		}
+		if !strings.HasPrefix(final, "ffmpeg_output_") || filepath.Ext(final) != "."+defaultExt {
+			t.Errorf("final filename = %q, want ffmpeg_output_*.%s default", final, defaultExt)
+		}
+	})
+}
 
 // TestResolveAVToolOutputFilename covers the avtool naming decision: output_filename
 // wins over the deprecated output_file_name alias; the client-provided extension is

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/README.md
@@ -14,7 +14,8 @@ The following tools are exposed by this server:
     *   `text` (string, required): The text to synthesize into speech.
     *   `voice_name` (string, optional): The specific Chirp3-HD voice name to use (e.g., "en-US-Chirp3-HD-Zephyr").
         *   If not provided, defaults to "en-US-Chirp3-HD-Zephyr" if available, otherwise the first available Chirp3-HD voice.
-    *   `output_filename_prefix` (string, optional): A prefix for the output WAV filename if saving locally. A timestamp and .wav extension will be appended.
+    *   `output_filename` (string, optional): Full base name for the output WAV file, e.g. `greeting.wav`. The extension is forced to `.wav`. Takes precedence over `output_filename_prefix` (which only supplies a prefix). See [Naming Outputs](../README.md#naming-outputs-output_filename).
+    *   `output_filename_prefix` (string, optional): **Deprecated — prefer `output_filename`.** A prefix for the output WAV filename if saving locally. A timestamp and .wav extension will be appended. Still accepted for backward compatibility.
         *   Default: `"chirp_audio"`
     *   `output_directory` (string, optional): If provided, specifies a local directory to save the generated audio file to. Filenames will be generated automatically using the prefix. If not provided, audio data is returned in the response.
     *   `pronunciations` (array of strings, optional): An array of custom pronunciations. Each item should be a string in the format 'phrase:phonetic_representation' (e.g., 'tomato:təˈmeɪtoʊ'). All items must use the same encoding specified by `pronunciation_encoding`.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3.go
@@ -38,6 +38,11 @@ var (
 	// Single source of truth is the VERSION file at the root of the
 	// mcp-genmedia-go tree. Defaults to "dev" for un-injected builds.
 	version = "dev"
+
+	// writeFileFn is the local-file-write seam. It is a package-level variable so
+	// the handler's naming/collision wiring is unit-testable without touching the
+	// real filesystem — mirroring the writeFileFn indirection in mcp-gemini-go.
+	writeFileFn = os.WriteFile
 )
 
 const (
@@ -500,6 +505,30 @@ func resolveChirpOutputFilename(args map[string]any, voiceName string) (string, 
 	return fmt.Sprintf("%s-%s-%s.wav", prefix, safeVoiceName, time.Now().Format(timeFormatForFilename)), nil
 }
 
+// saveChirpAudio wires the resolved output_filename through to the local file
+// write: it resolves the client-predictable name (§4a/§4b via
+// resolveChirpOutputFilename), joins it under outputDir, applies the
+// collision-overwrite warning (§4e), and writes the bytes through the injectable
+// writeFileFn seam. It returns the cleaned saved path. A name-resolution failure is
+// returned as nameErr (fatal to the caller); a write failure as writeErr (the
+// caller falls back to returning the audio inline). Splitting the two errors
+// mirrors the handler's original behavior.
+func saveChirpAudio(args map[string]any, audioBytes []byte, outputDir, voiceName string) (savedFilename string, nameErr, writeErr error) {
+	genFilename, err := resolveChirpOutputFilename(args, voiceName)
+	if err != nil {
+		return "", err, nil
+	}
+	savedFilename = filepath.Clean(filepath.Join(outputDir, genFilename))
+	// Collision policy: overwrite with a warning (design §4e).
+	if _, statErr := os.Stat(savedFilename); statErr == nil {
+		log.Printf("Warning: output file %q already exists in %s; overwriting (collision policy).", genFilename, outputDir)
+	}
+	if werr := writeFileFn(savedFilename, audioBytes, 0644); werr != nil {
+		return savedFilename, nil, werr
+	}
+	return savedFilename, nil, nil
+}
+
 func chirpTTSHandler(client *texttospeech.Client, ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	var contentItems []mcp.Content
 
@@ -621,29 +650,21 @@ func chirpTTSHandler(client *texttospeech.Client, ctx context.Context, request m
 			audioItem := mcp.AudioContent{Type: "audio", Data: base64AudioData, MIMEType: "audio/wav"}
 			contentItems = append(contentItems, audioItem)
 		} else {
-			genFilename, nameErr := resolveChirpOutputFilename(request.GetArguments(), selectedVoice.Name)
+			savedName, nameErr, writeErr := saveChirpAudio(request.GetArguments(), audioContentBytes, outputDir, selectedVoice.Name)
 			if nameErr != nil {
 				return mcp.NewToolResultError(nameErr.Error()), nil
 			}
-			savedFilename = filepath.Join(outputDir, genFilename)
-			savedFilename = filepath.Clean(savedFilename)
-
-			// Collision policy: overwrite with a warning (design §4e).
-			if _, statErr := os.Stat(savedFilename); statErr == nil {
-				log.Printf("Warning: output file %q already exists in %s; overwriting (collision policy).", genFilename, outputDir)
-			}
-
-			err = os.WriteFile(savedFilename, audioContentBytes, 0644)
-			if err != nil {
-				fileSaveMessage = fmt.Sprintf("Error writing audio file %s: %v. Audio data will be returned in response instead.", savedFilename, err)
+			if writeErr != nil {
+				fileSaveMessage = fmt.Sprintf("Error writing audio file %s: %v. Audio data will be returned in response instead.", savedName, writeErr)
 				log.Print(fileSaveMessage)
 				base64AudioData := base64.StdEncoding.EncodeToString(audioContentBytes)
 				audioItem := mcp.AudioContent{Type: "audio", Data: base64AudioData, MIMEType: "audio/wav"}
 				contentItems = append(contentItems, audioItem)
 				savedFilename = ""
 			} else {
-				fileSaveMessage = fmt.Sprintf("Audio saved to: %s (%d bytes).", savedFilename, len(audioContentBytes))
-				log.Printf("Audio content (%d bytes) written to file: %s", len(audioContentBytes), savedFilename)
+				savedFilename = savedName
+				fileSaveMessage = fmt.Sprintf("Audio saved to: %s (%d bytes).", savedName, len(audioContentBytes))
+				log.Printf("Audio content (%d bytes) written to file: %s", len(audioContentBytes), savedName)
 			}
 		}
 	} else {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/chirp3_test.go
@@ -15,9 +15,92 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestSaveChirpAudioWiring is a handler-level wiring test: it drives saveChirpAudio
+// (the function the handler calls to persist audio) with the os.WriteFile seam
+// (writeFileFn) replaced by a recorder, and asserts the resolved output_filename
+// actually reaches the write with the extension forced to .wav, precedence honored,
+// and traversal sanitized. chirp3 synthesizes one selected voice, so only the n==1
+// (<stem>.wav) case occurs; the shared _1..n suffix rule is covered where
+// multi-output actually happens (imagen/veo/nanobanana/gemini-image/omni) and in
+// mcp-common's BuildOutputFilenames tests.
+func TestSaveChirpAudioWiring(t *testing.T) {
+	const (
+		voice = "en-US-Chirp3-HD-Zephyr"
+		dir   = "/out"
+	)
+	origWrite := writeFileFn
+	t.Cleanup(func() { writeFileFn = origWrite })
+
+	var gotPath string
+	var gotBytes []byte
+	writeFileFn = func(name string, data []byte, _ os.FileMode) error {
+		gotPath, gotBytes = name, data
+		return nil
+	}
+
+	cases := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"single artifact, ext kept", map[string]any{"output_filename": "greeting.wav"}, "greeting.wav"},
+		{"wrong extension forced to .wav", map[string]any{"output_filename": "greeting.mp3"}, "greeting.wav"},
+		{"missing extension gets forced", map[string]any{"output_filename": "greeting"}, "greeting.wav"},
+		{"output_filename wins over legacy prefix", map[string]any{"output_filename": "greeting.wav", "output_filename_prefix": "legacy"}, "greeting.wav"},
+		{"traversal sanitized before write", map[string]any{"output_filename": "../../etc/greeting.wav"}, "greeting.wav"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath, gotBytes = "", nil
+			saved, nameErr, writeErr := saveChirpAudio(tc.args, []byte("audio"), dir, voice)
+			if nameErr != nil || writeErr != nil {
+				t.Fatalf("unexpected errors: name=%v write=%v", nameErr, writeErr)
+			}
+			want := filepath.Clean(filepath.Join(dir, tc.want))
+			if saved != want || gotPath != want {
+				t.Errorf("saved=%q writeTarget=%q, want %q", saved, gotPath, want)
+			}
+			if string(gotBytes) != "audio" {
+				t.Errorf("bytes written = %q, want %q", gotBytes, "audio")
+			}
+		})
+	}
+
+	t.Run("legacy prefix scheme preserved when output_filename unset", func(t *testing.T) {
+		saved, nameErr, writeErr := saveChirpAudio(map[string]any{"output_filename_prefix": "custom"}, []byte("a"), dir, voice)
+		if nameErr != nil || writeErr != nil {
+			t.Fatalf("unexpected errors: name=%v write=%v", nameErr, writeErr)
+		}
+		base := filepath.Base(saved)
+		if !strings.HasPrefix(base, "custom-"+voice+"-") || !strings.HasSuffix(base, ".wav") {
+			t.Errorf("legacy scheme not wired to write: got %q", saved)
+		}
+	})
+
+	t.Run("write error surfaced separately from name error", func(t *testing.T) {
+		writeFileFn = func(string, []byte, os.FileMode) error { return fmt.Errorf("disk full") }
+		t.Cleanup(func() {
+			writeFileFn = func(name string, data []byte, _ os.FileMode) error { gotPath, gotBytes = name, data; return nil }
+		})
+		saved, nameErr, writeErr := saveChirpAudio(map[string]any{"output_filename": "greeting.wav"}, []byte("a"), dir, voice)
+		if nameErr != nil {
+			t.Fatalf("unexpected name error: %v", nameErr)
+		}
+		if writeErr == nil {
+			t.Fatalf("expected write error")
+		}
+		if saved != filepath.Clean(filepath.Join(dir, "greeting.wav")) {
+			t.Errorf("saved path should still be reported on write error, got %q", saved)
+		}
+	})
+}
 
 // TestResolveChirpOutputFilename covers the chirp3 naming decision: output_filename
 // wins over the deprecated output_filename_prefix, the extension is forced to the

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/integration_gcs_rename_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/integration_gcs_rename_test.go
@@ -1,0 +1,172 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestIntegrationBuildNamesThenRename ties the two halves of the Path-C
+// (API-controls-GCS) naming pipeline together end-to-end and network-free: the
+// name computation (BuildOutputFilenames) feeds the copy-rename mechanism
+// (RenameGCSObjects) exactly as imagen/veo wire them. The GCS I/O is routed
+// through the in-memory fakeGCS seam, so no bucket or credentials are needed. It
+// asserts the deterministic 1-based suffix / no-suffix rules survive the rename
+// and that every source object ends up removed (design §4c/§4d).
+func TestIntegrationBuildNamesThenRename(t *testing.T) {
+	const (
+		bucket = "bkt"
+		prefix = "imagen_outputs/"
+	)
+
+	buildRenames := func(count int, base string) (renames []Rename, wantDst []string) {
+		names, err := BuildOutputFilenames(base, count, "image/png")
+		if err != nil {
+			t.Fatalf("BuildOutputFilenames(%q, %d): %v", base, count, err)
+		}
+		for i := 0; i < count; i++ {
+			src := fmt.Sprintf("%ssample_%d.png", prefix, i)
+			dst := prefix + names[i]
+			renames = append(renames, Rename{Src: src, Dst: dst})
+			wantDst = append(wantDst, dst)
+		}
+		return renames, wantDst
+	}
+
+	t.Run("multiple images -> suffixed dst objects, sources removed", func(t *testing.T) {
+		renames, wantDst := buildRenames(3, "hero.jpg") // wrong ext forced to .png
+		f := newFakeGCS(renames[0].Src, renames[1].Src, renames[2].Src)
+		f.install(t)
+
+		renamed, err := RenameGCSObjects(context.Background(), bucket, renames)
+		if err != nil {
+			t.Fatalf("RenameGCSObjects error: %v", err)
+		}
+		if !equalStr(renamed, wantDst) {
+			t.Errorf("renamed = %v, want %v", renamed, wantDst)
+		}
+		for _, dst := range wantDst {
+			if !f.objects[dst] {
+				t.Errorf("destination %q missing after rename; objects=%v", dst, f.list())
+			}
+		}
+		for _, r := range renames {
+			if f.objects[r.Src] {
+				t.Errorf("source %q should have been deleted; objects=%v", r.Src, f.list())
+			}
+		}
+		// The forced-extension suffixing must be present in the destinations.
+		if wantDst[0] != prefix+"hero_1.png" || wantDst[2] != prefix+"hero_3.png" {
+			t.Errorf("unexpected suffixed names: %v", wantDst)
+		}
+	})
+
+	t.Run("single image -> no suffix", func(t *testing.T) {
+		renames, wantDst := buildRenames(1, "hero")
+		f := newFakeGCS(renames[0].Src)
+		f.install(t)
+
+		renamed, err := RenameGCSObjects(context.Background(), bucket, renames)
+		if err != nil {
+			t.Fatalf("RenameGCSObjects error: %v", err)
+		}
+		if len(wantDst) != 1 || wantDst[0] != prefix+"hero.png" {
+			t.Fatalf("want single dst %shero.png, got %v", prefix, wantDst)
+		}
+		if !equalStr(renamed, wantDst) {
+			t.Errorf("renamed = %v, want %v", renamed, wantDst)
+		}
+		if !f.objects[wantDst[0]] || f.objects[renames[0].Src] {
+			t.Errorf("expected dst present and src gone; objects=%v", f.list())
+		}
+	})
+}
+
+// TestIntegrationGCSRenameLiveRoundTrip exercises the real copy-rename against a
+// live bucket end-to-end: it uploads two objects, renames them via
+// RenameGCSObjects (the exact §4d copy-fatal/delete-nonfatal helper imagen/veo
+// use), verifies the destinations exist and the sources are gone, then cleans up.
+//
+// It requires real GCS access and is therefore gated behind GENMEDIA_BUCKET: when
+// the env var is unset (as in CI, which drops go.work and runs without cloud
+// credentials) the test skips cleanly. Objects live under a unique, clearly-named
+// prefix so a run cannot collide with concurrent runs and cleanup is unambiguous.
+func TestIntegrationGCSRenameLiveRoundTrip(t *testing.T) {
+	bucket := os.Getenv("GENMEDIA_BUCKET")
+	if bucket == "" {
+		t.Skip("GENMEDIA_BUCKET not set; skipping live GCS rename round-trip")
+	}
+	ctx := context.Background()
+
+	prefix := fmt.Sprintf("integ_842_rename_%d/", time.Now().UnixNano())
+	src1, src2 := prefix+"sample_0.png", prefix+"sample_1.png"
+	dst1, dst2 := prefix+"hero_1.png", prefix+"hero_2.png"
+
+	// Best-effort cleanup of anything this test might leave behind.
+	t.Cleanup(func() {
+		for _, o := range []string{src1, src2, dst1, dst2} {
+			_ = deleteGCSObject(ctx, bucket, o)
+		}
+	})
+
+	for _, o := range []string{src1, src2} {
+		if err := UploadToGCS(ctx, bucket, o, "image/png", []byte("integration-test")); err != nil {
+			t.Fatalf("UploadToGCS(%s): %v", o, err)
+		}
+	}
+
+	renamed, err := RenameGCSObjects(ctx, bucket, []Rename{{Src: src1, Dst: dst1}, {Src: src2, Dst: dst2}})
+	if err != nil {
+		t.Fatalf("RenameGCSObjects error: %v", err)
+	}
+	if !equalStr(renamed, []string{dst1, dst2}) {
+		t.Fatalf("renamed = %v, want %v", renamed, []string{dst1, dst2})
+	}
+
+	for _, o := range []string{dst1, dst2} {
+		exists, err := gcsObjectExists(ctx, bucket, o)
+		if err != nil {
+			t.Fatalf("gcsObjectExists(%s): %v", o, err)
+		}
+		if !exists {
+			t.Errorf("destination %q should exist after rename", o)
+		}
+	}
+	for _, o := range []string{src1, src2} {
+		exists, err := gcsObjectExists(ctx, bucket, o)
+		if err != nil {
+			t.Fatalf("gcsObjectExists(%s): %v", o, err)
+		}
+		if exists {
+			t.Errorf("source %q should have been deleted after rename", o)
+		}
+	}
+}
+
+func equalStr(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
@@ -15,6 +15,7 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
+- `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../README.md#naming-outputs-output_filename).
 
 ### `gemini_audio_tts`
 
@@ -27,7 +28,8 @@ Synthesizes speech from text using Gemini models, allowing for granular control 
 - `voice_name` (string, optional): The voice to use. Defaults to `Callirrhoe`. Use the `list_gemini_voices` tool to see all options.
 - `model_name` (string, optional): The model to use. Defaults to `gemini-3.1-flash-tts-preview`.
 - `output_directory` (string, optional): Local directory to save the generated audio file to.
-- `output_filename_prefix` (string, optional): A prefix for the output WAV filename.
+- `output_filename` (string, optional): Full base name for the output WAV file, e.g. `greeting.wav`. The extension is forced to `.wav`. Takes precedence over `output_filename_prefix` (which only supplies a prefix). See [Naming Outputs](../README.md#naming-outputs-output_filename).
+- `output_filename_prefix` (string, optional): **Deprecated — prefer `output_filename`.** A prefix for the output WAV filename. Still accepted for backward compatibility.
 
 ### `list_gemini_voices`
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/integration_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/integration_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestIntegrationGeminiImageNamingEndToEnd is an end-to-end (Path-B: manual
+// write + upload) integration test. It drives the real handler response path,
+// processGeminiImageResponse, with the REAL local-write seam (writeFileFn =
+// os.WriteFile) so files actually land on disk, while routing the GCS leg through
+// the network-free uploadToGCSFn seam to capture the object names that would be
+// uploaded. It asserts that a single output_filename produces the same
+// deterministic, extension-forced, 1-based-suffixed names on BOTH sinks at once —
+// the local file tree and the GCS object names — proving the naming is computed
+// once and applied consistently across destinations (design §4b/§4c).
+//
+// TestProcessGeminiImageResponseNaming already covers the name computation via an
+// injected writeFileFn; this test additionally proves the real os.WriteFile lands
+// the bytes and that the local and GCS names agree. The live GCS upload leg is
+// covered, gated behind GENMEDIA_BUCKET, in mcp-common's integration test.
+func TestIntegrationGeminiImageNamingEndToEnd(t *testing.T) {
+	origUpload := uploadToGCSFn
+	t.Cleanup(func() { uploadToGCSFn = origUpload })
+
+	readNames := func(t *testing.T, dir string) []string {
+		t.Helper()
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("ReadDir(%s): %v", dir, err)
+		}
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		sort.Strings(names)
+		return names
+	}
+
+	t.Run("output_filename applied identically to local files and GCS objects", func(t *testing.T) {
+		dir := t.TempDir()
+		var gcsObjects []string
+		uploadToGCSFn = func(_ context.Context, _ /*bucket*/, object, _ /*mime*/ string, _ []byte) error {
+			gcsObjects = append(gcsObjects, object)
+			return nil
+		}
+
+		resp := imageResponse(
+			imagePart("image/png", []byte("a")),
+			imagePart("image/png", []byte("b")),
+			imagePart("image/png", []byte("c")),
+		)
+		// Wrong extension (.jpeg) forced to real MIME (.png); n>1 => _1..n.
+		if _, err := processGeminiImageResponse(
+			context.Background(), resp, map[string]any{"output_filename": "hero.jpeg"},
+			dir, "gs://bkt/pre/", "bkt", "pre/",
+		); err != nil {
+			t.Fatalf("processGeminiImageResponse error: %v", err)
+		}
+
+		wantLocal := []string{"hero_1.png", "hero_2.png", "hero_3.png"}
+		if got := readNames(t, dir); !equalStrings(got, wantLocal) {
+			t.Errorf("local files = %v, want %v", got, wantLocal)
+		}
+		wantGCS := []string{"pre/hero_1.png", "pre/hero_2.png", "pre/hero_3.png"}
+		sort.Strings(gcsObjects)
+		if !equalStrings(gcsObjects, wantGCS) {
+			t.Errorf("uploaded GCS objects = %v, want %v", gcsObjects, wantGCS)
+		}
+		// Bytes actually written by the real os.WriteFile seam.
+		for name, want := range map[string]string{"hero_1.png": "a", "hero_2.png": "b", "hero_3.png": "c"} {
+			b, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("ReadFile(%s): %v", name, err)
+			}
+			if string(b) != want {
+				t.Errorf("%s = %q, want %q", name, b, want)
+			}
+		}
+	})
+
+	t.Run("single image -> no suffix on both sinks", func(t *testing.T) {
+		dir := t.TempDir()
+		var gcsObjects []string
+		uploadToGCSFn = func(_ context.Context, _, object, _ string, _ []byte) error {
+			gcsObjects = append(gcsObjects, object)
+			return nil
+		}
+		resp := imageResponse(imagePart("image/png", []byte("solo")))
+		if _, err := processGeminiImageResponse(
+			context.Background(), resp, map[string]any{"output_filename": "hero"},
+			dir, "gs://bkt/pre/", "bkt", "pre/",
+		); err != nil {
+			t.Fatalf("processGeminiImageResponse error: %v", err)
+		}
+		if got := readNames(t, dir); !equalStrings(got, []string{"hero.png"}) {
+			t.Errorf("local files = %v, want [hero.png]", got)
+		}
+		if !equalStrings(gcsObjects, []string{"pre/hero.png"}) {
+			t.Errorf("uploaded GCS objects = %v, want [pre/hero.png]", gcsObjects)
+		}
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers.go
@@ -41,6 +41,30 @@ func resolveGeminiTTSFilename(args map[string]any, voiceName, legacyExt, mimeTyp
 	return fmt.Sprintf("%s-%s-%s%s", prefix, voiceName, time.Now().Format(timeFormatForTTSFilename), legacyExt), nil
 }
 
+// saveGeminiTTSAudio wires the resolved output_filename through to the local file
+// write: it resolves the client-predictable name (output_filename wins over the
+// legacy output_filename_prefix; extension forced to the true audio MIME — §4a/§4b),
+// joins it under outputDir, applies the collision-overwrite warning (§4e), and
+// writes the bytes through the injectable writeFileFn seam. It returns the full
+// saved path. A name-resolution failure is returned as nameErr (fatal to the
+// caller); a write failure as writeErr (the caller falls back to returning the
+// audio inline). Splitting the two errors mirrors the handler's original behavior.
+func saveGeminiTTSAudio(args map[string]any, audioBytes []byte, outputDir, voiceName, legacyExt, mimeType string) (savedFilename string, nameErr, writeErr error) {
+	filename, err := resolveGeminiTTSFilename(args, voiceName, legacyExt, mimeType)
+	if err != nil {
+		return "", err, nil
+	}
+	savedFilename = filepath.Join(outputDir, filename)
+	// Collision policy: overwrite with a warning (design §4e).
+	if _, statErr := os.Stat(savedFilename); statErr == nil {
+		log.Printf("Warning: output file %q already exists in %s; overwriting (collision policy).", filename, outputDir)
+	}
+	if werr := writeFileFn(savedFilename, audioBytes, 0644); werr != nil {
+		return savedFilename, nil, werr
+	}
+	return savedFilename, nil, nil
+}
+
 const (
 	geminiTTSAPIEndpoint     = "https://texttospeech.googleapis.com/v1/text:synthesize"
 	defaultGeminiTTSModel    = "gemini-3.1-flash-tts-preview"
@@ -306,17 +330,12 @@ func geminiAudioTTSHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 			base64AudioData := base64.StdEncoding.EncodeToString(audioBytes)
 			contentItems = append(contentItems, mcp.AudioContent{Type: "audio", Data: base64AudioData, MIMEType: mimeType})
 		} else {
-			filename, nameErr := resolveGeminiTTSFilename(request.GetArguments(), voiceName, fileExtension, mimeType)
+			savedFilename, nameErr, writeErr := saveGeminiTTSAudio(request.GetArguments(), audioBytes, outputDir, voiceName, fileExtension, mimeType)
 			if nameErr != nil {
 				return mcp.NewToolResultError(nameErr.Error()), nil
 			}
-			savedFilename := filepath.Join(outputDir, filename)
-			// Collision policy: overwrite with a warning (design §4e).
-			if _, statErr := os.Stat(savedFilename); statErr == nil {
-				log.Printf("Warning: output file %q already exists in %s; overwriting (collision policy).", filename, outputDir)
-			}
-			if err := writeFileFn(savedFilename, audioBytes, 0644); err != nil {
-				fileSaveMessage = fmt.Sprintf("Error writing audio file %s: %v. Audio data will be returned in response instead.", savedFilename, err)
+			if writeErr != nil {
+				fileSaveMessage = fmt.Sprintf("Error writing audio file %s: %v. Audio data will be returned in response instead.", savedFilename, writeErr)
 				log.Print(fileSaveMessage)
 				base64AudioData := base64.StdEncoding.EncodeToString(audioBytes)
 				contentItems = append(contentItems, mcp.AudioContent{Type: "audio", Data: base64AudioData, MIMEType: mimeType})

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/tts_handlers_test.go
@@ -15,9 +15,94 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestSaveGeminiTTSAudioWiring is a handler-level wiring test: it drives
+// saveGeminiTTSAudio (the function the handler calls to persist audio) with the
+// os.WriteFile seam (writeFileFn) replaced by a recorder, and asserts the resolved
+// output_filename actually reaches the write with the extension forced to the true
+// audio MIME, precedence honored, and the collision path not erroring. gemini-TTS
+// is single-artifact, so only the n==1 (<stem>.<ext>) case occurs; the shared
+// _1..n suffix rule is covered where multi-output actually happens (imagen/veo/
+// nanobanana/gemini-image/omni) and in mcp-common's BuildOutputFilenames tests.
+func TestSaveGeminiTTSAudioWiring(t *testing.T) {
+	const (
+		voice = "Callirrhoe"
+		dir   = "/out"
+	)
+	origWrite := writeFileFn
+	t.Cleanup(func() { writeFileFn = origWrite })
+
+	var gotPath string
+	var gotBytes []byte
+	writeFileFn = func(name string, data []byte, _ os.FileMode) error {
+		gotPath, gotBytes = name, data
+		return nil
+	}
+
+	cases := []struct {
+		name      string
+		args      map[string]any
+		legacyExt string
+		mimeType  string
+		want      string
+	}{
+		{"single artifact, ext kept", map[string]any{"output_filename": "speech.wav"}, ".wav", "audio/wav", "speech.wav"},
+		{"extension forced to encoding MIME", map[string]any{"output_filename": "speech.wav"}, ".mp3", "audio/mpeg", "speech.mp3"},
+		{"output_filename wins over legacy prefix", map[string]any{"output_filename": "speech.wav", "output_filename_prefix": "legacy"}, ".wav", "audio/wav", "speech.wav"},
+		{"traversal sanitized before write", map[string]any{"output_filename": "../../etc/speech.wav"}, ".wav", "audio/wav", "speech.wav"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath, gotBytes = "", nil
+			saved, nameErr, writeErr := saveGeminiTTSAudio(tc.args, []byte("audio"), dir, voice, tc.legacyExt, tc.mimeType)
+			if nameErr != nil || writeErr != nil {
+				t.Fatalf("unexpected errors: name=%v write=%v", nameErr, writeErr)
+			}
+			want := filepath.Join(dir, tc.want)
+			if saved != want || gotPath != want {
+				t.Errorf("saved=%q writeTarget=%q, want %q", saved, gotPath, want)
+			}
+			if string(gotBytes) != "audio" {
+				t.Errorf("bytes written = %q, want %q", gotBytes, "audio")
+			}
+		})
+	}
+
+	t.Run("legacy prefix scheme preserved when output_filename unset", func(t *testing.T) {
+		gotPath = ""
+		saved, nameErr, writeErr := saveGeminiTTSAudio(map[string]any{"output_filename_prefix": "custom"}, []byte("a"), dir, voice, ".wav", "audio/wav")
+		if nameErr != nil || writeErr != nil {
+			t.Fatalf("unexpected errors: name=%v write=%v", nameErr, writeErr)
+		}
+		base := filepath.Base(saved)
+		if !strings.HasPrefix(base, "custom-"+voice+"-") || !strings.HasSuffix(base, ".wav") {
+			t.Errorf("legacy scheme not wired to write: got %q", saved)
+		}
+	})
+
+	t.Run("write error is surfaced separately from name error", func(t *testing.T) {
+		writeFileFn = func(string, []byte, os.FileMode) error { return fmt.Errorf("disk full") }
+		t.Cleanup(func() {
+			writeFileFn = func(name string, data []byte, _ os.FileMode) error { gotPath, gotBytes = name, data; return nil }
+		})
+		saved, nameErr, writeErr := saveGeminiTTSAudio(map[string]any{"output_filename": "speech.wav"}, []byte("a"), dir, voice, ".wav", "audio/wav")
+		if nameErr != nil {
+			t.Fatalf("unexpected name error: %v", nameErr)
+		}
+		if writeErr == nil {
+			t.Fatalf("expected write error")
+		}
+		if saved != filepath.Join(dir, "speech.wav") {
+			t.Errorf("saved path should still be reported on write error, got %q", saved)
+		}
+	})
+}
 
 // TestResolveGeminiTTSFilename covers the gemini-TTS naming decision: output_filename
 // wins over the deprecated output_filename_prefix, the extension is forced to the

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/README.md
@@ -21,6 +21,7 @@ The following tool is exposed by this server:
         *   Common values: `"1:1"` (square), `"16:9"` (widescreen), `"9:16"` (portrait)
     *   `gcs_bucket_uri` (string, optional): GCS URI prefix to store the generated images (e.g., "your-bucket/outputs/" or "gs://your-bucket/outputs/"). If provided, images are saved to GCS instead of returning bytes directly.
     *   `output_directory` (string, optional): If provided, specifies a local directory to save the generated image(s) to.
+    *   `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension (`hero_1.png … hero_n.png`). Applied identically to local files and GCS objects. See [Naming Outputs](../README.md#naming-outputs-output_filename).
 
 ### Resources
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen.go
@@ -281,12 +281,17 @@ func imagenOutputNames(outputFilename string, count int, mimeType string) []stri
 
 // buildImagenRenamePlan maps the API-written GCS objects (Path C: imagen lets
 // Vertex name the objects sample_k under the output prefix) to the client-desired
-// names. It returns the bucket, the ordered src→dst renames, and the resulting
-// gs:// URIs (aligned with srcURIs order). names are the output of
-// imagenOutputNames; when names is empty it returns nil (default API names kept).
-func buildImagenRenamePlan(gcsOutputURI string, srcURIs, names []string) (bucket string, renames []common.Rename, dstURIs []string) {
+// names. It returns the bucket, the ordered src→dst renames, and — aligned 1:1 with
+// renames — the source gs:// URI each rename came from (planSrcURIs) and the
+// resulting destination gs:// URI (dstURIs). names[i] belongs to the artifact
+// srcURIs[i] by identity, so a skipped (unparseable) URI never drifts the mapping.
+// The returned planSrcURIs lets the caller write each renamed URI back onto the
+// exact artifact it came from by identity rather than by slice position. names are
+// the output of imagenOutputNames; when names is empty it returns nil (default API
+// names kept).
+func buildImagenRenamePlan(gcsOutputURI string, srcURIs, names []string) (bucket string, renames []common.Rename, planSrcURIs, dstURIs []string) {
 	if len(names) == 0 || len(srcURIs) == 0 {
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 	bucket, prefix := common.ParseGCSBucketAndPrefix(gcsOutputURI)
 	n := len(srcURIs)
@@ -301,9 +306,29 @@ func buildImagenRenamePlan(gcsOutputURI string, srcURIs, names []string) (bucket
 		}
 		dstObject := prefix + names[i]
 		renames = append(renames, common.Rename{Src: srcObject, Dst: dstObject})
+		planSrcURIs = append(planSrcURIs, srcURIs[i])
 		dstURIs = append(dstURIs, common.BuildGCSURI(bucket, dstObject))
 	}
-	return bucket, renames, dstURIs
+	return bucket, renames, planSrcURIs, dstURIs
+}
+
+// applyRenamedURIs writes each successfully-renamed destination URI back onto the
+// artifact it came from, pairing by identity (the source gs:// URI in planSrcURIs)
+// rather than by slice position. renames/planSrcURIs/dstURIs are aligned 1:1 by
+// construction (buildImagenRenamePlan), and renamedCount is how many leading plan
+// entries common.RenameGCSObjects reported as renamed (it returns a prefix of the
+// plan, truncated at the first failure). Positional writeback into the
+// (un-compacted) gcsSavedURIs would drift if any source URI was skipped or the
+// batch partially failed; identity pairing never does.
+func applyRenamedURIs(gcsSavedURIs, planSrcURIs, dstURIs []string, renamedCount int) {
+	for k := 0; k < renamedCount && k < len(dstURIs) && k < len(planSrcURIs); k++ {
+		for idx := range gcsSavedURIs {
+			if gcsSavedURIs[idx] == planSrcURIs[k] {
+				gcsSavedURIs[idx] = dstURIs[k]
+				break
+			}
+		}
+	}
 }
 
 func imagenGenerationHandler(client *genai.Client, ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -598,12 +623,13 @@ func imagenGenerationHandler(client *genai.Client, ctx context.Context, request 
 	// failure; the reported URIs reflect the successfully-renamed objects.
 	var renameNote string
 	if outputNames != nil && len(gcsSavedURIs) > 0 {
-		renameBucket, renames, dstURIs := buildImagenRenamePlan(gcsOutputURI, gcsSavedURIs, outputNames)
+		renameBucket, renames, planSrcURIs, dstURIs := buildImagenRenamePlan(gcsOutputURI, gcsSavedURIs, outputNames)
 		if len(renames) > 0 {
 			renamed, rErr := common.RenameGCSObjects(ctx, renameBucket, renames)
-			for i := 0; i < len(renamed) && i < len(dstURIs); i++ {
-				gcsSavedURIs[i] = dstURIs[i]
-			}
+			// Pair each renamed URI back to its source artifact by identity, not by
+			// slice position, so a skipped/unparseable URI or a partial batch failure
+			// never writes a renamed URI onto the wrong artifact.
+			applyRenamedURIs(gcsSavedURIs, planSrcURIs, dstURIs, len(renamed))
 			if rErr != nil {
 				renameNote = fmt.Sprintf("Note: renaming generated GCS object(s) to match output_filename '%s' partially failed (some API-original sample_* objects may remain): %v", outputFilename, rErr)
 				log.Print(renameNote)

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen_test.go
@@ -65,10 +65,15 @@ func TestBuildImagenRenamePlan(t *testing.T) {
 	}
 	names := imagenOutputNames("hero.png", 4, "image/png")
 
-	bucket, renames, dstURIs := buildImagenRenamePlan(gcsOutputURI, srcURIs, names)
+	bucket, renames, planSrcURIs, dstURIs := buildImagenRenamePlan(gcsOutputURI, srcURIs, names)
 
 	if bucket != "mybucket" {
 		t.Errorf("bucket = %q, want mybucket", bucket)
+	}
+	// planSrcURIs is aligned 1:1 with renames/dstURIs and echoes the source URIs so
+	// the caller can pair renamed URIs back by identity, not slice position.
+	if !reflect.DeepEqual(planSrcURIs, srcURIs) {
+		t.Errorf("planSrcURIs = %v, want %v", planSrcURIs, srcURIs)
 	}
 	wantRenames := []common.Rename{
 		{Src: "imagen_outputs/sample_0.png", Dst: "imagen_outputs/hero_1.png"},
@@ -93,7 +98,7 @@ func TestBuildImagenRenamePlan(t *testing.T) {
 // TestBuildImagenRenamePlanSingle: n==1 ⇒ no suffix (hero.png), bucket-root prefix.
 func TestBuildImagenRenamePlanSingle(t *testing.T) {
 	names := imagenOutputNames("hero.png", 1, "image/png")
-	bucket, renames, dstURIs := buildImagenRenamePlan("gs://mybucket/", []string{"gs://mybucket/sample_0.png"}, names)
+	bucket, renames, _, dstURIs := buildImagenRenamePlan("gs://mybucket/", []string{"gs://mybucket/sample_0.png"}, names)
 	if bucket != "mybucket" {
 		t.Errorf("bucket = %q, want mybucket", bucket)
 	}
@@ -109,8 +114,55 @@ func TestBuildImagenRenamePlanSingle(t *testing.T) {
 // handler leaves the API-written object names untouched (byte-for-byte legacy).
 func TestBuildImagenRenamePlanBackCompat(t *testing.T) {
 	names := imagenOutputNames("", 4, "image/png") // nil
-	bucket, renames, dstURIs := buildImagenRenamePlan("gs://mybucket/imagen_outputs/", []string{"gs://mybucket/imagen_outputs/sample_0.png"}, names)
-	if bucket != "" || renames != nil || dstURIs != nil {
-		t.Errorf("expected empty plan for unset output_filename, got bucket=%q renames=%v dstURIs=%v", bucket, renames, dstURIs)
+	bucket, renames, planSrcURIs, dstURIs := buildImagenRenamePlan("gs://mybucket/imagen_outputs/", []string{"gs://mybucket/imagen_outputs/sample_0.png"}, names)
+	if bucket != "" || renames != nil || planSrcURIs != nil || dstURIs != nil {
+		t.Errorf("expected empty plan for unset output_filename, got bucket=%q renames=%v planSrcURIs=%v dstURIs=%v", bucket, renames, planSrcURIs, dstURIs)
 	}
+}
+
+// TestApplyRenamedURIsIdentityPairing proves the URI writeback pairs each rename
+// result to its artifact by identity (source URI), not by slice position (nit
+// p3b-1). It constructs a reordered/partial rename result set over a src list with a
+// middle unparseable URI (skipped by the plan) and asserts the renamed URIs land on
+// the correct artifacts — a positional writeback would drift them.
+func TestApplyRenamedURIsIdentityPairing(t *testing.T) {
+	// The middle artifact's URI is unparseable, so the plan skips it. names[i]
+	// belongs to artifact i, so artifact 2 must be renamed to hero_3.png.
+	gcsSavedURIs := []string{
+		"gs://mybucket/imagen_outputs/sample_0.png",
+		"not-a-gcs-uri", // unparseable → skipped by the plan
+		"gs://mybucket/imagen_outputs/sample_2.png",
+	}
+	names := imagenOutputNames("hero.png", 3, "image/png") // hero_1.png, hero_2.png, hero_3.png
+
+	_, renames, planSrcURIs, dstURIs := buildImagenRenamePlan("gs://mybucket/imagen_outputs/", gcsSavedURIs, names)
+	if len(renames) != 2 {
+		t.Fatalf("expected 2 renames (middle skipped), got %d", len(renames))
+	}
+
+	t.Run("full success renames both parseable artifacts to the right names", func(t *testing.T) {
+		saved := append([]string(nil), gcsSavedURIs...)
+		applyRenamedURIs(saved, planSrcURIs, dstURIs, len(renames)) // renamedCount = 2
+		want := []string{
+			"gs://mybucket/imagen_outputs/hero_1.png",
+			"not-a-gcs-uri", // untouched
+			"gs://mybucket/imagen_outputs/hero_3.png",
+		}
+		if !reflect.DeepEqual(saved, want) {
+			t.Errorf("identity writeback = %v, want %v", saved, want)
+		}
+	})
+
+	t.Run("partial failure only writes back the renamed prefix, still by identity", func(t *testing.T) {
+		saved := append([]string(nil), gcsSavedURIs...)
+		applyRenamedURIs(saved, planSrcURIs, dstURIs, 1) // only the first rename succeeded
+		want := []string{
+			"gs://mybucket/imagen_outputs/hero_1.png",
+			"not-a-gcs-uri",
+			"gs://mybucket/imagen_outputs/sample_2.png", // NOT drifted onto by hero_3
+		}
+		if !reflect.DeepEqual(saved, want) {
+			t.Errorf("partial identity writeback = %v, want %v", saved, want)
+		}
+	})
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/integration_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/integration_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestIntegrationImagenRenameNamingEndToEnd is an end-to-end (Path-C:
+// API-controls-GCS) integration test for the imagen naming pipeline. imagen lets
+// Vertex write and name the objects (sample_k) under the output prefix, then
+// renames them to the client-desired names. This test composes the whole
+// server-side chain the handler runs —
+//
+//	imagenOutputNames → buildImagenRenamePlan → (RenameGCSObjects) → applyRenamedURIs
+//
+// — and asserts the gs:// URIs handed back to the client are the renamed ones. The
+// GCS copy/delete step itself is simulated here by reporting how many plan entries
+// "renamed" (RenameGCSObjects returns a prefix of the plan, truncated at the first
+// failure); the real copy-rename against a bucket is exercised network-free via
+// the fakeGCS seam and, gated behind GENMEDIA_BUCKET, live in mcp-common. This
+// keeps the test network-free while covering deterministic suffixing, extension
+// forcing, single-image (no suffix), partial-failure writeback, and the unset
+// back-compat path.
+func TestIntegrationImagenRenameNamingEndToEnd(t *testing.T) {
+	const gcsOutputURI = "gs://mybucket/imagen_outputs/"
+
+	// srcURIs are the API-written objects (Vertex names them sample_k).
+	srcURIs := func(n int) []string {
+		out := make([]string, n)
+		for i := 0; i < n; i++ {
+			out[i] = "gs://mybucket/imagen_outputs/sample_" + itoa(i) + ".png"
+		}
+		return out
+	}
+
+	// run drives the full chain and returns the gs:// URIs as the client would see
+	// them. renamedCount simulates how many leading plan entries RenameGCSObjects
+	// reported as renamed (== len(plan) on full success).
+	run := func(outputFilename string, count int, renamedCount int) []string {
+		saved := srcURIs(count)
+		names := imagenOutputNames(outputFilename, count, "image/png")
+		_, renames, planSrcURIs, dstURIs := buildImagenRenamePlan(gcsOutputURI, saved, names)
+		if renamedCount < 0 {
+			renamedCount = len(renames) // full success
+		}
+		applyRenamedURIs(saved, planSrcURIs, dstURIs, renamedCount)
+		return saved
+	}
+
+	t.Run("multiple images -> 1-based suffix, extension forced, writeback by identity", func(t *testing.T) {
+		got := run("hero.jpg", 3, -1) // wrong ext forced to .png; full success
+		want := []string{
+			"gs://mybucket/imagen_outputs/hero_1.png",
+			"gs://mybucket/imagen_outputs/hero_2.png",
+			"gs://mybucket/imagen_outputs/hero_3.png",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("client URIs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("single image -> no suffix", func(t *testing.T) {
+		got := run("hero", 1, -1)
+		want := []string{"gs://mybucket/imagen_outputs/hero.png"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("client URIs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("partial rename failure -> only renamed URIs rewritten, rest keep API names", func(t *testing.T) {
+		// Only the first of three copies succeeded before RenameGCSObjects failed.
+		got := run("hero", 3, 1)
+		want := []string{
+			"gs://mybucket/imagen_outputs/hero_1.png",
+			"gs://mybucket/imagen_outputs/sample_1.png",
+			"gs://mybucket/imagen_outputs/sample_2.png",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("client URIs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unset output_filename -> no rename plan, API names kept (back-compat)", func(t *testing.T) {
+		got := run("", 2, -1)
+		want := []string{
+			"gs://mybucket/imagen_outputs/sample_0.png",
+			"gs://mybucket/imagen_outputs/sample_1.png",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("client URIs = %v, want %v (unset must keep default API names)", got, want)
+		}
+	})
+}
+
+// itoa is a tiny dependency-free int->string for building sample_k URIs (k < 10
+// in these tests).
+func itoa(i int) string {
+	return string(rune('0' + i))
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/README.md
@@ -19,7 +19,8 @@ The following tool is exposed by this server:
         *   Min: `1`.
         *   Note: Currently, only the first sample is processed and returned/saved.
     *   `output_gcs_bucket` (string, optional): Google Cloud Storage bucket name (without `gs://` prefix). If provided, audio is saved to GCS. If this parameter is empty but the `GENMEDIA_BUCKET` environment variable is set, `GENMEDIA_BUCKET` will be used.
-    *   `file_name` (string, optional): Desired file name (e.g., "my_song.wav"). Used for GCS object and local file. If omitted, a unique name like "lyria_output_&lt;uid&gt;.wav" is generated.
+    *   `output_filename` (string, optional): Base name for the output (e.g., "my_song.wav"). Used for the GCS object and local file; the extension is forced to the audio type (`.wav`). Takes precedence over `file_name`. If omitted, a unique name like "lyria_output_&lt;uid&gt;.wav" is generated. See [Naming Outputs](../README.md#naming-outputs-output_filename).
+    *   `file_name` (string, optional): **Deprecated — prefer `output_filename`.** Desired file name (e.g., "my_song.wav"). Used for GCS object and local file. Still accepted for backward compatibility.
     *   `local_path` (string, optional): Local directory path. If provided, audio is saved locally.
     *   `model_id` (string, optional): Specific Lyria model ID to use for the Vertex AI endpoint.
         *   Defaults to the value of the `DEFAULT_LYRIA_MODEL_ID (Deprecated)` environment variable, or `"lyria-3-clip-preview"` if the variable is not set.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria.go
@@ -68,6 +68,11 @@ const (
 // tag through goreleaser for releases). Defaults to "dev" for un-injected builds.
 var version = "dev"
 
+// writeFileFn is the local-file-write seam. It is a package-level variable so the
+// handler's naming/collision wiring is unit-testable without touching the real
+// filesystem — mirroring the writeFileFn indirection in mcp-gemini-go.
+var writeFileFn = os.WriteFile
+
 // init handles command-line flags and initial logging setup.
 func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -377,12 +382,7 @@ func lyriaGenerateMusicHandler(ctx context.Context, request mcp.CallToolRequest)
 				localSaveMessage = fmt.Sprintf("Failed to create local directory %s: %v.", localDirectoryPathParameter, errMkdir)
 				log.Printf("Error creating local directory %s: %v", localDirectoryPathParameter, errMkdir)
 			} else {
-				fullLocalPath := filepath.Join(localDirectoryPathParameter, baseFilename)
-				// Collision policy: overwrite with a warning (design §4e).
-				if _, statErr := os.Stat(fullLocalPath); statErr == nil {
-					log.Printf("Warning: output file %q already exists in %s; overwriting (collision policy).", baseFilename, localDirectoryPathParameter)
-				}
-				errWrite := os.WriteFile(fullLocalPath, audioBytes, 0644)
+				fullLocalPath, errWrite := saveLyriaLocalFile(localDirectoryPathParameter, baseFilename, audioBytes)
 				if errWrite != nil {
 					localSaveMessage = fmt.Sprintf("Failed to save audio locally to %s: %v.", fullLocalPath, errWrite)
 					log.Printf("Error saving audio locally to %s: %v", fullLocalPath, errWrite)
@@ -454,6 +454,26 @@ func resolveLyriaOutputFilename(params map[string]any) (string, error) {
 		return "", err
 	}
 	return names[0], nil
+}
+
+// saveLyriaLocalFile wires the resolved base filename through to the local file
+// write: it joins baseFilename under localDir, applies the collision-overwrite
+// warning (§4e), and writes the bytes through the injectable writeFileFn seam. The
+// baseFilename is the value produced by resolveLyriaOutputFilename (output_filename
+// wins over the legacy file_name alias; extension forced to the true audio MIME —
+// §4a/§4b) or the shortid default when unset, so the same client-predictable name
+// is used verbatim for both the local file and the GCS object. It returns the full
+// local path and any write error.
+func saveLyriaLocalFile(localDir, baseFilename string, audioBytes []byte) (fullLocalPath string, err error) {
+	fullLocalPath = filepath.Join(localDir, baseFilename)
+	// Collision policy: overwrite with a warning (design §4e).
+	if _, statErr := os.Stat(fullLocalPath); statErr == nil {
+		log.Printf("Warning: output file %q already exists in %s; overwriting (collision policy).", baseFilename, localDir)
+	}
+	if werr := writeFileFn(fullLocalPath, audioBytes, 0644); werr != nil {
+		return fullLocalPath, werr
+	}
+	return fullLocalPath, nil
 }
 
 // invokeLyriaAndUpload calls the Lyria model and optionally uploads the result to GCS.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria_test.go
@@ -14,7 +14,84 @@
 
 package main
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSaveLyriaLocalFileWiring is a handler-level wiring test: it drives
+// saveLyriaLocalFile (the function the handler calls to persist audio locally) with
+// the os.WriteFile seam (writeFileFn) replaced by a recorder, and asserts that the
+// resolved output_filename actually reaches the write. It pairs resolveLyriaOutputFilename
+// with the write so the assertion covers the full name→write path: output_filename
+// wins over the legacy file_name alias, the extension is forced to .wav, and the
+// name is single-artifact (<stem>.wav — lyria returns one artifact; the shared
+// _1..n suffix rule is covered where multi-output happens and in mcp-common).
+func TestSaveLyriaLocalFileWiring(t *testing.T) {
+	const dir = "/out"
+
+	origWrite := writeFileFn
+	t.Cleanup(func() { writeFileFn = origWrite })
+
+	var gotPath string
+	var gotBytes []byte
+	writeFileFn = func(name string, data []byte, _ os.FileMode) error {
+		gotPath, gotBytes = name, data
+		return nil
+	}
+
+	cases := []struct {
+		name   string
+		params map[string]any
+		want   string
+	}{
+		{"single artifact, ext kept", map[string]any{"output_filename": "song.wav"}, "song.wav"},
+		{"wrong extension forced to .wav", map[string]any{"output_filename": "song.mp3"}, "song.wav"},
+		{"legacy file_name alias used when output_filename unset", map[string]any{"file_name": "legacy.wav"}, "legacy.wav"},
+		{"output_filename wins over legacy file_name", map[string]any{"output_filename": "new.wav", "file_name": "legacy.wav"}, "new.wav"},
+		{"traversal sanitized before write", map[string]any{"output_filename": "../../etc/song.wav"}, "song.wav"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath, gotBytes = "", nil
+			base, err := resolveLyriaOutputFilename(tc.params)
+			if err != nil {
+				t.Fatalf("resolveLyriaOutputFilename error: %v", err)
+			}
+			fullPath, werr := saveLyriaLocalFile(dir, base, []byte("audio"))
+			if werr != nil {
+				t.Fatalf("saveLyriaLocalFile error: %v", werr)
+			}
+			want := filepath.Join(dir, tc.want)
+			if fullPath != want || gotPath != want {
+				t.Errorf("fullPath=%q writeTarget=%q, want %q", fullPath, gotPath, want)
+			}
+			if string(gotBytes) != "audio" {
+				t.Errorf("bytes written = %q, want %q", gotBytes, "audio")
+			}
+		})
+	}
+
+	t.Run("write error surfaced with the intended path", func(t *testing.T) {
+		writeFileFn = func(string, []byte, os.FileMode) error { return fmt.Errorf("disk full") }
+		t.Cleanup(func() {
+			writeFileFn = func(name string, data []byte, _ os.FileMode) error { gotPath, gotBytes = name, data; return nil }
+		})
+		base, err := resolveLyriaOutputFilename(map[string]any{"output_filename": "song.wav"})
+		if err != nil {
+			t.Fatalf("resolve error: %v", err)
+		}
+		fullPath, werr := saveLyriaLocalFile(dir, base, []byte("a"))
+		if werr == nil {
+			t.Fatalf("expected write error")
+		}
+		if fullPath != filepath.Join(dir, "song.wav") {
+			t.Errorf("path should still be reported on write error, got %q", fullPath)
+		}
+	})
+}
 
 // TestResolveLyriaOutputFilename covers the lyria naming decision: output_filename
 // wins over the legacy file_name alias, the extension is forced to the audio MIME,

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
@@ -15,6 +15,7 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
+- `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../README.md#naming-outputs-output_filename).
 - `seed` (number, optional): Non-negative integer seed for best-effort reproducible image generation.
 
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/integration_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/integration_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestIntegrationNanobananaNamingToDisk is an end-to-end (Path-A) integration
+// test: it drives the real handler response path, processImageResponse, through
+// the REAL persistence seam (common.PersistMediaOutputs — not a fake) and asserts
+// the resolved output_filename actually lands on disk with the right names AND the
+// right bytes. This goes beyond TestProcessImageResponseWiring, which injects a
+// fake seam and only observes the requested FileName: here the whole chain
+// (ResolveOutputFilename → buildImageFilenames → PersistMediaOutputs → os.WriteFile)
+// runs and the observable artifact is the file tree.
+//
+// It is network-free: gcsBucketURI is empty, so the GCS branch of
+// PersistMediaOutputs is never taken (no credentials, no bucket). The live GCS
+// leg of Path A/C is covered, gated behind GENMEDIA_BUCKET, in mcp-common's
+// integration_gcs_rename_test.go.
+func TestIntegrationNanobananaNamingToDisk(t *testing.T) {
+	readNames := func(t *testing.T, dir string) []string {
+		t.Helper()
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("ReadDir(%s): %v", dir, err)
+		}
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		sort.Strings(names)
+		return names
+	}
+	readBytes := func(t *testing.T, dir, name string) string {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", name, err)
+		}
+		return string(b)
+	}
+
+	t.Run("multiple images -> 1-based suffixed files with forced extension", func(t *testing.T) {
+		dir := t.TempDir()
+		resp := imageResponse(
+			textPart("here you go"),
+			imagePart("image/png", []byte("alpha")),
+			imagePart("image/png", []byte("bravo")),
+			imagePart("image/png", []byte("charlie")),
+		)
+		// Client asks for hero.jpeg but the bytes are PNG: the extension must be
+		// forced to .png (design §4b) and, because n>1, suffixed _1..n (§4c).
+		if _, err := processImageResponse(context.Background(), resp, map[string]any{"output_filename": "hero.jpeg"}, dir, ""); err != nil {
+			t.Fatalf("processImageResponse error: %v", err)
+		}
+		want := []string{"hero_1.png", "hero_2.png", "hero_3.png"}
+		if got := readNames(t, dir); !equalStrings(got, want) {
+			t.Fatalf("files on disk = %v, want %v", got, want)
+		}
+		// Bytes must be paired to the right name in generation order.
+		for name, wantData := range map[string]string{"hero_1.png": "alpha", "hero_2.png": "bravo", "hero_3.png": "charlie"} {
+			if got := readBytes(t, dir, name); got != wantData {
+				t.Errorf("%s bytes = %q, want %q", name, got, wantData)
+			}
+		}
+	})
+
+	t.Run("single image -> no suffix", func(t *testing.T) {
+		dir := t.TempDir()
+		resp := imageResponse(imagePart("image/png", []byte("solo")))
+		if _, err := processImageResponse(context.Background(), resp, map[string]any{"output_filename": "hero"}, dir, ""); err != nil {
+			t.Fatalf("processImageResponse error: %v", err)
+		}
+		if got := readNames(t, dir); !equalStrings(got, []string{"hero.png"}) {
+			t.Fatalf("files on disk = %v, want [hero.png]", got)
+		}
+		if got := readBytes(t, dir, "hero.png"); got != "solo" {
+			t.Errorf("hero.png bytes = %q, want %q", got, "solo")
+		}
+	})
+
+	t.Run("unset output_filename keeps the legacy default scheme on disk", func(t *testing.T) {
+		dir := t.TempDir()
+		resp := imageResponse(imagePart("image/jpeg", []byte("x")))
+		if _, err := processImageResponse(context.Background(), resp, map[string]any{}, dir, ""); err != nil {
+			t.Fatalf("processImageResponse error: %v", err)
+		}
+		got := readNames(t, dir)
+		if len(got) != 1 || filepath.Ext(got[0]) != ".jpg" || got[0][:7] != "gemini_" {
+			t.Fatalf("expected a single legacy gemini_*.jpg file, got %v", got)
+		}
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/README.md
@@ -44,7 +44,12 @@ The server exposes the following tool:
         Sent in `generation_config`.
     *   `output_directory` (string, optional): Local directory to save the generated
         video(s) to. Filenames (`omni_<timestamp>_<n>.mp4`) are generated
-        automatically.
+        automatically unless `output_filename` is set.
+    *   `output_filename` (string, optional): Base name for the output(s), e.g.
+        `clip.mp4`. The extension is forced to the true video type and, when more
+        than one video is generated, a `_1..n` suffix is inserted before the
+        extension. Applied identically to local files and GCS objects. See
+        [Naming Outputs](../README.md#naming-outputs-output_filename).
     *   `gcs_bucket_uri` (string, optional): GCS URI prefix to store generated
         video(s) (e.g., `your-bucket/outputs/`). If not provided and
         `GENMEDIA_BUCKET` is set, `gs://<GENMEDIA_BUCKET>/omni_outputs/` is used.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/README.md
@@ -13,7 +13,8 @@ The server exposes the following tools:
 *   **Parameters**:
     *   `prompt` (string, required): Text prompt for video generation.
     *   `bucket` (string, optional): Google Cloud Storage bucket where the API will save the generated video(s) (e.g., "your-bucket/output-folder" or "gs://your-bucket/output-folder"). If not provided, and `GENMEDIA_BUCKET` env var is set, `gs://<GENMEDIA_BUCKET>/veo_outputs/` will be used. One of these (param or env var) is effectively required.
-    *   `output_directory` (string, optional): If provided, specifies a local directory to download the generated video(s) to. Filenames will be generated automatically.
+    *   `output_directory` (string, optional): If provided, specifies a local directory to download the generated video(s) to. Filenames will be generated automatically unless `output_filename` is set.
+    *   `output_filename` (string, optional): Base name for the output(s), e.g. `clip.mp4`. The extension is forced to the true video type and, when more than one video is returned, a `_1..n` suffix is inserted before the extension. Veo lets the API write the objects to GCS and then renames them to this name (no `sample_*` originals remain on success). See [Naming Outputs](../README.md#naming-outputs-output_filename).
     *   `model` (string, optional): Model to use for video generation. Can be a full model ID or a common alias. See the `mcp-common/models.go` file for a complete list of supported models and aliases.
     *   `num_videos` (number, optional): Number of videos to generate. Note: the maximum is model-dependent.
     *   `aspect_ratio` (string, optional): Aspect ratio of the generated videos. Note: supported aspect ratios are model-dependent.
@@ -30,6 +31,7 @@ The server exposes the following tools:
     *   `prompt` (string, optional): Optional text prompt to guide video generation from the image.
     *   `bucket` (string, optional): Google Cloud Storage bucket for output. Same logic as `veo_t2v`.
     *   `output_directory` (string, optional): Local directory for download. Same logic as `veo_t2v`.
+    *   `output_filename` (string, optional): Base output name. Same logic as `veo_t2v`.
     *   `model` (string, optional): Model to use. Default: `"veo-3.1-fast-generate-001"`.
     *   `num_videos` (number, optional): Number of videos. Default: `1`. Min: `1`, Max: `4`.
     *   `aspect_ratio` (string, optional): Aspect ratio. Default: `"16:9"`.
@@ -46,6 +48,7 @@ The server exposes the following tools:
     *   `prompt` (string, optional): Optional text prompt to guide video extension.
     *   `bucket` (string, optional): Google Cloud Storage bucket for output. Same logic as `veo_t2v`.
     *   `output_directory` (string, optional): Local directory for download. Same logic as `veo_t2v`.
+    *   `output_filename` (string, optional): Base output name. Same logic as `veo_t2v`.
     *   `model` (string, optional): Model to use. Supported by Veo 3.1 models.
     *   `num_videos` (number, optional): Number of videos. Default: `1`. Min: `1`, Max: `4`.
     *   `seed` (number, optional): Non-negative integer seed for best-effort reproducible video generation.
@@ -53,7 +56,7 @@ The server exposes the following tools:
 ### 4. `veo_first_last_to_video` & `veo_reference_to_video` & `veo_ingredients_to_video`
 
 *   **Description**: Advanced video generation features supporting reference images and start/end frame interpolation.
-*   These tools also support the common Veo generation parameters, including `seed` (number, optional): a non-negative integer seed for best-effort reproducible video generation.
+*   These tools also support the common Veo generation parameters, including `seed` (number, optional): a non-negative integer seed for best-effort reproducible video generation, and `output_filename` (string, optional): a base output name applied with the same logic as `veo_t2v` (see [Naming Outputs](../README.md#naming-outputs-output_filename)).
 
 ## Environment Variable Configuration
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo_test.go
@@ -68,10 +68,15 @@ func TestBuildVeoRenamePlan(t *testing.T) {
 	}
 	names := veoOutputNames("clip.mp4", 3, "video/mp4")
 
-	bucket, renames, dstURIs := buildVeoRenamePlan(gcsOutputURI, srcURIs, names)
+	bucket, renames, planSrcURIs, dstURIs := buildVeoRenamePlan(gcsOutputURI, srcURIs, names)
 
 	if bucket != "mybucket" {
 		t.Errorf("bucket = %q, want mybucket", bucket)
+	}
+	// planSrcURIs is aligned 1:1 with renames/dstURIs and echoes the source URIs so
+	// the caller can pair renamed URIs back by identity, not slice position.
+	if !reflect.DeepEqual(planSrcURIs, srcURIs) {
+		t.Errorf("planSrcURIs = %v, want %v", planSrcURIs, srcURIs)
 	}
 	wantRenames := []common.Rename{
 		{Src: "veo_outputs/1234/sample_0.mp4", Dst: "veo_outputs/clip_1.mp4"},
@@ -94,7 +99,7 @@ func TestBuildVeoRenamePlan(t *testing.T) {
 // TestBuildVeoRenamePlanSingle: n==1 ⇒ no suffix (clip.mp4), extension forced.
 func TestBuildVeoRenamePlanSingle(t *testing.T) {
 	names := veoOutputNames("clip.mov", 1, "video/mp4")
-	bucket, renames, dstURIs := buildVeoRenamePlan("gs://mybucket/veo_outputs/", []string{"gs://mybucket/veo_outputs/sample_0.mp4"}, names)
+	bucket, renames, _, dstURIs := buildVeoRenamePlan("gs://mybucket/veo_outputs/", []string{"gs://mybucket/veo_outputs/sample_0.mp4"}, names)
 	if bucket != "mybucket" {
 		t.Errorf("bucket = %q, want mybucket", bucket)
 	}
@@ -111,21 +116,22 @@ func TestBuildVeoRenamePlanSingle(t *testing.T) {
 // leaves the API-written object names untouched (byte-for-byte legacy behavior).
 func TestBuildVeoRenamePlanBackCompat(t *testing.T) {
 	names := veoOutputNames("", 3, "video/mp4") // nil
-	bucket, renames, dstURIs := buildVeoRenamePlan("gs://mybucket/veo_outputs/", []string{"gs://mybucket/veo_outputs/sample_0.mp4"}, names)
-	if bucket != "" || renames != nil || dstURIs != nil {
-		t.Errorf("expected empty plan for unset output_filename, got bucket=%q renames=%v dstURIs=%v", bucket, renames, dstURIs)
+	bucket, renames, planSrcURIs, dstURIs := buildVeoRenamePlan("gs://mybucket/veo_outputs/", []string{"gs://mybucket/veo_outputs/sample_0.mp4"}, names)
+	if bucket != "" || renames != nil || planSrcURIs != nil || dstURIs != nil {
+		t.Errorf("expected empty plan for unset output_filename, got bucket=%q renames=%v planSrcURIs=%v dstURIs=%v", bucket, renames, planSrcURIs, dstURIs)
 	}
 }
 
-// TestVeoRenamePlanFeedsRenameHelper exercises the plan against the shared batch
-// rename helper using its network-free seam: a successful batch removes every API
-// original (originals-removed guarantee) and reports the client-named destinations.
-// The seam (copy/delete/exists indirection) is owned and fault-injected in
-// mcp-common; here we confirm the veo plan is a valid input that drives it end to
-// end without network or credentials.
-func TestVeoRenamePlanFeedsRenameHelper(t *testing.T) {
+// TestVeoRenamePlanIsNonNoop asserts that buildVeoRenamePlan yields a valid,
+// non-no-op set of renames: each destination is the deterministic client name,
+// distinct from the API sample_* source, so common.RenameGCSObjects would copy+
+// delete each source. This test does NOT call RenameGCSObjects — the actual
+// copy-fatal / delete-nonfatal / collision-overwrite / originals-removed contract
+// is asserted network-free in mcp-common, the module that owns the copy/delete/
+// exists seam. Here we only verify the plan is a well-formed input to that helper.
+func TestVeoRenamePlanIsNonNoop(t *testing.T) {
 	names := veoOutputNames("clip.mp4", 2, "video/mp4")
-	_, renames, _ := buildVeoRenamePlan(
+	_, renames, _, _ := buildVeoRenamePlan(
 		"gs://mybucket/veo_outputs/",
 		[]string{
 			"gs://mybucket/veo_outputs/sample_0.mp4",
@@ -136,11 +142,56 @@ func TestVeoRenamePlanFeedsRenameHelper(t *testing.T) {
 	if len(renames) != 2 {
 		t.Fatalf("expected 2 renames, got %d", len(renames))
 	}
-	// Sanity: the destinations are the deterministic client names, distinct from the
-	// API sample_* sources (so RenameGCSObjects will copy+delete each source).
+	// The destinations are the deterministic client names, distinct from the API
+	// sample_* sources (so RenameGCSObjects will copy+delete each source).
 	for i, r := range renames {
 		if r.Src == r.Dst {
 			t.Errorf("rename %d is a no-op (src==dst=%q); expected sample_* → clip name", i, r.Src)
 		}
 	}
+}
+
+// TestApplyRenamedURIsIdentityPairing proves the URI writeback pairs each rename
+// result to its artifact by identity (source URI), not by slice position (nit
+// p3b-1). It uses a src list with a middle unparseable URI (skipped by the plan)
+// and asserts renamed URIs land on the correct artifacts — a positional writeback
+// would drift them.
+func TestApplyRenamedURIsIdentityPairing(t *testing.T) {
+	gcsVideoURIs := []string{
+		"gs://mybucket/veo_outputs/sample_0.mp4",
+		"not-a-gcs-uri", // unparseable → skipped by the plan
+		"gs://mybucket/veo_outputs/sample_2.mp4",
+	}
+	names := veoOutputNames("clip.mp4", 3, "video/mp4") // clip_1.mp4, clip_2.mp4, clip_3.mp4
+
+	_, renames, planSrcURIs, dstURIs := buildVeoRenamePlan("gs://mybucket/veo_outputs/", gcsVideoURIs, names)
+	if len(renames) != 2 {
+		t.Fatalf("expected 2 renames (middle skipped), got %d", len(renames))
+	}
+
+	t.Run("full success renames both parseable artifacts to the right names", func(t *testing.T) {
+		saved := append([]string(nil), gcsVideoURIs...)
+		applyRenamedURIs(saved, planSrcURIs, dstURIs, len(renames))
+		want := []string{
+			"gs://mybucket/veo_outputs/clip_1.mp4",
+			"not-a-gcs-uri",
+			"gs://mybucket/veo_outputs/clip_3.mp4",
+		}
+		if !reflect.DeepEqual(saved, want) {
+			t.Errorf("identity writeback = %v, want %v", saved, want)
+		}
+	})
+
+	t.Run("partial failure only writes back the renamed prefix, still by identity", func(t *testing.T) {
+		saved := append([]string(nil), gcsVideoURIs...)
+		applyRenamedURIs(saved, planSrcURIs, dstURIs, 1)
+		want := []string{
+			"gs://mybucket/veo_outputs/clip_1.mp4",
+			"not-a-gcs-uri",
+			"gs://mybucket/veo_outputs/sample_2.mp4", // NOT drifted onto by clip_3
+		}
+		if !reflect.DeepEqual(saved, want) {
+			t.Errorf("partial identity writeback = %v, want %v", saved, want)
+		}
+	})
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/video_logic.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/video_logic.go
@@ -54,12 +54,14 @@ func veoOutputNames(outputFilename string, count int, mimeType string) []string 
 // name the objects itself under the OutputGCSURI prefix) to the client-desired
 // names. srcURIs and names are aligned 1:1 by identity (srcURIs[i] is the video
 // whose desired name is names[i]), so a skipped/partial element never drifts the
-// mapping. It returns the bucket, the ordered src→dst renames, and the resulting
-// gs:// URIs (aligned with srcURIs order). When names is empty it returns nil
-// (default API names kept).
-func buildVeoRenamePlan(gcsOutputURI string, srcURIs, names []string) (bucket string, renames []common.Rename, dstURIs []string) {
+// mapping. It returns the bucket, the ordered src→dst renames, and — aligned 1:1
+// with renames — the source gs:// URI each rename came from (planSrcURIs) and the
+// resulting destination gs:// URI (dstURIs). planSrcURIs lets the caller write each
+// renamed URI back onto the exact artifact it came from by identity rather than by
+// slice position. When names is empty it returns nil (default API names kept).
+func buildVeoRenamePlan(gcsOutputURI string, srcURIs, names []string) (bucket string, renames []common.Rename, planSrcURIs, dstURIs []string) {
 	if len(names) == 0 || len(srcURIs) == 0 {
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 	bucket, prefix := common.ParseGCSBucketAndPrefix(gcsOutputURI)
 	n := len(srcURIs)
@@ -74,9 +76,29 @@ func buildVeoRenamePlan(gcsOutputURI string, srcURIs, names []string) (bucket st
 		}
 		dstObject := prefix + names[i]
 		renames = append(renames, common.Rename{Src: srcObject, Dst: dstObject})
+		planSrcURIs = append(planSrcURIs, srcURIs[i])
 		dstURIs = append(dstURIs, common.BuildGCSURI(bucket, dstObject))
 	}
-	return bucket, renames, dstURIs
+	return bucket, renames, planSrcURIs, dstURIs
+}
+
+// applyRenamedURIs writes each successfully-renamed destination URI back onto the
+// artifact it came from, pairing by identity (the source gs:// URI in planSrcURIs)
+// rather than by slice position. renames/planSrcURIs/dstURIs are aligned 1:1 by
+// construction (buildVeoRenamePlan), and renamedCount is how many leading plan
+// entries common.RenameGCSObjects reported as renamed (a prefix of the plan,
+// truncated at the first failure). Positional writeback into the (un-compacted)
+// gcsVideoURIs would drift if any source URI was skipped or the batch partially
+// failed; identity pairing never does.
+func applyRenamedURIs(gcsVideoURIs, planSrcURIs, dstURIs []string, renamedCount int) {
+	for k := 0; k < renamedCount && k < len(dstURIs) && k < len(planSrcURIs); k++ {
+		for idx := range gcsVideoURIs {
+			if gcsVideoURIs[idx] == planSrcURIs[k] {
+				gcsVideoURIs[idx] = dstURIs[k]
+				break
+			}
+		}
+	}
 }
 
 // callGenerateVideosAPI orchestrates the entire video generation process.
@@ -384,12 +406,13 @@ func callGenerateVideosAPI(
 	// context used for downloads), before the tool returns.
 	var renameNote string
 	if outputNames != nil && len(gcsVideoURIs) > 0 {
-		renameBucket, renames, dstURIs := buildVeoRenamePlan(config.OutputGCSURI, gcsVideoURIs, outputNames)
+		renameBucket, renames, planSrcURIs, dstURIs := buildVeoRenamePlan(config.OutputGCSURI, gcsVideoURIs, outputNames)
 		if len(renames) > 0 {
 			renamed, rErr := common.RenameGCSObjects(ctx, renameBucket, renames)
-			for j := 0; j < len(renamed) && j < len(dstURIs); j++ {
-				gcsVideoURIs[j] = dstURIs[j]
-			}
+			// Pair each renamed URI back to its source artifact by identity, not by
+			// slice position, so a skipped/unparseable URI or a partial batch failure
+			// never writes a renamed URI onto the wrong artifact.
+			applyRenamedURIs(gcsVideoURIs, planSrcURIs, dstURIs, len(renamed))
 			if rErr != nil {
 				renameNote = fmt.Sprintf("Note: renaming generated GCS object(s) to match output_filename '%s' partially failed (some API-original objects may remain): %v", outputFilename, rErr)
 				log.Print(renameNote)


### PR DESCRIPTION
## Phase 4 polish for `output_filename` (#842) — final polish, no new features

Builds on #1632 (which landed the `output_filename` standardization + veo
GCS copy-rename). This PR is **polish only**: added tests, one contained
correctness fix, and documentation. **No new features, VERSION untouched.**

All commits are intentionally NO-BUMP (`test:` / `chore:` / `docs:`), so
release-please should not compute a version bump from this PR.

### What's here
- **`test(mcp-genmedia)`: handler-level `output_filename` wiring tests** for
  lyria, chirp3, gemini-TTS, and avtool — cover `n==1 => base.ext`,
  `n>1 => base_1..n.ext`, extension-forcing (with the **avtool exemption**:
  avtool extension is *not* forced), and legacy-alias precedence
  (`output_filename` wins over `file_name` / `output_filename_prefix` /
  `output_file_name`).
- **`chore(mcp-genmedia)`: pair renamed GCS URIs to artifacts by identity**
  (imagen + veo) — writeback of renamed URIs is matched to source artifacts by
  identity so partial-rename failures cannot mis-associate results. Contained,
  low-risk correctness fix with unit coverage; also renamed the veo
  rename-plan test to `TestVeoRenamePlanIsNonNoop` to stop it over-claiming.
- **`test(mcp-genmedia)`: end-to-end naming integration tests** across
  Path A/B/C using network-free seams (nanobanana on-disk via real
  `PersistMediaOutputs`; gemini local+GCS agreement; imagen full
  plan→writeback chain; mcp-common `BuildOutputFilenames`→`RenameGCSObjects`
  via in-memory fake GCS). A live-GCS round-trip is gated behind
  `GENMEDIA_BUCKET` and skips when unset.
- **`docs(mcp-genmedia)`: document `output_filename`** — a canonical
  "Naming Outputs" section in the main README and docs-site landing page
  (precedence, extension-forcing + avtool exemption, `_1..n` suffix,
  overwrite-on-collision, path sanitization, Path-C copy-rename), plus a
  concise per-tool parameter entry on every server README/page and a
  deprecation note for the legacy aliases.

### Verification
- `go build` / `go test` green standalone (`GOWORK=off`) and under `go.work`
  for every touched module; `gofmt`/`go vet` clean on all changed files.
- Pre-existing, unrelated env failures only: avtool `TestRunFFmpegCommand` and
  `TestExecuteGetMediaInfo` require `ffmpeg`/`ffprobe` on `PATH` (not present
  in CI-less sandbox); not introduced by this PR.

Do not merge without coordinator sign-off.
