### PR TITLE
fix(mcp-genmedia): tidy modules after cloud-interactions-go v0.2.1 (#1629)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-chirp3-go/go.sum
@@ -52,8 +52,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/go.sum
@@ -46,8 +46,6 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
 github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
 github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/go.sum
@@ -52,8 +52,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/go.sum
@@ -52,8 +52,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/ghchinoy/cloud-interactions-go v0.2.0 // indirect
+	github.com/ghchinoy/cloud-interactions-go v0.2.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/go.sum
@@ -50,8 +50,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/ghchinoy/cloud-interactions-go v0.2.0 h1:V79/e94w53sCn8JZANBizTVy6Pe4vsla9ZvtOLdJ/SE=
-github.com/ghchinoy/cloud-interactions-go v0.2.0/go.mod h1:cWFyRpnjN94Z5IaB1NIedT5nds+Lu2t389BMszxpM/4=
+github.com/ghchinoy/cloud-interactions-go v0.2.1 h1:Hj35/LdR08s3H5a/+pPLc/TUsL/1K6UCc1LoizFSG1U=
+github.com/ghchinoy/cloud-interactions-go v0.2.1/go.mod h1:O5EC4PwoD/QCbdKGvH+GYhLLY8FuvwtCp3JqlP0lEeY=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Un-red `main`: tidy modules after cloud-interactions-go v0.2.1 (#1629)

#1629 bumped `github.com/ghchinoy/cloud-interactions-go` to **v0.2.1** in
`mcp-common/go.mod`+`go.sum` **only**. The dependent modules (avtool,
chirp3, gemini, imagen, lyria, veo, nanobanana, omni) still pinned
**v0.2.0** as an *indirect* require while `replace`-ing
`mcp-common => ../mcp-common`. In the standalone (`GOWORK=off`, readonly)
build the CI uses, the module graph is inconsistent, so
`go test`/`go build` reports **`updates to go.mod needed; to update it:
go mod tidy`** and `build-and-test` went **red on `main`**
(push run 31460116619).

### Fix
`go mod tidy` per module to align every module's indirect require (and
`go.sum`) with `cloud-interactions-go v0.2.1`.

- **`go.mod`/`go.sum` only — no code changes, `VERSION` untouched.**
- **Not an API break:** all 9 modules `go build ./...` + `go vet ./...`
  clean under standalone (`GOWORK=off`) mode after tidy.

Minimal, mechanical dependency-consistency fix to restore a green `main`.
