### PR TITLE
chore(mcp-genmedia): resource_link sink matrix, live leg + docs (#483)

### DIFF
--- a/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
@@ -103,6 +103,32 @@ removal planned): AVTool `output_file_name`, Lyria `file_name`, and the Chirp 3 
 Gemini TTS `output_filename_prefix` (a *prefix* only — `output_filename` gives the
 full name).
 
+## Resource Links for GCS Outputs
+
+When a tool writes an artifact to Google Cloud Storage, it additionally returns
+one MCP [`resource_link`](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#resource-links)
+content item **per GCS artifact**, so an MCP client can address the output as a
+first-class resource rather than parsing it out of the text summary.
+
+*   **GCS sink only.** A `resource_link` is emitted **only when the artifact was
+    uploaded to GCS** (`gcs_bucket_uri` or a server's bucket fallback). Inline-only
+    and local-only responses are unchanged — no link is added.
+*   **One link per artifact,** appended after the existing content in generation
+    order (so `n` GCS artifacts produce `n` links, aligned 1..n).
+*   **`uri` is the `gs://` URI** — the durable identity of the object, **not** the
+    expiring V4-signed HTTPS URL. The signed URL (when generated) still appears in
+    the text summary; the `resource_link` gives clients a stable handle.
+*   **`name`** is the object's name, **`mimeType`** is the artifact's true output
+    MIME type, and **`description`** is a 1-based human label (e.g.
+    `nanobanana output 1 of 1`).
+*   **Text output is unchanged (back-compat).** The `resource_link` items are
+    *appended*; the existing text content is byte-for-byte identical to before this
+    feature.
+
+**In scope:** Gemini Image, Imagen (text-to-image and edit), Veo, Lyria,
+Nanobanana. **Out of scope:** Gemini TTS, Chirp 3, and AVTool do not emit
+`resource_link` items.
+
 ## Authentication
 
 The servers use Google's Application Default Credentials (ADC). Ensure you have authenticated by one of the following methods:

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
@@ -19,6 +19,8 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
 
+When images are uploaded to GCS, `gemini_image_generation` appends one MCP `resource_link` content item per image (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`); the text summary is unchanged. This applies to image generation only — `gemini_audio_tts` does **not** emit resource links. See [Resource Links for GCS Outputs](../index.md#resource-links-for-gcs-outputs).
+
 ### `gemini_audio_tts`
 
 Synthesizes speech from text using Gemini models, allowing for granular control over style, pace, tone, and emotional expression through natural-language prompts.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-imagen-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-imagen-go/index.md
@@ -25,6 +25,8 @@ The following tool is exposed by this server:
     *   `output_directory` (string, optional): If provided, specifies a local directory to save the generated image(s) to.
     *   `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).
 
+When images are written to GCS, the tool appends one MCP `resource_link` content item per image — and one for the edited image on image-editing calls (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`); the text summary is unchanged. See [Resource Links for GCS Outputs](../index.md#resource-links-for-gcs-outputs).
+
 ### Resources
 
 The server exposes the following resources:

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-lyria-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-lyria-go/index.md
@@ -27,6 +27,8 @@ The following tool is exposed by this server:
     *   `model_id` (string, optional): Specific Lyria model ID to use for the Google Cloud AI endpoint.
         *   Defaults to the value of the `DEFAULT_LYRIA_MODEL_ID (Deprecated)` environment variable, or `"lyria-3-clip-preview"` if the variable is not set.
 
+When audio is written to GCS, the tool appends one MCP `resource_link` content item for the uploaded audio (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`); the text summary is unchanged, and local-only / inline responses add no link. See [Resource Links for GCS Outputs](../index.md#resource-links-for-gcs-outputs).
+
 ## Environment Variable Configuration
 
 The tool utilizes the following environment variables:

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-nanobanana-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-nanobanana-go/index.md
@@ -19,8 +19,7 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
 
-
-
+When images are uploaded to GCS, the tool appends one MCP `resource_link` content item per image (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`); the text summary is unchanged. See [Resource Links for GCS Outputs](../index.md#resource-links-for-gcs-outputs).
 
 ## Environment Variable Configuration
 

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-veo-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-veo-go/index.md
@@ -22,6 +22,8 @@ The server exposes the following tools:
     *   `aspect_ratio` (string, optional): Aspect ratio of the generated videos. Note: supported aspect ratios are model-dependent.
     *   `duration` (number, optional): Duration of the generated video in seconds. Note: the supported duration range is model-dependent.
 
+Because Veo always writes to GCS, every Veo tool appends one MCP `resource_link` content item per generated video (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`); the text summary is unchanged. See [Resource Links for GCS Outputs](../index.md#resource-links-for-gcs-outputs).
+
 ### 2. `veo_i2v` (Image-to-Video)
 
 *   **Description**: Generate a video from an input image (and optional prompt) using Veo. Video is saved to GCS and optionally downloaded locally. Supported image MIME types: image/jpeg, image/png.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/README.md
@@ -241,6 +241,33 @@ release):
 | `mcp-lyria-go` | `file_name` | Full output name. |
 | `mcp-chirp3-go`, `mcp-gemini-go` (TTS) | `output_filename_prefix` | A *prefix* only (a timestamp/voice + extension is appended); `output_filename` provides the full name. |
 
+## Resource Links for GCS Outputs
+
+When a tool writes an artifact to Google Cloud Storage, it additionally returns
+one MCP [`resource_link`](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#resource-links)
+content item **per GCS artifact**, so an MCP client can address the output as a
+first-class resource rather than parsing it out of the text summary.
+
+- **GCS sink only.** A `resource_link` is emitted **only when the artifact was
+  uploaded to GCS** (`gcs_bucket_uri` or a server's bucket fallback). Inline-only
+  and local-only responses are unchanged — no link is added.
+- **One link per artifact,** appended after the existing content in generation
+  order (so for `n` GCS artifacts you get `n` links, aligned 1..n).
+- **`uri` is the `gs://` URI** — the durable identity of the object, **not** the
+  expiring V4-signed HTTPS URL. The signed URL (when generated) still appears in
+  the text summary as before; the `resource_link` gives clients a stable handle.
+- **`name`** is the object's name, **`mimeType`** is the artifact's true output
+  MIME type, and **`description`** is a 1-based human label (e.g.
+  `nanobanana output 1 of 1`).
+- **Text output is unchanged (back-compat).** The `resource_link` items are
+  *appended*; the existing text content (model text, signed-URL line, saved-files
+  summary) is byte-for-byte identical to before this feature.
+
+**In scope:** `mcp-nanobanana-go`, `mcp-gemini-go` (image generation/editing),
+`mcp-imagen-go` (text-to-image and edit), `mcp-veo-go`, `mcp-lyria-go`, and the
+shared omni renderer. **Out of scope:** `mcp-chirp3-go`, `mcp-gemini-go` **TTS**,
+and `mcp-avtool-go` do not emit `resource_link` items.
+
 ## Configuration (Environment Variables)
 
 All servers in this project are configured using environment variables. While some servers have unique variables, the following are common to most of them:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_matrix_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_matrix_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestRenderOmniResultBothLocalAndGCS completes the cross-cutting sink matrix for
+// the shared omni renderer (used by mcp-omni-go and mcp-gemini-go): when a call
+// writes BOTH locally and to GCS, a resource_link is emitted for the GCS identity
+// and the local saved-files line is preserved in the (unchanged) text (design
+// #483 P4 Test Plan). The GCS upload / signing seams are stubbed; the local write
+// is real (t.TempDir), so the leg is network-free.
+func TestRenderOmniResultBothLocalAndGCS(t *testing.T) {
+	origUpload := uploadToGCSFn
+	origSign := generateV4SignedURLFn
+	t.Cleanup(func() { uploadToGCSFn = origUpload; generateV4SignedURLFn = origSign })
+	uploadToGCSFn = func(context.Context, string, string, string, []byte) error { return nil }
+	generateV4SignedURLFn = func(_ context.Context, _, object string, _ time.Duration) (string, error) {
+		return "https://signed.example/" + object, nil
+	}
+
+	dir := t.TempDir()
+	result := &OmniResult{
+		Videos:         [][]byte{[]byte("mp4-bytes")},
+		VideoMimeTypes: []string{"video/mp4"},
+		Text:           "here is your video",
+	}
+	content, err := RenderOmniResult(context.Background(), result, dir, "my-bucket/prefix", "clip.mp4")
+	if err != nil {
+		t.Fatalf("RenderOmniResult error: %v", err)
+	}
+
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content items (text + 1 link), got %d", len(content))
+	}
+	link, ok := content[1].(mcp.ResourceLink)
+	if !ok {
+		t.Fatalf("content[1] = %T, want mcp.ResourceLink", content[1])
+	}
+	if link.URI != "gs://my-bucket/prefix/clip.mp4" {
+		t.Errorf("resource_link URI = %q, want gs://my-bucket/prefix/clip.mp4", link.URI)
+	}
+	text, ok := content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] = %T, want mcp.TextContent", content[0])
+	}
+	// The local path and the gs:// URI both appear in the saved-files summary.
+	if !strings.Contains(text.Text, dir) {
+		t.Errorf("both sink text lost the local path %q; got %q", dir, text.Text)
+	}
+	if !strings.Contains(text.Text, "gs://my-bucket/prefix/clip.mp4") {
+		t.Errorf("both sink text lost the gs:// URI; got %q", text.Text)
+	}
+}
+
+// TestRenderOmniResultGCSBackCompat asserts the GCS-path text summary is
+// byte-for-byte the pre-#483 output (model text, signed-URL line, saved-files
+// line). #483 only APPENDS the resource_link after content[0]; content[0] must be
+// identical. output_filename pins the object name and the expiry env is pinned so
+// the whole summary is deterministic.
+func TestRenderOmniResultGCSBackCompat(t *testing.T) {
+	t.Setenv("OMNI_SIGNED_URL_EXPIRY_HOURS", "24")
+
+	origUpload := uploadToGCSFn
+	origSign := generateV4SignedURLFn
+	t.Cleanup(func() { uploadToGCSFn = origUpload; generateV4SignedURLFn = origSign })
+	uploadToGCSFn = func(context.Context, string, string, string, []byte) error { return nil }
+	generateV4SignedURLFn = func(_ context.Context, _, object string, _ time.Duration) (string, error) {
+		return "https://signed.example/" + object, nil
+	}
+
+	result := &OmniResult{
+		Videos:         [][]byte{[]byte("mp4-bytes")},
+		VideoMimeTypes: []string{"video/mp4"},
+		Text:           "the video",
+	}
+	content, err := RenderOmniResult(context.Background(), result, "", "my-bucket/prefix", "clip.mp4")
+	if err != nil {
+		t.Fatalf("RenderOmniResult error: %v", err)
+	}
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content items (text + 1 link), got %d", len(content))
+	}
+	text, ok := content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] = %T, want mcp.TextContent", content[0])
+	}
+	want := "the video\n\n" +
+		"Signed URL for prefix/clip.mp4 (valid " + (24 * time.Hour).String() + "):\n" +
+		"https://signed.example/prefix/clip.mp4\n\n" +
+		"Generated and saved 1 video(s): gs://my-bucket/prefix/clip.mp4"
+	if text.Text != want {
+		t.Errorf("back-compat text drift:\n got=%q\nwant=%q", text.Text, want)
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
@@ -17,6 +17,8 @@ Generates content (text and/or images) based on a multimodal prompt.
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.
 - `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../README.md#naming-outputs-output_filename).
 
+When `gcs_bucket_uri` is set, `gemini_image_generation` appends one MCP `resource_link` content item per uploaded image (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`); the text summary is unchanged. This applies to image generation only — `gemini_audio_tts` does **not** emit resource links. See [Resource Links for GCS Outputs](../README.md#resource-links-for-gcs-outputs).
+
 ### `gemini_audio_tts`
 
 Synthesizes speech from text using Gemini models, allowing for granular control over style, pace, tone, and emotional expression through natural-language prompts.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers_matrix_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers_matrix_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestGeminiResourceLinkMatrix completes the cross-cutting sink matrix for the
+// gemini image handler (design #483 P4 Test Plan). The GCS-sink and inline legs
+// are already covered by handlers_resource_link_test.go; this adds the local-only
+// and both-local+GCS legs plus an explicit byte-for-byte back-compat assertion on
+// the GCS text summary. All legs are network-free (write/upload seams stubbed).
+func TestGeminiResourceLinkMatrix(t *testing.T) {
+	resourceLinks := func(res *mcp.CallToolResult) []mcp.ResourceLink {
+		var links []mcp.ResourceLink
+		for _, c := range res.Content {
+			if rl, ok := c.(mcp.ResourceLink); ok {
+				links = append(links, rl)
+			}
+		}
+		return links
+	}
+	inlineImages := func(res *mcp.CallToolResult) int {
+		n := 0
+		for _, c := range res.Content {
+			if _, ok := c.(mcp.ImageContent); ok {
+				n++
+			}
+		}
+		return n
+	}
+	firstText := func(t *testing.T, res *mcp.CallToolResult) string {
+		t.Helper()
+		text, ok := res.Content[0].(mcp.TextContent)
+		if !ok {
+			t.Fatalf("content[0] is %T, want mcp.TextContent", res.Content[0])
+		}
+		return text.Text
+	}
+
+	// Local-only sink: image is written locally (write seam stubbed), NO inline
+	// image content is returned, and NO resource_link is emitted (no file:// links).
+	t.Run("local-only sink -> no resource_link, no inline image", func(t *testing.T) {
+		origWrite := writeFileFn
+		t.Cleanup(func() { writeFileFn = origWrite })
+		writeFileFn = func(string, []byte, os.FileMode) error { return nil }
+
+		resp := imageResponse(textPart("hi"), imagePart("image/png", []byte("a")))
+		res, err := processGeminiImageResponse(context.Background(), resp, map[string]any{"output_filename": "shot.png"}, "/tmp/out", "", "", "")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if got := len(resourceLinks(res)); got != 0 {
+			t.Errorf("local-only produced %d resource_link(s), want 0", got)
+		}
+		if got := inlineImages(res); got != 0 {
+			t.Errorf("local-only returned %d inline image(s), want 0", got)
+		}
+		if text := firstText(t, res); !strings.Contains(text, "Generated and saved 1 image(s): /tmp/out/shot.png") {
+			t.Errorf("local-only text missing saved-file line; got %q", text)
+		}
+	})
+
+	// Both local+GCS: resource_link IS emitted (GCS identity); the local saved
+	// line is preserved alongside the GCS uploaded line.
+	t.Run("both local+GCS -> resource_link present, local text preserved", func(t *testing.T) {
+		origWrite := writeFileFn
+		origUpload := uploadToGCSFn
+		t.Cleanup(func() { writeFileFn = origWrite; uploadToGCSFn = origUpload })
+		writeFileFn = func(string, []byte, os.FileMode) error { return nil }
+		uploadToGCSFn = func(context.Context, string, string, string, []byte) error { return nil }
+
+		resp := imageResponse(textPart("hi"), imagePart("image/png", []byte("a")))
+		res, err := processGeminiImageResponse(context.Background(), resp, map[string]any{"output_filename": "shot.png"}, "/tmp/out", "gs://test-bucket/pfx", "test-bucket", "pfx")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		links := resourceLinks(res)
+		if len(links) != 1 {
+			t.Fatalf("both sink produced %d resource_link(s), want 1", len(links))
+		}
+		if links[0].URI != "gs://test-bucket/pfx/shot.png" {
+			t.Errorf("resource_link URI = %q, want gs://test-bucket/pfx/shot.png", links[0].URI)
+		}
+		text := firstText(t, res)
+		if !strings.Contains(text, "Generated and saved 1 image(s): /tmp/out/shot.png") {
+			t.Errorf("both sink text lost local saved line; got %q", text)
+		}
+		if !strings.Contains(text, "Generated and uploaded 1 image(s) to GCS: gs://test-bucket/pfx/shot.png") {
+			t.Errorf("both sink text lost GCS uploaded line; got %q", text)
+		}
+	})
+
+	// GCS sink back-compat: content[0] is byte-for-byte the pre-#483 text summary
+	// (model text + GCS uploaded line). #483 only appends the resource_link.
+	t.Run("GCS sink -> text byte-identical (back-compat)", func(t *testing.T) {
+		origUpload := uploadToGCSFn
+		t.Cleanup(func() { uploadToGCSFn = origUpload })
+		uploadToGCSFn = func(context.Context, string, string, string, []byte) error { return nil }
+
+		resp := imageResponse(textPart("here you go"), imagePart("image/png", []byte("a")))
+		res, err := processGeminiImageResponse(context.Background(), resp, map[string]any{"output_filename": "shot.png"}, "", "gs://test-bucket/pfx", "test-bucket", "pfx")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if got := len(resourceLinks(res)); got != 1 {
+			t.Fatalf("GCS sink produced %d resource_link(s), want 1", got)
+		}
+		want := "here you go\n\nGenerated and uploaded 1 image(s) to GCS: gs://test-bucket/pfx/shot.png"
+		if got := firstText(t, res); got != want {
+			t.Errorf("back-compat text drift:\n got=%q\nwant=%q", got, want)
+		}
+	})
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/README.md
@@ -23,6 +23,8 @@ The following tool is exposed by this server:
     *   `output_directory` (string, optional): If provided, specifies a local directory to save the generated image(s) to.
     *   `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension (`hero_1.png … hero_n.png`). Applied identically to local files and GCS objects. See [Naming Outputs](../README.md#naming-outputs-output_filename).
 
+When images are written to GCS, the tool appends one MCP `resource_link` content item per uploaded image — and for image editing, one for the edited image (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`). The text summary is unchanged. See [Resource Links for GCS Outputs](../README.md#resource-links-for-gcs-outputs).
+
 ### Resources
 
 The server exposes the following resources:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen_matrix_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-imagen-go/imagen_matrix_test.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestImagenResourceLinkMatrix completes the cross-cutting sink matrix for imagen
+// at the resource_link seam (design #483 P4 Test Plan). The GCS multi-image and
+// inline legs are covered by imagen_resource_link_test.go; this adds the
+// local-only and both-local+GCS legs and asserts the leading text (content[0]) is
+// preserved byte-for-byte — the back-compat guarantee — in every case. The helper
+// only decides the resource_link tail from the resolved gs:// URIs, so these are
+// pure, network-free assertions.
+func TestImagenResourceLinkMatrix(t *testing.T) {
+	// Local-only sink: the handler's text carries a local saved-files line and no
+	// gs:// URI is resolved, so no resource_link is appended and the text is intact.
+	t.Run("local-only sink -> no resource_link, text byte-identical", func(t *testing.T) {
+		localText := "Generated and saved 1 image(s): /tmp/out/shot.png"
+		text := mcp.TextContent{Type: "text", Text: localText}
+		content := appendImagenResourceLinks([]mcp.Content{text}, nil, nil)
+		if len(content) != 1 {
+			t.Fatalf("local-only produced %d content items, want 1 (no link)", len(content))
+		}
+		if got := content[0].(mcp.TextContent).Text; got != localText {
+			t.Errorf("text drift on local-only path:\n got=%q\nwant=%q", got, localText)
+		}
+	})
+
+	// Both local+GCS: the handler's text carries BOTH the local saved-files line
+	// and the GCS uploaded line; one resource_link is appended for the gs:// URI and
+	// content[0] is preserved byte-for-byte (local text intact).
+	t.Run("both local+GCS -> resource_link present, text byte-identical", func(t *testing.T) {
+		bothText := "Generated and saved 1 image(s): /tmp/out/shot.png\n\n" +
+			"Generated and uploaded 1 image(s) to GCS: gs://bucket/pfx/shot.png"
+		text := mcp.TextContent{Type: "text", Text: bothText}
+		content := appendImagenResourceLinks([]mcp.Content{text},
+			[]string{"gs://bucket/pfx/shot.png"}, []string{"image/png"})
+		if len(content) != 2 {
+			t.Fatalf("both sink produced %d content items, want 2 (text + link)", len(content))
+		}
+		if got := content[0].(mcp.TextContent).Text; got != bothText {
+			t.Errorf("text drift on both path (back-compat):\n got=%q\nwant=%q", got, bothText)
+		}
+		link, ok := content[1].(mcp.ResourceLink)
+		if !ok {
+			t.Fatalf("content[1] = %T, want mcp.ResourceLink", content[1])
+		}
+		if link.URI != "gs://bucket/pfx/shot.png" {
+			t.Errorf("resource_link URI = %q, want gs://bucket/pfx/shot.png", link.URI)
+		}
+	})
+
+	// imagen edit (single artifact): both local+GCS -> one link, text preserved.
+	t.Run("edit both local+GCS -> resource_link present, text byte-identical", func(t *testing.T) {
+		editText := "Edited image saved locally to /tmp/out/edit.png and uploaded to gs://bucket/edits/edit.png"
+		text := mcp.TextContent{Type: "text", Text: editText}
+		content := appendImagenEditResourceLink([]mcp.Content{text}, "gs://bucket/edits/edit.png", "image/png")
+		if len(content) != 2 {
+			t.Fatalf("edit both sink produced %d content items, want 2", len(content))
+		}
+		if got := content[0].(mcp.TextContent).Text; got != editText {
+			t.Errorf("edit text drift:\n got=%q\nwant=%q", got, editText)
+		}
+		if content[1].(mcp.ResourceLink).URI != "gs://bucket/edits/edit.png" {
+			t.Errorf("edit resource_link URI = %q, want gs://bucket/edits/edit.png", content[1].(mcp.ResourceLink).URI)
+		}
+	})
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/README.md
@@ -25,6 +25,8 @@ The following tool is exposed by this server:
     *   `model_id` (string, optional): Specific Lyria model ID to use for the Vertex AI endpoint.
         *   Defaults to the value of the `DEFAULT_LYRIA_MODEL_ID (Deprecated)` environment variable, or `"lyria-3-clip-preview"` if the variable is not set.
 
+When audio is written to GCS (`output_gcs_bucket` or the `GENMEDIA_BUCKET` fallback), the tool appends one MCP `resource_link` content item for the uploaded audio (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`). The text summary is unchanged, and local-only / inline responses add no link. See [Resource Links for GCS Outputs](../README.md#resource-links-for-gcs-outputs).
+
 ## Environment Variable Configuration
 
 The tool utilizes the following environment variables:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria_matrix_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/lyria_matrix_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestLyriaResourceLinkMatrix completes the cross-cutting sink matrix for lyria at
+// the resource_link seam (design #483 P4 Test Plan). The GCS and inline/no-link
+// legs are covered by lyria_resource_link_test.go; this adds the local-only and
+// both-local+GCS legs and asserts content[0] is preserved byte-for-byte
+// (back-compat). Lyria supports a local sink (local_path), a GCS sink, and inline
+// audio; a resource_link is emitted only when a GCS object exists.
+func TestLyriaResourceLinkMatrix(t *testing.T) {
+	// Local-only sink (local_path set, no GCS): text carries the local saved line;
+	// no GCS object -> no resource_link; text byte-identical.
+	t.Run("local-only sink -> no resource_link, text byte-identical", func(t *testing.T) {
+		localText := "Successfully saved audio locally to /tmp/out/track.wav."
+		text := mcp.TextContent{Type: "text", Text: localText}
+		content := appendLyriaResourceLink([]mcp.Content{text}, "", "", "audio/wav")
+		if len(content) != 1 {
+			t.Fatalf("local-only produced %d content items, want 1 (no link)", len(content))
+		}
+		if got := content[0].(mcp.TextContent).Text; got != localText {
+			t.Errorf("text drift on local-only path:\n got=%q\nwant=%q", got, localText)
+		}
+	})
+
+	// Both local+GCS: text carries BOTH the local saved line and the GCS line; one
+	// resource_link is appended for the gs:// URI and content[0] is preserved.
+	t.Run("both local+GCS -> resource_link present, text byte-identical", func(t *testing.T) {
+		bothText := "Successfully saved audio locally to /tmp/out/track.wav. " +
+			"Successfully uploaded to gs://my-bucket/lyria_outputs/track.wav."
+		text := mcp.TextContent{Type: "text", Text: bothText}
+		content := appendLyriaResourceLink([]mcp.Content{text}, "my-bucket", "lyria_outputs/track.wav", "audio/wav")
+		if len(content) != 2 {
+			t.Fatalf("both sink produced %d content items, want 2 (text + link)", len(content))
+		}
+		if got := content[0].(mcp.TextContent).Text; got != bothText {
+			t.Errorf("text drift on both path (back-compat):\n got=%q\nwant=%q", got, bothText)
+		}
+		link, ok := content[1].(mcp.ResourceLink)
+		if !ok {
+			t.Fatalf("content[1] = %T, want mcp.ResourceLink", content[1])
+		}
+		if link.URI != "gs://my-bucket/lyria_outputs/track.wav" {
+			t.Errorf("resource_link URI = %q, want gs://my-bucket/lyria_outputs/track.wav", link.URI)
+		}
+		if link.MIMEType != "audio/wav" {
+			t.Errorf("resource_link MIMEType = %q, want audio/wav", link.MIMEType)
+		}
+	})
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
@@ -45,6 +45,8 @@ The tool utilizes the following environment variables:
 
 When `gcs_bucket_uri` (or the `GENMEDIA_BUCKET` fallback) is set, the tool uploads each generated image to GCS, returns the `gs://` URI, and additionally returns a **V4-signed HTTPS URL** so MCP clients can display the image without the bucket being public. This is useful for remote/containerized deployments (SSE bridge, Cloud Run) where no retrievable local directory exists — without a bucket configured and no `output_directory`, generated image bytes are discarded.
 
+On the GCS path the tool also appends one MCP `resource_link` content item per uploaded image (`uri` = the `gs://` URI, with the object `name`, `mimeType`, and a 1-based `description`). The text summary is unchanged. See [Resource Links for GCS Outputs](../README.md#resource-links-for-gcs-outputs).
+
 ### Signed URLs — credentials
 
 Generating a signed URL requires an RSA signer:

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/integration_resource_link_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/integration_resource_link_test.go
@@ -15,9 +15,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -104,15 +106,87 @@ func TestIntegrationNanobananaResourceLinks(t *testing.T) {
 	})
 
 	t.Run("live GCS sink (gated behind GENMEDIA_BUCKET)", func(t *testing.T) {
-		bucket := os.Getenv("GENMEDIA_BUCKET")
+		bucket := strings.TrimSpace(os.Getenv("GENMEDIA_BUCKET"))
 		if bucket == "" {
 			t.Skip("GENMEDIA_BUCKET not set; skipping live GCS resource_link integration")
 		}
-		// The default (network-free) subtest already validates the response-building
-		// contract against the real persistence seam's PersistedMedia shape. A full
-		// live run additionally needs a genai client + credentials; when a live
-		// harness is wired it should drive nanobananaGenerateContentHandler and
-		// assert content[0] text + content[1..n] resource_link with gs://%s/... uris.
-		t.Logf("GENMEDIA_BUCKET=%s set; live nanobanana resource_link path exercised by the live harness", bucket)
+		// This leg is a REAL live integration (#483 P4, resolves P1 review NB#2 —
+		// the former placeholder only logged). It drives processImageResponse through
+		// the REAL persistence seam (common.PersistMediaOutputs -> real GCS upload +
+		// real V4 signed URL) using ambient credentials (ADC or
+		// GOOGLE_APPLICATION_CREDENTIALS), then proves the emitted resource_link
+		// identifies an object that genuinely exists in GCS by downloading it back
+		// and comparing bytes.
+		//
+		// No genai call is needed: the resource_link contract lives entirely in the
+		// GCS-persist + response-building step, which this exercises end-to-end with
+		// real cloud I/O. The leg is fully gated behind GENMEDIA_BUCKET so it skips
+		// cleanly in CI (no creds, no bucket). Objects are written under a unique,
+		// self-cleaning prefix; cleanup is best-effort via `gcloud storage rm`.
+		ctx := context.Background()
+
+		// Normalize GENMEDIA_BUCKET to "gs://<bucket>[/prefix]" and append a unique
+		// per-run prefix so parallel/repeat runs never collide and cleanup is scoped.
+		base := strings.TrimSuffix(strings.TrimPrefix(bucket, "gs://"), "/")
+		gcsBucketURI := fmt.Sprintf("gs://%s/nanobanana_outputs/live-483-%d", base, time.Now().UnixNano())
+		t.Cleanup(func() {
+			// Best-effort teardown; ignore errors (e.g. gcloud absent) so a passing
+			// assertion is never masked by a cleanup failure.
+			out, err := exec.Command("gcloud", "storage", "rm", "--recursive", gcsBucketURI).CombinedOutput()
+			if err != nil {
+				t.Logf("cleanup: could not remove %s: %v (%s)", gcsBucketURI, err, strings.TrimSpace(string(out)))
+			}
+		})
+
+		// Use the REAL persistence seam for this leg (do NOT stub persistMediaOutputs).
+		imgBytes := []byte("\x89PNG\r\n\x1a\n#483 live resource_link integration payload")
+		resp := imageResponse(textPart("live leg"), imagePart("image/png", imgBytes))
+		res, err := processImageResponse(ctx, resp, map[string]any{}, "", gcsBucketURI)
+		if err != nil {
+			t.Fatalf("processImageResponse (live) error: %v", err)
+		}
+
+		// The real upload must have succeeded (GCS errors are non-fatal and surfaced
+		// as a warning line in the text — assert none appeared).
+		text, ok := res.Content[0].(mcp.TextContent)
+		if !ok {
+			t.Fatalf("content[0] is %T, want mcp.TextContent", res.Content[0])
+		}
+		if strings.Contains(text.Text, "failed to upload") {
+			t.Fatalf("live GCS upload reported a failure in the text summary: %q", text.Text)
+		}
+
+		// Exactly one image -> text + one resource_link.
+		if len(res.Content) != 2 {
+			t.Fatalf("content len = %d, want 2 (text + 1 link); text=%q", len(res.Content), text.Text)
+		}
+		rl, ok := res.Content[1].(mcp.ResourceLink)
+		if !ok {
+			t.Fatalf("content[1] is %T, want mcp.ResourceLink", res.Content[1])
+		}
+		if rl.Type != mcp.ContentTypeLink {
+			t.Errorf("content[1].Type = %q, want %q", rl.Type, mcp.ContentTypeLink)
+		}
+		if !strings.HasPrefix(rl.URI, gcsBucketURI+"/") || !strings.HasSuffix(rl.URI, ".png") {
+			t.Errorf("content[1].URI = %q, want %q/<name>.png", rl.URI, gcsBucketURI)
+		}
+		if rl.MIMEType != "image/png" {
+			t.Errorf("content[1].MIMEType = %q, want image/png", rl.MIMEType)
+		}
+		if rl.Description != "nanobanana output 1 of 1" {
+			t.Errorf("content[1].Description = %q, want %q", rl.Description, "nanobanana output 1 of 1")
+		}
+
+		// The decisive live assertion: the gs:// identity in the resource_link points
+		// at a real object whose bytes round-trip. This is what the old placeholder
+		// never did.
+		got, err := common.DownloadFromGCSAsBytes(ctx, rl.URI)
+		if err != nil {
+			t.Fatalf("downloading the linked object %s failed (object should exist): %v", rl.URI, err)
+		}
+		if !bytes.Equal(got, imgBytes) {
+			t.Errorf("linked object bytes (%d) != uploaded bytes (%d)", len(got), len(imgBytes))
+		}
+		t.Logf("live resource_link verified: %s (%d bytes round-tripped)", rl.URI, len(got))
 	})
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/matrix_resource_link_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/matrix_resource_link_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
+)
+
+// TestNanobananaResourceLinkMatrix is the cross-cutting sink matrix for nanobanana
+// (design #483 P4 Test Plan): it asserts the resource_link contract across the
+// inline (no sink), local-only, both-local+GCS, and GCS-only paths, plus an
+// explicit byte-for-byte back-compat check of the text summary on the GCS path.
+// Every leg is network-free: the persistence seam is stubbed to return a
+// deterministic PersistedMedia for the requested sink, so the whole matrix runs
+// in CI without credentials.
+func TestNanobananaResourceLinkMatrix(t *testing.T) {
+	// Pin the signed-URL expiry so the back-compat text is deterministic.
+	t.Setenv("NANOBANANA_SIGNED_URL_EXPIRY_HOURS", "24")
+
+	// resourceLinks returns just the resource_link items in res.Content.
+	resourceLinks := func(t *testing.T, res *mcp.CallToolResult) []mcp.ResourceLink {
+		t.Helper()
+		var links []mcp.ResourceLink
+		for _, c := range res.Content {
+			if rl, ok := c.(mcp.ResourceLink); ok {
+				links = append(links, rl)
+			}
+		}
+		return links
+	}
+	firstText := func(t *testing.T, res *mcp.CallToolResult) string {
+		t.Helper()
+		text, ok := res.Content[0].(mcp.TextContent)
+		if !ok {
+			t.Fatalf("content[0] is %T, want mcp.TextContent", res.Content[0])
+		}
+		return text.Text
+	}
+
+	// Inline sink (no output_directory, no gcs_bucket_uri): nanobanana persists
+	// nothing, so there is NO resource_link and no signed-URL / saved-files line.
+	t.Run("inline sink -> no resource_link", func(t *testing.T) {
+		orig := persistMediaOutputs
+		t.Cleanup(func() { persistMediaOutputs = orig })
+		persistMediaOutputs = func(_ context.Context, _ common.MediaArtifact, _, _ string, _ time.Duration) (common.PersistedMedia, error) {
+			return common.PersistedMedia{}, nil // nothing saved
+		}
+
+		resp := imageResponse(textPart("hello"), imagePart("image/png", []byte("x")))
+		res, err := processImageResponse(context.Background(), resp, map[string]any{}, "", "")
+		if err != nil {
+			t.Fatalf("processImageResponse error: %v", err)
+		}
+		if links := resourceLinks(t, res); len(links) != 0 {
+			t.Errorf("inline sink produced %d resource_link(s), want 0", len(links))
+		}
+		text := firstText(t, res)
+		if !strings.Contains(text, "hello") {
+			t.Errorf("text missing model output; got %q", text)
+		}
+		if strings.Contains(text, "Signed URL") || strings.Contains(text, "Generated and saved") {
+			t.Errorf("inline sink text should not mention a saved file / signed URL; got %q", text)
+		}
+	})
+
+	// Local-only sink (output_directory set, no GCS): a local file is written but
+	// there is NO resource_link (this PR does not emit file:// links); the local
+	// saved-files line is present and unchanged.
+	t.Run("local-only sink -> no resource_link, local text preserved", func(t *testing.T) {
+		orig := persistMediaOutputs
+		t.Cleanup(func() { persistMediaOutputs = orig })
+		persistMediaOutputs = func(_ context.Context, art common.MediaArtifact, outputDir, _ string, _ time.Duration) (common.PersistedMedia, error) {
+			return common.PersistedMedia{LocalPath: outputDir + "/" + art.FileName}, nil
+		}
+
+		resp := imageResponse(textPart("hello"), imagePart("image/png", []byte("x")))
+		res, err := processImageResponse(context.Background(), resp, map[string]any{"output_filename": "shot.png"}, "/tmp/out", "")
+		if err != nil {
+			t.Fatalf("processImageResponse error: %v", err)
+		}
+		if links := resourceLinks(t, res); len(links) != 0 {
+			t.Errorf("local-only sink produced %d resource_link(s), want 0", len(links))
+		}
+		text := firstText(t, res)
+		if !strings.Contains(text, "Generated and saved 1 image(s): /tmp/out/shot.png") {
+			t.Errorf("local-only text missing saved-file line; got %q", text)
+		}
+	})
+
+	// Both local+GCS: a resource_link IS emitted (GCS identity) and the local
+	// saved-files line is preserved in the (unchanged) text.
+	t.Run("both local+GCS -> resource_link present, local text preserved", func(t *testing.T) {
+		orig := persistMediaOutputs
+		t.Cleanup(func() { persistMediaOutputs = orig })
+		persistMediaOutputs = func(_ context.Context, art common.MediaArtifact, outputDir, gcsBucketURI string, _ time.Duration) (common.PersistedMedia, error) {
+			return common.PersistedMedia{
+				LocalPath: outputDir + "/" + art.FileName,
+				GCSURI:    strings.TrimSuffix(gcsBucketURI, "/") + "/" + art.FileName,
+				GCSObject: art.FileName,
+				SignedURL: "https://signed.example/" + art.FileName,
+			}, nil
+		}
+
+		resp := imageResponse(textPart("hello"), imagePart("image/png", []byte("x")))
+		res, err := processImageResponse(context.Background(), resp, map[string]any{"output_filename": "shot.png"}, "/tmp/out", "gs://bkt/pfx")
+		if err != nil {
+			t.Fatalf("processImageResponse error: %v", err)
+		}
+		links := resourceLinks(t, res)
+		if len(links) != 1 {
+			t.Fatalf("both sink produced %d resource_link(s), want 1", len(links))
+		}
+		if links[0].URI != "gs://bkt/pfx/shot.png" {
+			t.Errorf("resource_link URI = %q, want gs://bkt/pfx/shot.png", links[0].URI)
+		}
+		text := firstText(t, res)
+		if !strings.Contains(text, "/tmp/out/shot.png") {
+			t.Errorf("both sink text lost the local path; got %q", text)
+		}
+		if !strings.Contains(text, "gs://bkt/pfx/shot.png") {
+			t.Errorf("both sink text lost the gs:// summary line; got %q", text)
+		}
+	})
+
+	// GCS sink back-compat: the text summary is byte-for-byte what the pre-#483
+	// code produced (model text, signed-URL line, saved-files line). #483 only
+	// APPENDS the resource_link after content[0]; content[0] must be identical.
+	t.Run("GCS sink -> text byte-identical (back-compat)", func(t *testing.T) {
+		orig := persistMediaOutputs
+		t.Cleanup(func() { persistMediaOutputs = orig })
+		persistMediaOutputs = func(_ context.Context, art common.MediaArtifact, _, gcsBucketURI string, _ time.Duration) (common.PersistedMedia, error) {
+			return common.PersistedMedia{
+				GCSURI:    strings.TrimSuffix(gcsBucketURI, "/") + "/" + art.FileName,
+				GCSObject: "pfx/" + art.FileName,
+				SignedURL: "https://signed.example/x",
+			}, nil
+		}
+
+		resp := imageResponse(textPart("here you go"), imagePart("image/png", []byte("x")))
+		res, err := processImageResponse(context.Background(), resp, map[string]any{"output_filename": "shot.png"}, "", "gs://bkt/pfx")
+		if err != nil {
+			t.Fatalf("processImageResponse error: %v", err)
+		}
+		if links := resourceLinks(t, res); len(links) != 1 {
+			t.Fatalf("GCS sink produced %d resource_link(s), want 1", len(links))
+		}
+
+		// The exact text the unchanged builder emits: model text, then the signed-URL
+		// line, then the saved-files summary — all TrimSpace'd.
+		want := fmt.Sprintf(
+			"here you go\n\nSigned URL for pfx/shot.png (valid %s):\nhttps://signed.example/x\n\nGenerated and saved 1 image(s): gs://bkt/pfx/shot.png",
+			(24 * time.Hour).String(),
+		)
+		if got := firstText(t, res); got != want {
+			t.Errorf("back-compat text drift:\n got=%q\nwant=%q", got, want)
+		}
+	})
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/README.md
@@ -21,6 +21,8 @@ The server exposes the following tools:
     *   `duration` (number, optional): Duration of the generated video in seconds. Note: the supported duration range is model-dependent.
     *   `seed` (number, optional): Non-negative integer seed for best-effort reproducible video generation.
 
+Because Veo always writes to GCS, every Veo tool appends one MCP `resource_link` content item per generated video (`uri` = the `gs://` URI, plus `name`, `mimeType`, and a 1-based `description`). The text summary is unchanged. See [Resource Links for GCS Outputs](../README.md#resource-links-for-gcs-outputs).
+
 ### 2. `veo_i2v` (Image-to-Video)
 
 *   **Description**: Generate a video from an input image (and optional prompt) using Veo. Video is saved to GCS and optionally downloaded locally. Supported image MIME types: image/jpeg, image/png.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo_matrix_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-veo-go/veo_matrix_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestVeoResourceLinkMatrix completes the cross-cutting sink matrix for veo at the
+// resource_link seam (design #483 P4 Test Plan). The GCS multi-video and inline
+// legs are covered by veo_resource_link_test.go; this adds the local-only and
+// both-local+GCS legs and asserts the leading text (content[0]) is preserved
+// byte-for-byte (back-compat) in every case.
+func TestVeoResourceLinkMatrix(t *testing.T) {
+	// Local-only sink: text has a local saved line, no gs:// URI resolved -> no link.
+	t.Run("local-only sink -> no resource_link, text byte-identical", func(t *testing.T) {
+		localText := "Video(s) saved locally to /tmp/out/clip.mp4"
+		text := mcp.TextContent{Type: "text", Text: localText}
+		content := appendVeoResourceLinks([]mcp.Content{text}, nil, "video/mp4")
+		if len(content) != 1 {
+			t.Fatalf("local-only produced %d content items, want 1 (no link)", len(content))
+		}
+		if got := content[0].(mcp.TextContent).Text; got != localText {
+			t.Errorf("text drift on local-only path:\n got=%q\nwant=%q", got, localText)
+		}
+	})
+
+	// Both local+GCS: text has BOTH the local and gs:// lines; one link per gs://
+	// URI is appended and content[0] is preserved byte-for-byte.
+	t.Run("both local+GCS -> resource_link present, text byte-identical", func(t *testing.T) {
+		bothText := "Video(s) saved locally to /tmp/out/clip.mp4 and uploaded to gs://bucket/veo_outputs/clip.mp4"
+		text := mcp.TextContent{Type: "text", Text: bothText}
+		content := appendVeoResourceLinks([]mcp.Content{text},
+			[]string{"gs://bucket/veo_outputs/clip.mp4"}, "video/mp4")
+		if len(content) != 2 {
+			t.Fatalf("both sink produced %d content items, want 2 (text + link)", len(content))
+		}
+		if got := content[0].(mcp.TextContent).Text; got != bothText {
+			t.Errorf("text drift on both path (back-compat):\n got=%q\nwant=%q", got, bothText)
+		}
+		link, ok := content[1].(mcp.ResourceLink)
+		if !ok {
+			t.Fatalf("content[1] = %T, want mcp.ResourceLink", content[1])
+		}
+		if link.URI != "gs://bucket/veo_outputs/clip.mp4" {
+			t.Errorf("resource_link URI = %q, want gs://bucket/veo_outputs/clip.mp4", link.URI)
+		}
+		if link.MIMEType != "video/mp4" {
+			t.Errorf("resource_link MIMEType = %q, want video/mp4", link.MIMEType)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Phase-4 final polish for #483 (**no new features, no contract change, NO-BUMP**).
Builds directly on the merged #483 feat commit. Adds test coverage and docs for the
MCP `resource_link` content item returned per GCS artifact.

### Tests (`test(mcp-genmedia): ...`)
- **Cross-cutting sink matrix** across nanobanana, gemini-image, imagen (t2i + edit),
  veo, lyria, and the shared omni renderer. Each server covers: GCS sink (link present,
  correct uri/mimeType/count/order), inline sink (no link), local-only sink (no link),
  both local+GCS (link present, local text preserved), and **back-compat** (text
  byte-for-byte identical to pre-#483 on the GCS path — asserted explicitly).
- **Real env-gated live GCS leg** for nanobanana (resolves the P1 review finding that
  the live leg was a log-only placeholder): gated behind `GENMEDIA_BUCKET`, creates a
  throwaway prefix, uploads via the real persistence path, round-trips the bytes back
  from GCS, and cleans up. Skips cleanly when `GENMEDIA_BUCKET` is unset (CI/default).
- All legs are network-free / creds-free by default except the gated live leg.

### Docs (`docs(mcp-genmedia): ...`)
- New **"Resource Links for GCS Outputs"** section in the shared README and docs-site
  index (matching the `output_filename` doc style), plus a per-server note for
  nanobanana, gemini-image, imagen, veo, and lyria. Documents: one `resource_link`
  per GCS artifact, `uri` = durable `gs://` identity (not the expiring signed URL),
  `name`/`mimeType`/1-based `description`, GCS-sink-only, text unchanged.
- Explicitly notes **chirp3, gemini TTS, and avtool are out of scope**.

## Verification
Build + vet + test pass for every touched module **both ways** — with the go.work
workspace and standalone with `GOWORK=off` (CI-style): mcp-common, mcp-nanobanana-go,
mcp-gemini-go, mcp-imagen-go, mcp-veo-go, mcp-lyria-go, mcp-omni-go.

`VERSION` untouched; no production code changed (tests + docs only).

Do not merge — coordinator gates merges.