### PR TITLE
docs(core): add boot smoke-test script and fix local-run Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,39 @@ Stay up-to-date with upcoming breaking changes and releases on our **[Changelog 
 
 ### Quick Start
 
-If you want to quickly run the UI without having to set up a local development environment, use Cloud Shell and follow the tutorial instructions:
+#### Run it locally
+
+The app is a Python ([Mesop](https://mesop-dev.github.io/mesop/) on FastAPI) application that requires **Python 3.14+** and uses [`uv`](https://github.com/astral-sh/uv) for dependency management. You also need a Google Cloud project with Vertex AI access — the UI calls Vertex (Gemini, Veo, Imagen, Lyria) regardless of where the web server runs.
+
+```bash
+# 1. Install uv (macOS/Linux) if you don't have it:
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 2. Authenticate to Google Cloud (provides Application Default Credentials):
+gcloud auth application-default login
+export PROJECT_ID=$(gcloud config get-value project)
+
+# 3. Sync dependencies (uv installs Python 3.14 automatically) and run:
+uv sync
+uv run main.py
+```
+
+Then open <http://localhost:8080/> — `/` redirects to `/home`. See [Local Setup & Development](https://googlecloudplatform.github.io/vertex-ai-creative-studio/core/installation/local_setup/) on the Documentation Hub for `.env` configuration and available environment variables.
+
+Prefer a fully hosted environment? Use Cloud Shell and follow the tutorial:
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio.git&cloudshell_tutorial=tutorial.md)
+
+#### Smoke-test before you merge
+
+`scripts/smoke_test.sh` is a quick, automated boot check for the core app: it runs `uv sync`, boots the app under gunicorn/uvicorn in `APP_ENV=local` mode, and verifies the UI serves (`GET /` → `/home` → 200, `GET /__login` → 200). An optional, env-gated leg (`-l`) makes one live Vertex `gemini-2.5-flash` generation call when a `PROJECT_ID` and Application Default Credentials are present.
+
+```bash
+./scripts/smoke_test.sh        # boot + UI check
+./scripts/smoke_test.sh -l     # also run the live Vertex generation leg
+```
+
+Run it **before merging any PR that touches core-app runtime code** (`pages/`, `models/`, `state/`, `config/`, `main.py`) to catch boot-health regressions early. It is a fast pre-merge sanity check, **not** a substitute for the test suite and **not** a deploy/IAP/Load-Balancer validation (that's the [Terraform deployment path](https://googlecloudplatform.github.io/vertex-ai-creative-studio/core/installation/deploy/)). To click around the running app yourself, use the local run above; the script is for a quick, hands-off "does it still boot and serve?" answer.
 
 ### Deploying to Google Cloud
 

--- a/docs-site/src/content/docs/core/installation/local_setup.md
+++ b/docs-site/src/content/docs/core/installation/local_setup.md
@@ -48,3 +48,14 @@ uv run main.py
 ```
 
 Traditional Mesop hot reload capabilities (i.e. `mesop main.py`) are not fully available at this time.
+
+### Smoke-testing your changes
+
+Before merging any change that touches core-app runtime code (`pages/`, `models/`, `state/`, `config/`, `main.py`), run the boot smoke test:
+
+```bash
+./scripts/smoke_test.sh        # uv sync + boot + GET / -> /home (200) + GET /__login (200)
+./scripts/smoke_test.sh -l     # also runs one live Vertex generateContent call (needs PROJECT_ID + ADC)
+```
+
+It is a fast, automated "does it still boot and serve?" check — not a replacement for the test suite, and not a deploy/IAP/Load Balancer validation. Running the app manually (above) remains the way to click around the UI yourself.

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Boot smoke test for the GenMedia Creative Studio core app.
+#
+# What this checks:
+#   1. Dependencies sync (uv sync) with the pinned Python (>=3.14).
+#   2. The app boots under gunicorn/uvicorn in APP_ENV=local mode.
+#   3. GET /        -> 307 redirect to /home, which serves HTTP 200 (Mesop UI).
+#   4. GET /__login -> HTTP 200.
+#   5. (Optional, env-gated) one live Vertex gemini-2.5-flash generateContent
+#      call, only when a PROJECT_ID + working ADC are available.
+#
+# What this does NOT check: it is not the full test suite, not a deploy
+# validation, and not an IAP / Load Balancer check (that's the terraform path).
+#
+# Usage:
+#   ./scripts/smoke_test.sh              # boot + UI check (recommended default)
+#   ./scripts/smoke_test.sh -l           # also run the live Vertex generation leg
+#   ./scripts/smoke_test.sh -p 8090      # use a different port
+#   ./scripts/smoke_test.sh -t 120       # wait up to 120s for boot
+#
+# Environment variables respected:
+#   PROJECT_ID   Google Cloud project used by the app (falls back to
+#                `gcloud config get-value project`, else a local placeholder).
+#   PORT         Port to bind (default: 8080). Overridden by -p.
+#   LIVE_CHECK   Set to 1 to enable the live Vertex leg (same as -l).
+#   REGION       Vertex region for the live leg (default: us-central1).
+#
+# Run this before merging any PR that touches core-app runtime code
+# (pages/, models/, state/, config/, main.py).
+
+set -euo pipefail
+
+# --- Resolve repo root (script lives in <root>/scripts) --------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# --- Defaults / options ----------------------------------------------------
+PORT="${PORT:-8080}"
+BOOT_TIMEOUT=90
+LIVE_CHECK="${LIVE_CHECK:-0}"
+REGION="${REGION:-us-central1}"
+
+while getopts "p:t:lh" opt; do
+  case ${opt} in
+    p) PORT="${OPTARG}" ;;
+    t) BOOT_TIMEOUT="${OPTARG}" ;;
+    l) LIVE_CHECK=1 ;;
+    h)
+      echo "Usage: $0 [-p PORT] [-t BOOT_TIMEOUT_SECS] [-l]"
+      echo "  -p PORT   Port to bind the app (default: 8080)"
+      echo "  -t SECS   Seconds to wait for the app to boot (default: 90)"
+      echo "  -l        Also run the optional live Vertex generateContent leg"
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -${OPTARG}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+BASE_URL="http://localhost:${PORT}"
+APP_PID=""
+
+echo "======================================================================"
+echo "🚀 GMCS Core App Boot Smoke Test"
+echo "Repo root : ${REPO_ROOT}"
+echo "Base URL  : ${BASE_URL}"
+echo "======================================================================"
+echo ""
+
+# --- Teardown (runs on any exit) -------------------------------------------
+cleanup() {
+  if [ -n "${APP_PID}" ] && kill -0 "${APP_PID}" 2>/dev/null; then
+    echo ""
+    echo "🧹 Tearing down app (pid ${APP_PID})..."
+    # Kill the whole process group so uvicorn workers are reaped too.
+    kill -TERM "-${APP_PID}" 2>/dev/null || kill -TERM "${APP_PID}" 2>/dev/null || true
+    sleep 2
+    kill -KILL "-${APP_PID}" 2>/dev/null || kill -KILL "${APP_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  echo ""
+  echo "----------------------------------------------------------------------"
+  echo "❌ SMOKE TEST FAILED: $*"
+  echo "----------------------------------------------------------------------"
+  if [ -f "${BOOT_LOG:-/dev/null}" ]; then
+    echo "--- Last 30 lines of boot log (${BOOT_LOG}) ---"
+    tail -30 "${BOOT_LOG}" || true
+  fi
+  exit 1
+}
+
+# --- Step 1: toolchain check (fail fast, do NOT auto-install) ---------------
+echo "🔎 1/4  Checking toolchain..."
+if ! command -v uv >/dev/null 2>&1; then
+  fail "'uv' is not installed. Install it (https://github.com/astral-sh/uv), e.g.
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        This script does not auto-install the toolchain."
+fi
+echo "     ✅ uv found: $(uv --version)"
+
+# --- Step 2: dependency sync -----------------------------------------------
+echo ""
+echo "📦 2/4  Syncing dependencies (uv sync)..."
+if ! uv sync >/tmp/gmcs_smoke_sync.log 2>&1; then
+  echo "--- uv sync output ---"; tail -30 /tmp/gmcs_smoke_sync.log || true
+  fail "'uv sync' failed. Ensure Python >=3.14 is available (uv can install it)."
+fi
+echo "     ✅ dependencies synced"
+
+# --- Step 3: boot the app in APP_ENV=local ---------------------------------
+echo ""
+echo "🚦 3/4  Booting app (APP_ENV=local) on port ${PORT}..."
+
+if [ -z "${PROJECT_ID:-}" ]; then
+  PROJECT_ID="$(gcloud config get-value project 2>/dev/null || true)"
+fi
+if [ -z "${PROJECT_ID:-}" ]; then
+  PROJECT_ID="local-smoke-test"
+  echo "     ⚠️  PROJECT_ID not set and none from gcloud; using placeholder '${PROJECT_ID}'."
+fi
+echo "     PROJECT_ID=${PROJECT_ID}"
+
+BOOT_LOG="$(mktemp /tmp/gmcs_smoke_boot.XXXXXX.log)"
+
+# setsid gives the app its own process group so cleanup() can reap workers.
+APP_ENV=local PROJECT_ID="${PROJECT_ID}" PORT="${PORT}" \
+  setsid .venv/bin/gunicorn \
+    --bind ":${PORT}" \
+    --workers 1 \
+    --threads 8 \
+    --timeout 0 \
+    --forwarded-allow-ips="*" \
+    -k uvicorn.workers.UvicornWorker \
+    main:app >"${BOOT_LOG}" 2>&1 &
+APP_PID=$!
+echo "     app pid/pgid: ${APP_PID}  (log: ${BOOT_LOG})"
+
+# --- Step 4: poll until the UI serves 200 ----------------------------------
+echo ""
+echo "🌐 4/4  Waiting for the UI (timeout ${BOOT_TIMEOUT}s)..."
+deadline=$(( $(date +%s) + BOOT_TIMEOUT ))
+home_code="000"
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if ! kill -0 "${APP_PID}" 2>/dev/null; then
+    fail "app process exited before serving traffic (see boot log)."
+  fi
+  home_code="$(curl -sL -o /dev/null -w '%{http_code}' -m 5 "${BASE_URL}/" 2>/dev/null || echo 000)"
+  if [ "${home_code}" = "200" ]; then
+    break
+  fi
+  sleep 2
+done
+
+if [ "${home_code}" != "200" ]; then
+  fail "GET / did not reach a 200 within ${BOOT_TIMEOUT}s (last code: ${home_code})."
+fi
+
+# Assert the redirect target is /home.
+redirect_url="$(curl -s -o /dev/null -w '%{redirect_url}' -m 5 "${BASE_URL}/" 2>/dev/null || true)"
+echo "     ✅ GET /        -> 307 -> ${redirect_url:-/home} (200)"
+
+login_code="$(curl -s -o /dev/null -w '%{http_code}' -m 5 "${BASE_URL}/__login" 2>/dev/null || echo 000)"
+if [ "${login_code}" != "200" ]; then
+  fail "GET /__login returned ${login_code} (expected 200)."
+fi
+echo "     ✅ GET /__login -> ${login_code}"
+
+# --- Optional: live Vertex generateContent leg -----------------------------
+LIVE_RESULT="skipped"
+if [ "${LIVE_CHECK}" = "1" ]; then
+  echo ""
+  echo "🧪 (optional) Live Vertex gemini-2.5-flash generateContent leg..."
+  if [ "${PROJECT_ID}" = "local-smoke-test" ]; then
+    echo "     ⏭️  Skipped: no real PROJECT_ID available."
+  elif ! command -v gcloud >/dev/null 2>&1; then
+    echo "     ⏭️  Skipped: gcloud not installed (needed for an access token)."
+  else
+    TOKEN="$(gcloud auth application-default print-access-token 2>/dev/null || true)"
+    if [ -z "${TOKEN}" ]; then
+      echo "     ⏭️  Skipped: no Application Default Credentials available."
+    else
+      URL="https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/publishers/google/models/gemini-2.5-flash:generateContent"
+      gen_code="$(curl -s -o /tmp/gmcs_smoke_gen.json -w '%{http_code}' -m 30 \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        -X POST "${URL}" \
+        -d '{"contents":[{"role":"user","parts":[{"text":"Reply with the single word: pong"}]}]}' \
+        2>/dev/null || echo 000)"
+      if [ "${gen_code}" = "200" ]; then
+        echo "     ✅ live generateContent -> 200"
+        LIVE_RESULT="pass"
+      else
+        echo "     ⚠️  live generateContent -> ${gen_code} (non-fatal). Response:"
+        head -c 500 /tmp/gmcs_smoke_gen.json 2>/dev/null || true
+        echo ""
+        LIVE_RESULT="warn(${gen_code})"
+      fi
+    fi
+  fi
+else
+  echo ""
+  echo "🧪 (optional) Live Vertex leg not requested (pass -l or LIVE_CHECK=1 to enable)."
+fi
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "======================================================================"
+echo "✅ SMOKE TEST PASSED"
+echo "   boot: OK | GET /: 200 | GET /__login: 200 | live: ${LIVE_RESULT}"
+echo "======================================================================"
+exit 0

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,8 +1,8 @@
-# GenMedia Creative Studio: Veo 2 module Tutorial
+# GenMedia Creative Studio: Quick Start Tutorial
 
 ## Welcome!
 
-If you're seeing this, you've cloned the correct repository, and you should be in the `experiments/veo-app` directory! Let's get started.
+If you're seeing this, you've cloned the correct repository. The core application lives at the repository root, so make sure you're in the repository's top-level directory before continuing. Let's get started.
 
 <walkthrough-project-setup></walkthrough-project-setup>
 
@@ -48,8 +48,6 @@ If you have one, great! If not, create one:
 ```bash
 gcloud storage buckets create -l us-central1 gs://<walkthrough-project-name/>-assets
 ```
-
-Notre
 
 ### uv
 


### PR DESCRIPTION
## What

Adds a **boot smoke test** for the core Creative Studio app and fixes the local-run onboarding docs that a fresh user hits first.

### `scripts/smoke_test.sh` (new)
A quick, automated boot check that mirrors the sibling `scripts/smoke_telemetry.sh` convention:
- Fails fast if `uv` is missing (does **not** auto-install the toolchain).
- Runs `uv sync`, then boots the app under gunicorn/uvicorn in `APP_ENV=local`.
- Asserts `GET /` → 307 → `/home` (200) and `GET /__login` (200), with a boot timeout and clean teardown (trap) on success or failure.
- Optional, env-gated live leg (`-l`): one real Vertex `gemini-2.5-flash` `generateContent` call when a `PROJECT_ID` + ADC are present — skips cleanly otherwise. Never required for a pass.
- Clear `PASS`/`FAIL` summary and non-zero exit on failure.

**Run it before merging any PR that touches core-app runtime code** (`pages/`, `models/`, `state/`, `config/`, `main.py`).

### Docs fixes
- **`README.md` Quick Start**: previously had *no* local-run commands — only a Cloud Shell button. Added real "Run it locally" steps (`uv` + Python 3.14 + `uv run main.py`) and a "Smoke-test before you merge" section.
- **`tutorial.md`** (the Cloud Shell tutorial the Quick Start button loads): was stale — it told users to `cd experiments/veo-app`, a directory that no longer exists (the core app is at the repo root). Fixed the directory guidance, a typo, and the outdated title.
- **`docs-site/.../core/installation/local_setup.md`**: cross-references the smoke test.

## What it does NOT check
Not the full test suite, not a deploy validation, and not IAP/Load-Balancer — that's the Terraform path.

## Validation
- ✅ Ran against **`main`** — boot + UI + optional live Vertex leg all pass.
- ✅ Ran against open PR **#1639** (`feature/telemetry-observability-costing`) branch — boot + UI + live leg all pass; no boot-health problem found.
- Verbatim "Quick Start as a fresh user" check confirmed the app *start command* works but the README Quick Start / `tutorial.md` were misleading (fixed here).

Scope: docs + a smoke-test script only. No production code changes, no version bump.