### PR TITLE
fix(omni): lock Mode/Model/Aspect Ratio/Duration on follow-up turns (#1644)

### DIFF
--- a/pages/omni.py
+++ b/pages/omni.py
@@ -327,7 +327,24 @@ def render_chat_thread(state: PageState) -> None:
 
 def render_settings_panel(state: PageState, _app_state: AppState) -> None:
     """Render the configuration settings panel."""
+    # Once a conversation has started, lock the generation settings so the
+    # whole conversation stays consistent. This mirrors the turn-gating used
+    # for the left pane above (see render_page_content).
+    chat_started = (
+        bool(state.previous_interaction_id)
+        or len(json.loads(state.chat_messages_json)) > 0
+    )
+
     me.text("Model Settings", type="headline-6")
+
+    if chat_started:
+        me.text(
+            "Settings are locked after the first turn to keep this "
+            "conversation consistent. Start a new conversation (Reset Chat) "
+            "to change them.",
+            type="caption",
+            style=me.Style(font_style="italic"),
+        )
 
     me.text("Generation Mode", type="body-2")
     me.select(
@@ -340,6 +357,7 @@ def render_settings_panel(state: PageState, _app_state: AppState) -> None:
         ],
         value=state.omni_mode,
         on_selection_change=on_mode_change,
+        disabled=chat_started,
     )
 
     me.text("Omni Model Version", type="body-2")
@@ -351,6 +369,7 @@ def render_settings_panel(state: PageState, _app_state: AppState) -> None:
         ],
         value=state.omni_model,
         on_selection_change=on_model_change,
+        disabled=chat_started,
     )
 
     me.text("Aspect Ratio", type="body-2")
@@ -362,6 +381,7 @@ def render_settings_panel(state: PageState, _app_state: AppState) -> None:
         ],
         value=state.aspect_ratio,
         on_selection_change=on_aspect_ratio_change,
+        disabled=chat_started,
     )
 
     me.text(f"Video Duration: {state.video_length}s", type="body-2")
@@ -370,6 +390,7 @@ def render_settings_panel(state: PageState, _app_state: AppState) -> None:
         max=10,
         value=state.video_length,
         on_value_change=on_duration_change,
+        disabled=chat_started,
     )
 
     me.box(style=me.Style(height=24))


### PR DESCRIPTION
## Summary

Fixes #1644. Locks the four Omni generation controls once a conversation has started so the whole conversation stays consistent.

In `pages/omni.py` `render_settings_panel`, all four controls previously stayed editable on follow-up turns. This change:

- Computes `chat_started` using the same turn-gating condition already used for the left pane (`bool(state.previous_interaction_id) or len(json.loads(state.chat_messages_json)) > 0`).
- Passes `disabled=chat_started` to all four controls: **Mode** select, **Model** select, **Aspect Ratio** select, **Duration** slider (rendered as disabled, not hidden).
- Adds a short explanatory caption when locked: *"Settings are locked after the first turn to keep this conversation consistent. Start a new conversation (Reset Chat) to change them."*
- `on_reset_chat` already clears `previous_interaction_id` / `chat_messages_json`, so all four controls **auto-re-enable on Reset Chat** — no handler change needed.

## Why lock all four (not just Mode)

An empirical spike confirmed Model, Aspect Ratio, and Duration all genuinely flow into the follow-up-turn API call: Model as the structured `model=` param; Aspect Ratio / Duration injected into the outbound prompt text. Leaving them editable lets a user silently change what is sent mid-conversation.

## FYI / follow-up candidate (NOT addressed here)

The spike also found that `omni_mode` is effectively **inert at the API level on follow-up turns** — on the multi-turn branch (`models/omni.py:179-193`) the mode-dependent media-append helper is never called, so the reference media Mode selects is not reapplied on follow-ups. Whether reference-media selection *should* persist/reapply on follow-ups is a separate, deeper behavioral question and is **out of scope** for this UI-lock fix. Noting it here as a follow-up candidate; `models/omni.py` is intentionally untouched.

## Verification

- `python -m py_compile pages/omni.py` under the pinned Python (3.14, via `uv`) — clean.
- `scripts/smoke_test.sh` — **PASSED** (boot OK, `GET /` -> 307 -> /home 200, `GET /__login` 200).
- No new tests required for a UI-attribute change. Existing `test/test_omni.py` asserts request-building in `models/omni.py`, not UI enabled/disabled state — nothing depends on the old always-enabled behavior.
