### PR TITLE
chore: bump core app version to 1.13.0 (MINOR)

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -55,7 +55,7 @@ class NavConfig(BaseModel):
 class Default:
     """Defaults class."""
 
-    VERSION: str = "1.12.3"  # Fallback if package metadata is missing
+    VERSION: str = "1.13.0"  # Fallback if package metadata is missing
     BUILD_COMMIT: str = ""
     BUILD_DATE: str = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vertex-ai-genmedia-creative-studio"
-version = "1.12.3"
+version = "1.13.0"
 description = "GenMedia Creative Studio - Veo, Lyria, Nano Banana, Imagen, Gemini, Gemini TTS"
 readme = "README.md"
 requires-python = ">=3.14, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -2219,7 +2219,7 @@ wheels = [
 
 [[package]]
 name = "vertex-ai-genmedia-creative-studio"
-version = "1.12.3"
+version = "1.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
## Summary
Version-only housekeeping PR: bump the **core app** version from `1.12.3` → `1.13.0` (**MINOR**), per explicit owner request as its own standalone follow-on PR.

The MINOR bump reflects the batch of notable changes that landed since `1.12.3`:
- telemetry / observability feature (#1639)
- image-aware rewriter (#1642)
- omni UX fix (#1644)

## Files changed (version-of-record, in lockstep)
- `pyproject.toml` — `[project] version`
- `config/default.py` — `Default.VERSION` fallback constant
- `uv.lock` — project version entry (regenerated via `uv lock`)

Scope is the **core app only**. Nothing under `experiments/` is touched (that suite versions separately via release-please).

## Verification
- `uv lock` / `uv sync` — succeed; `pyproject.toml` well-formed, lockfile updated to `1.13.0`.
- `config.default.Default.VERSION` fallback resolves to `1.13.0`.
- `scripts/smoke_test.sh` — **PASSED** (app boots under `APP_ENV=local`; `GET /` → 307 → `/home` 200; `GET /__login` → 200).

No other changes.