### PR TITLE
fix(veo): repoint Character Consistency video to veo-3.1-fast (GA sunset)

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -189,7 +189,7 @@ class Default:
     CHARACTER_CONSISTENCY_IMAGEN_MODEL: str = "imagen-3.0-capability-001"
     CHARACTER_CONSISTENCY_VEO_MODEL: str = os.environ.get(
         "CHARACTER_CONSISTENCY_VEO_MODEL",
-        "veo-3.0-fast-generate-001",
+        "veo-3.1-fast-generate-001",
     )
     CHARACTER_CONSISTENCY_GEMINI_MODEL: str = os.environ.get(
         "CHARACTER_CONSISTENCY_GEMINI_MODEL",


### PR DESCRIPTION
## What
Repoint the **Character Consistency (video)** active code path off the GA Veo endpoint being sunset on **2026-06-30**.

`config/default.py`: `CHARACTER_CONSISTENCY_VEO_MODEL` default
`veo-3.0-fast-generate-001` → `veo-3.1-fast-generate-001`.

This is the **only functional edit** in this PR (Phase V1 — active-path repoint).

## Why
GA Veo endpoints sunset **2026-06-30**; after that any core-app path naming `veo-3.0-fast-generate-001` will 404. Character Consistency consumes this constant as an always-on hardcoded path (`models/character_consistency.py:252,361`), so it is an active outage risk — not merely a selectable dropdown entry.

## Verification
- **Static:** the new value resolves through `VEO_MODELS` to `version_id` `3.1-fast` (`config/veo_models.py`), whose `supported_modes` are `[t2v, i2v, interpolation, r2v]`. The actual generation call (`models/character_consistency.py:360`, `generate_videos(..., image=input_image)`) is **i2v**, which 3.1-fast supports. The modes Character Consistency uses (t2v/i2v/interpolation) are all covered. No call-site change required.
- **Tests:** relevant unit tests pass — `test_veo_i2v_model_selection.py`, `test_character_consistency_page.py`, `test_character_consistency_imagen.py` (5 passed, 1 integration deselected).
- **Live E2E:** the full config → Vertex → rendered-video path is **not runnable in the sandbox** (`@pytest.mark.integration` tests require real Vertex credentials + a GCP project). Not executed; not faked. The swap is proven statically (constant flows to the i2v call site; endpoint id is a valid `VEO_MODELS` entry; modes covered).

## Scope
Core app only. The three sunsetting `VEO_MODELS` dropdown entries (`config/veo_models.py`) are intentionally **not** touched here — that is Phase V2. `experiments/` untouched.

## Note (out of scope for V1)
`dotenv.template:210-211` still documents the old default (`veo-3.0-fast-generate-001`) as an example. Left unchanged to keep V1 to the single functional edit; flagging for the docs reconciliation in V2.