### PR TITLE
fix(veo): remove GA-sunset Veo models from dropdowns; green Veo tests + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ GenMedia Creative Studio is a web application showcasing Google Cloud's generati
 Current featureset:
 
 - **Image:** Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite), Gemini Flash Image Generation (Nano Banana 2), Gemini 3 Pro Image (Nano Banana Pro), Virtual Try-On
-- **Video:** Gemini Omni Flash, Veo 3.1, Veo 3, Veo 2
+- **Video:** Gemini Omni Flash, Veo 3.1, Veo 3
 - **Music:** Lyria 3 & 2
 - **Speech:** Chirp 3 HD, Gemini Text to Speech
 - **Workflows:** Character Consistency, Shop the Look, Starter Pack Moodboard, Interior Designer

--- a/config/veo_models.py
+++ b/config/veo_models.py
@@ -52,58 +52,9 @@ class VeoModelConfig:
 
 # This list is the single source of truth for all VEO model configurations.
 VEO_MODELS: List[VeoModelConfig] = [
-    VeoModelConfig(
-        version_id="2.0",
-        model_name="veo-2.0-generate-001",
-        display_name="Veo 2.0",
-        supported_modes=["t2v", "i2v", "interpolation"],
-        supported_aspect_ratios=["16:9", "9:16"],
-        resolutions=["720p"],
-        min_duration=5,
-        max_duration=8,
-        default_duration=5,
-        max_samples=4,
-        default_samples=1,
-        supports_prompt_enhancement=True,
-        default_prompt_enhancement=True,
-        supports_video_extension=True,
-        supported_extension_durations=[7],
-    ),
-    VeoModelConfig(
-        version_id="3.0",
-        model_name="veo-3.0-generate-001",
-        display_name="Veo 3.0",
-        supported_modes=["t2v", "i2v"],
-        supported_aspect_ratios=["16:9", "9:16"],
-        resolutions=["720p", "1080p"],
-        min_duration=4,
-        max_duration=8,
-        default_duration=8,
-        max_samples=4,
-        default_samples=1,
-        supports_prompt_enhancement=True,
-        requires_prompt_enhancement=True,
-        default_prompt_enhancement=True,
-        supported_durations=[4, 6, 8],
-
-    ),
-    VeoModelConfig(
-        version_id="3.0-fast",
-        model_name="veo-3.0-fast-generate-001",
-        display_name="Veo 3.0 Fast",
-        supported_modes=["t2v", "i2v"],
-        supported_aspect_ratios=["16:9", "9:16"],
-        resolutions=["720p", "1080p"],
-        min_duration=4,
-        max_duration=8,
-        default_duration=8,
-        max_samples=4,
-        default_samples=1,
-        supports_prompt_enhancement=True,
-        requires_prompt_enhancement=True,
-        default_prompt_enhancement=True,
-        supported_durations=[4, 6, 8],
-    ),
+    # NOTE: The GA endpoints veo-2.0-generate-001, veo-3.0-generate-001, and
+    # veo-3.0-fast-generate-001 were removed here as part of the GA sunset
+    # (see GA deprecation). Veo 3.1 models are the supported replacements.
     VeoModelConfig(
         version_id="3.1-fast",
         model_name="veo-3.1-fast-generate-001",

--- a/docs-site/src/content/docs/core/index.md
+++ b/docs-site/src/content/docs/core/index.md
@@ -58,7 +58,7 @@ GenMedia Creative Studio is a web application showcasing Google Cloud's generati
 Current featureset
 
 - Image: Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite), Gemini 3.1 Flash Image Generation (Nano Banana 2), Gemini 3 Pro Image (Nano Banana Pro), Imagen 3, Imagen 4, Virtual Try-On
-- Video: Gemini Omni Flash, Veo 3.1, Veo 3, Veo 2
+- Video: Gemini Omni Flash, Veo 3.1, Veo 3
 - Music: Lyria
 - Speech: Chirp 3 HD, Gemini Text to Speech
 - Workflows: Character Consistency, Shop the Look, Starter Pack Moodboard, Interior Designer

--- a/docs-site/src/content/docs/core/usage.md
+++ b/docs-site/src/content/docs/core/usage.md
@@ -18,7 +18,7 @@ Interact directly with the raw generative models to create single-modality outpu
     *   **Edit Images:** Edit existing images using powerful inpainting and outpainting tools.
 *   **Video Generation:** 
     *   **Gemini Omni:** Create, animate, reference, and iteratively edit video in a multi-turn chat workspace using Gemini Omni Flash.
-    *   **Veo:** Create high-fidelity videos from text or image prompts using Veo 2, Veo 3, and Veo 3.1.
+    *   **Veo:** Create high-fidelity videos from text or image prompts using Veo 3 and Veo 3.1.
 *   **Audio & Speech Generation:** 
     *   **Lyria:** Generate complex music tracks and thematic scores from text prompts.
     *   **Gemini TTS:** Synthesize expressive and highly-controllable text-to-speech.

--- a/dotenv.template
+++ b/dotenv.template
@@ -207,8 +207,8 @@ PROJECT_ID=
 # USE_MEDIA_PROXY=true
 
 # [OPTIONAL] Model used specifically in the Character Consistency workflow.
-# Default: veo-3.0-fast-generate-001
-# CHARACTER_CONSISTENCY_VEO_MODEL=veo-3.0-fast-generate-001
+# Default: veo-3.1-fast-generate-001
+# CHARACTER_CONSISTENCY_VEO_MODEL=veo-3.1-fast-generate-001
 
 # [OPTIONAL] Gemini model used in the Character Consistency workflow.
 # Default: Same as MODEL_ID

--- a/test/test_veo_api_integration.py
+++ b/test/test_veo_api_integration.py
@@ -12,18 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import os
+import sys
 
 import pytest
-from models.veo import text_to_video
-from config.veo_models import VEO_MODELS
 
-# Parametrize the test to run for each model defined in the configuration.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from config.veo_models import get_models_by_mode
+from models.requests import VideoGenerationRequest
+from models.veo import generate_video
+
+# Parametrize over each text-to-video capable model in the configuration.
+T2V_MODELS = get_models_by_mode("t2v")
+
+
 @pytest.mark.integration
-@pytest.mark.parametrize("model_config", VEO_MODELS)
-def test_veo_t2v_api_call(gcs_bucket_for_tests, model_config):
+@pytest.mark.parametrize(
+    "model_config", T2V_MODELS, ids=[m.version_id for m in T2V_MODELS]
+)
+def test_veo_t2v_api_call(model_config):
     """An integration test that calls the real VEO API for text-to-video.
-    
+
     This test is marked as 'integration' and will be skipped unless explicitly
     run with 'pytest -m integration'. It verifies that the application can
     successfully communicate with the live VEO API and receive a valid response
@@ -31,46 +41,34 @@ def test_veo_t2v_api_call(gcs_bucket_for_tests, model_config):
     """
     # --- Arrange ---
     # Use a simple, reliable prompt that is unlikely to trigger content filters.
-    prompt = "a happy dog running on a sunny beach"
-    output_gcs = f"{gcs_bucket_for_tests}/integration_tests"
-
-    # --- Act ---
-    # Call the actual text_to_video function, which will make a real API call.
-    # The duration and other parameters are now pulled from the model's config.
-    operation_result = text_to_video(
-        model=model_config.version_id,
-        prompt=prompt,
-        seed=42,
-        aspect_ratio=model_config.supported_aspect_ratios[0], # Use the first supported aspect ratio
-        sample_count=model_config.default_samples,
-        output_gcs=output_gcs,
-        enable_pr=model_config.supports_prompt_enhancement,
+    request = VideoGenerationRequest(
+        prompt="a happy dog running on a sunny beach",
+        model_version_id=model_config.version_id,
+        aspect_ratio=model_config.supported_aspect_ratios[0],
+        resolution=model_config.resolutions[0],
         duration_seconds=model_config.default_duration,
+        video_count=model_config.default_samples,
+        enhance_prompt=model_config.supports_prompt_enhancement,
+        generate_audio=False,
+        person_generation="Allow (Adults only)",
     )
 
+    # --- Act ---
+    # Call the actual generation function, which makes a real API call and
+    # returns (video_uris, resolution).
+    video_uris, resolution = generate_video(request)
+
     # --- Assert ---
-    # Print the full response object for debugging purposes.
-    print(f"\n--- Full API Response for model {model_version} ---")
-    print(operation_result)
+    print(f"\n--- API response for model {model_config.version_id} ---")
+    print(video_uris)
     print("----------------------------------------------------")
 
-    # Verify that the operation completed successfully and returned a valid response.
-    assert operation_result is not None, "The API operation result should not be None."
-    assert operation_result.get("done"), f"The 'done' flag in the operation should be True. Full response: {operation_result}"
+    assert video_uris, "The API should return at least one generated video URI."
+    for uri in video_uris:
+        assert uri.startswith("gs://"), f"Expected a GCS URI, got {uri}"
+    assert resolution == request.resolution
 
-    # Explicitly check for a top-level error in the operation result.
-    if 'error' in operation_result:
-        pytest.fail(f"API returned a top-level error: {operation_result['error']}")
-
-    response_data = operation_result.get("response", {})
-    assert "videos" in response_data, f"The response should contain a 'videos' key. Full response: {operation_result}"
-
-    videos = response_data["videos"]
-    assert len(videos) > 0, "The 'videos' list should not be empty."
-
-    video_uri = videos[0].get("gcsUri")
-    assert video_uri is not None, "The video should have a 'gcsUri'."
-    assert video_uri.startswith(output_gcs), f"The video URI should be in the specified output bucket. Got {video_uri}"
-
-    print(f"\nIntegration test for model {model_version} PASSED. Video generated successfully at: {video_uri}")
-
+    print(
+        f"\nIntegration test for model {model_config.version_id} PASSED. "
+        f"Videos generated: {video_uris}"
+    )

--- a/test/test_veo_deprecated_model_fallback.py
+++ b/test/test_veo_deprecated_model_fallback.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests: references to GA-sunset Veo models must fail soft.
+
+After the GA sunset, veo-2.0-generate-001, veo-3.0-generate-001, and
+veo-3.0-fast-generate-001 were removed from VEO_MODELS. Persisted state and
+library metadata created before the sunset can still reference those ids, so the
+config lookups and the display/version resolution the app performs on them must
+degrade gracefully (return None / fall back to a default) rather than raise.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from config.veo_models import (
+    DEFAULT_VEO_VERSION_ID,
+    VEO_MODELS,
+    get_veo_model_config,
+    get_version_id_by_model_name,
+)
+
+# version_id / model_name pairs that were removed at the GA sunset.
+REMOVED_VERSION_IDS = ["2.0", "3.0", "3.0-fast"]
+REMOVED_MODEL_NAMES = [
+    "veo-2.0-generate-001",
+    "veo-3.0-generate-001",
+    "veo-3.0-fast-generate-001",
+]
+
+
+@pytest.mark.parametrize("version_id", REMOVED_VERSION_IDS)
+def test_get_veo_model_config_returns_none_for_removed(version_id):
+    """Looking up a removed version_id returns None instead of raising."""
+    assert get_veo_model_config(version_id) is None
+
+
+@pytest.mark.parametrize("model_name", REMOVED_MODEL_NAMES)
+def test_get_version_id_by_model_name_returns_none_for_removed(model_name):
+    """Looking up a removed model_name returns None instead of raising."""
+    assert get_version_id_by_model_name(model_name) is None
+
+
+@pytest.mark.parametrize("model_name", REMOVED_MODEL_NAMES)
+def test_version_resolution_falls_back_to_default(model_name):
+    """The `or default` resolution pattern used across the app (e.g. object
+    rotation / interior design / DEFAULT_VEO_VERSION_ID) yields a valid,
+    still-supported model when metadata references a removed id."""
+    valid_version_ids = {m.version_id for m in VEO_MODELS}
+
+    # This mirrors the fail-soft pattern used at call sites throughout the app.
+    resolved = get_version_id_by_model_name(model_name) or DEFAULT_VEO_VERSION_ID
+
+    assert resolved in valid_version_ids
+    # And the resolved id is itself resolvable to a live config.
+    assert get_veo_model_config(resolved) is not None
+
+
+@pytest.mark.parametrize("model_name", REMOVED_MODEL_NAMES)
+def test_display_resolution_does_not_raise_for_removed(model_name):
+    """Display/version resolution of a persisted removed model id degrades to a
+    'model unavailable' style fallback rather than raising AttributeError."""
+    version_id = get_version_id_by_model_name(model_name)
+    config = get_veo_model_config(version_id) if version_id else None
+
+    # Guarded attribute access (the pattern used in the UI/service layers).
+    display_name = config.display_name if config else "Model unavailable"
+
+    assert display_name == "Model unavailable"
+
+
+def test_default_veo_version_id_is_supported():
+    """The module-level default must always resolve to a live config."""
+    assert get_veo_model_config(DEFAULT_VEO_VERSION_ID) is not None

--- a/test/test_veo_genai_sdk_integration.py
+++ b/test/test_veo_genai_sdk_integration.py
@@ -12,54 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-from unittest.mock import patch, MagicMock
-
 import os
 import sys
+
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+from config.veo_models import get_models_by_mode
+from models.requests import VideoGenerationRequest
 from models.veo import generate_video
-from state.veo_state import PageState
 
-@pytest.fixture
-def mock_state():
-    """Provides a mock PageState object for tests."""
-    state = PageState(
-        veo_prompt_input="a test prompt",
-        veo_model="2.0",
-        aspect_ratio="16:9",
-        video_length=5,
-        reference_image_gcs=None,
-        last_reference_image_gcs=None,
-        auto_enhance_prompt=False
+T2V_MODELS = get_models_by_mode("t2v")
+I2V_MODELS = get_models_by_mode("i2v")
+
+REFERENCE_IMAGE = os.environ.get(
+    "PERSON_IMAGE",
+    "gs://genai-blackbelt-fishfooding-assets/test-cat.png",
+)
+
+
+def _base_request(model_config, **overrides):
+    kwargs = dict(
+        prompt="a happy dog running on a sunny beach",
+        model_version_id=model_config.version_id,
+        aspect_ratio=model_config.supported_aspect_ratios[0],
+        resolution=model_config.resolutions[0],
+        duration_seconds=model_config.default_duration,
+        video_count=model_config.default_samples,
+        enhance_prompt=model_config.supports_prompt_enhancement,
+        generate_audio=False,
+        person_generation="Allow (Adults only)",
     )
-    return state
+    kwargs.update(overrides)
+    return VideoGenerationRequest(**kwargs)
+
 
 @pytest.mark.integration
-def test_veo2_t2v_generation(mock_state):
-    """Tests text-to-video with Veo 2.0."""
-    mock_state.veo_model = "2.0"
-    result = generate_video(mock_state)
-    assert result.startswith("gs://")
+@pytest.mark.parametrize(
+    "model_config", T2V_MODELS, ids=[m.version_id for m in T2V_MODELS]
+)
+def test_t2v_generation_via_genai_sdk(model_config):
+    """Text-to-video generation through the genai SDK for each supported model."""
+    video_uris, _ = generate_video(_base_request(model_config))
+    assert video_uris
+    assert all(uri.startswith("gs://") for uri in video_uris)
+
 
 @pytest.mark.integration
-def test_veo3_t2v_generation(mock_state):
-    """Tests text-to-video with Veo 3.0."""
-    mock_state.veo_model = "3.0"
-    result = generate_video(mock_state)
-    assert result.startswith("gs://")
-
-@pytest.mark.integration
-def test_veo3_fast_t2v_generation(mock_state):
-    """Tests text-to-video with Veo 3.0-fast."""
-    mock_state.veo_model = "3.0-fast"
-    result = generate_video(mock_state)
-    assert result.startswith("gs://")
-
-@pytest.mark.integration
-def test_veo_i2v_generation(mock_state):
-    """Tests image-to-video."""
-    mock_state.reference_image_gcs = "gs://genai-blackbelt-fishfooding-assets/test-cat.png"
-    result = generate_video(mock_state)
-    assert result.startswith("gs://")
+@pytest.mark.parametrize(
+    "model_config", I2V_MODELS, ids=[m.version_id for m in I2V_MODELS]
+)
+def test_i2v_generation_via_genai_sdk(model_config):
+    """Image-to-video generation through the genai SDK for each supported model."""
+    request = _base_request(model_config, reference_image_gcs=REFERENCE_IMAGE)
+    video_uris, _ = generate_video(request)
+    assert video_uris
+    assert all(uri.startswith("gs://") for uri in video_uris)

--- a/test/test_veo_generation_flow.py
+++ b/test/test_veo_generation_flow.py
@@ -12,68 +12,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Component test for the Veo generation flow's metadata handling.
 
+The synchronous on_click_veo path this file previously targeted was refactored
+into an async job flow; the MediaItem metadata (including the resolved model
+name) is now built in services.veo_service.create_initial_job. This test
+exercises that function directly, verifying both the happy path for a
+still-supported model and the fail-soft path for a GA-sunset model id.
+"""
 
-import pytest
-from unittest.mock import patch, MagicMock
-import datetime
-
-# Setup sys.path to allow imports from the parent directory.
 import os
 import sys
+from unittest.mock import patch
+
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from pages.veo import on_click_veo
-from state.veo_state import PageState
-from state.state import AppState
 from common.metadata import MediaItem
+from config.veo_models import VEO_MODELS
+from models.requests import VideoGenerationRequest
+from services.veo_service import create_initial_job
 
-@patch('pages.veo.add_media_item_to_firestore')
-@patch('pages.veo.generate_video', return_value="gs://fake-bucket/fake_video.mp4")
-@patch('mesop.state')
-def test_veo_generation_flow_and_metadata(mock_state, mock_generate_video, mock_add_media_item):
-    """
-    Tests the VEO generation flow, focusing on the data handling and metadata
-    creation after a successful API call.
-    """
-    # --- Arrange ---
-    # Setup the mocked state that the on_click_veo function will use.
-    mock_app_state = AppState(user_email="test_user@example.com")
-    mock_page_state = PageState(
-        veo_prompt_input="a test prompt for veo",
-        veo_model="2.0",
+# A still-supported model to drive the happy-path assertions.
+SUPPORTED_MODEL = VEO_MODELS[0]
+
+
+def _request(model_version_id):
+    return VideoGenerationRequest(
+        prompt="a test prompt for veo",
+        model_version_id=model_version_id,
         aspect_ratio="16:9",
-        video_length=5,
-        reference_image_gcs=None,
-        last_reference_image_gcs=None,
-        auto_enhance_prompt=False
+        resolution="720p",
+        duration_seconds=5,
+        video_count=1,
+        enhance_prompt=False,
+        generate_audio=False,
+        person_generation="Allow (Adults only)",
     )
 
-    # Configure the mesop.state mock to return the correct state object when called.
-    mock_state.side_effect = [mock_app_state, mock_page_state]
 
-    # --- Act ---
-    # Call the event handler function. This is a generator function, so we need to exhaust it.
-    for _ in on_click_veo(MagicMock()):
-        pass
+@patch("services.veo_service.add_media_item_to_firestore")
+def test_create_initial_job_logs_correct_model_metadata(mock_add_media_item):
+    """A job for a supported model logs a MediaItem with the resolved model_name."""
+    request = _request(SUPPORTED_MODEL.version_id)
 
-    # --- Assert ---
-    # 1. Verify that our main video generation function was called.
-    mock_generate_video.assert_called_once()
+    create_initial_job(request, user_email="test_user@example.com")
 
-    # 2. Verify that the Firestore logging function was called.
     mock_add_media_item.assert_called_once()
-
-    # 3. Inspect the data that was passed to the Firestore function.
-    # This is the crucial part that catches the `NameError` or `AttributeError`.
-    call_args, _ = mock_add_media_item.call_args
-    media_item_logged = call_args[0]
+    media_item_logged = mock_add_media_item.call_args[0][0]
 
     assert isinstance(media_item_logged, MediaItem)
     assert media_item_logged.user_email == "test_user@example.com"
     assert media_item_logged.prompt == "a test prompt for veo"
-    assert media_item_logged.gcsuri == "gs://fake-bucket/fake_video.mp4"
-    assert media_item_logged.model == "veo-2.0-generate-001" # This comes from config
+    assert media_item_logged.mode == "t2v"
+    # The model name is resolved from config for a supported version_id.
+    assert media_item_logged.model == SUPPORTED_MODEL.model_name
 
-    print("\nComponent-level integration test for VEO passed successfully.")
 
+@patch("services.veo_service.add_media_item_to_firestore")
+def test_create_initial_job_fails_soft_for_removed_model(mock_add_media_item):
+    """A job referencing a GA-sunset model id must NOT raise; it falls back to
+    recording the raw model_version_id rather than crashing on a None config."""
+    removed_id = "veo-2.0-generate-001"
+    request = _request(removed_id)
+
+    # Should not raise despite the model no longer existing in VEO_MODELS.
+    create_initial_job(request, user_email="test_user@example.com")
+
+    mock_add_media_item.assert_called_once()
+    media_item_logged = mock_add_media_item.call_args[0][0]
+    assert media_item_logged.model == removed_id

--- a/test/test_veo_t2v_model_selection.py
+++ b/test/test_veo_t2v_model_selection.py
@@ -13,80 +13,82 @@
 # limitations under the License.
 
 
-
 import os
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from models.veo import text_to_video
-from config.default import Default
+from config.veo_models import VEO_MODELS, get_models_by_mode
+from models.requests import VideoGenerationRequest
+from models.veo import generate_video
 
-@patch('models.veo.fetch_operation', return_value=MagicMock())
-@patch('models.veo.send_request_to_google_api', return_value={'name': 'mock_operation_name'})
-def test_t2v_uses_veo3_fast_model(mock_send_request, mock_fetch_operation):
-    """Tests that text_to_video uses the Veo 3.0 Fast endpoint when model is '3.0-fast'."""
-    cfg = Default()
-    text_to_video(
-        model="3.0-fast",
-        prompt="A test prompt",
-        seed=123,
-        aspect_ratio="16:9",
-        sample_count=1,
-        output_gcs="gs://fake-bucket/videos",
-        enable_pr=False,
-        duration_seconds=5,
+
+def _make_t2v_request(model_config):
+    """Builds a minimal text-to-video request for the given model config."""
+    return VideoGenerationRequest(
+        prompt="a happy dog running on a sunny beach",
+        model_version_id=model_config.version_id,
+        aspect_ratio=model_config.supported_aspect_ratios[0],
+        resolution=model_config.resolutions[0],
+        duration_seconds=model_config.default_duration,
+        video_count=model_config.default_samples,
+        enhance_prompt=model_config.default_prompt_enhancement,
+        generate_audio=False,
+        person_generation="Allow (Adults only)",
     )
 
-    mock_send_request.assert_called_once()
-    called_endpoint = mock_send_request.call_args[0][0]
-    assert cfg.VEO_EXP_FAST_MODEL_ID in called_endpoint
-    assert cfg.VEO_EXP_MODEL_ID not in called_endpoint
-    assert cfg.VEO_MODEL_ID not in called_endpoint
-    print(f"\nVeo 3.0 Fast test PASSED: Endpoint '{called_endpoint}' correctly contains '{cfg.VEO_EXP_FAST_MODEL_ID}'")
 
-@patch('models.veo.fetch_operation', return_value=MagicMock())
-@patch('models.veo.send_request_to_google_api', return_value={'name': 'mock_operation_name'})
-def test_t2v_uses_veo3_model(mock_send_request, mock_fetch_operation):
-    """Tests that text_to_video uses the Veo 3.0 endpoint when model is '3.0'."""
-    cfg = Default()
-    text_to_video(
-        model="3.0",
-        prompt="A test prompt",
-        seed=123,
-        aspect_ratio="16:9",
-        sample_count=1,
-        output_gcs="gs://fake-bucket/videos",
-        enable_pr=False,
-        duration_seconds=5,
-    )
+def _make_fake_operation(uri="gs://fake-bucket/videos/out.mp4"):
+    """Builds a fake, already-completed genai video operation."""
+    fake_video = MagicMock()
+    fake_video.video.uri = uri
+    fake_result = MagicMock()
+    fake_result.rai_media_filtered_count = 0
+    fake_result.generated_videos = [fake_video]
+    fake_op = MagicMock()
+    fake_op.done = True
+    fake_op.error = None
+    fake_op.response = "ok"
+    fake_op.result = fake_result
+    return fake_op
 
-    mock_send_request.assert_called_once()
-    called_endpoint = mock_send_request.call_args[0][0]
-    assert cfg.VEO_EXP_MODEL_ID in called_endpoint
-    assert cfg.VEO_MODEL_ID not in called_endpoint
-    print(f"\nVeo 3.0 test PASSED: Endpoint '{called_endpoint}' correctly contains '{cfg.VEO_EXP_MODEL_ID}'")
 
-@patch('models.veo.fetch_operation', return_value=MagicMock())
-@patch('models.veo.send_request_to_google_api', return_value={'name': 'mock_operation_name'})
-def test_t2v_uses_veo2_model(mock_send_request, mock_fetch_operation):
-    """Tests that text_to_video uses the Veo 2.0 endpoint when model is '2.0'."""
-    cfg = Default()
-    text_to_video(
-        model="2.0",
-        prompt="A test prompt",
-        seed=123,
-        aspect_ratio="16:9",
-        sample_count=1,
-        output_gcs="gs://fake-bucket/videos",
-        enable_pr=False,
-        duration_seconds=5,
-    )
+# Only text-to-video capable models are exercised here.
+T2V_MODELS = get_models_by_mode("t2v")
 
-    mock_send_request.assert_called_once()
-    called_endpoint = mock_send_request.call_args[0][0]
-    assert cfg.VEO_MODEL_ID in called_endpoint
-    assert cfg.VEO_EXP_MODEL_ID not in called_endpoint
-    print(f"\nVeo 2.0 test PASSED: Endpoint '{called_endpoint}' correctly contains '{cfg.VEO_MODEL_ID}'")
 
+@pytest.mark.parametrize(
+    "model_config", T2V_MODELS, ids=[m.version_id for m in T2V_MODELS]
+)
+@patch("models.veo.get_veo_client")
+def test_t2v_selects_correct_model_endpoint(mock_get_client, model_config):
+    """generate_video must dispatch t2v requests to the model_name backing the
+    selected version_id (post GA sunset, only Veo 3.1 models remain)."""
+    mock_client = MagicMock()
+    mock_client.models.generate_videos.return_value = _make_fake_operation()
+    mock_get_client.return_value = mock_client
+
+    video_uris, _ = generate_video(_make_t2v_request(model_config))
+
+    # The correct genai model_name for the selected version_id was requested.
+    mock_client.models.generate_videos.assert_called_once()
+    called_model = mock_client.models.generate_videos.call_args.kwargs["model"]
+    assert called_model == model_config.model_name
+    assert video_uris == ["gs://fake-bucket/videos/out.mp4"]
+
+
+def test_removed_veo_models_are_not_selectable():
+    """The GA-sunset endpoints must no longer be present in the t2v model set."""
+    version_ids = {m.version_id for m in T2V_MODELS}
+    model_names = {m.model_name for m in T2V_MODELS}
+    for removed in ("2.0", "3.0", "3.0-fast"):
+        assert removed not in version_ids
+    for removed in (
+        "veo-2.0-generate-001",
+        "veo-3.0-generate-001",
+        "veo-3.0-fast-generate-001",
+    ):
+        assert removed not in model_names


### PR DESCRIPTION
## Summary

Part of the GA endpoint deprecation (Issue V, Phase V2 — the fan-out after V1 repointed Character Consistency to `veo-3.1-fast`). **OQ-2 decision: REMOVE NOW.** Scope: **core app only** (no `experiments/`).

Removes the three GA-sunset Veo model configs from `config/veo_models.py`:
- `veo-2.0-generate-001` (version_id `2.0`)
- `veo-3.0-generate-001` (version_id `3.0`)
- `veo-3.0-fast-generate-001` (version_id `3.0-fast`)

All Veo dropdowns iterate `VEO_MODELS` unfiltered (`components/veo/generation_controls.py`, `pages/portraits.py`, `pages/storyboarder.py`, extend dialog), so removing the entries drops them everywhere. Only the Veo 3.1 family remains: `3.1-fast`, `3.1`, `3.1-lite`. Verified no runtime code keys on the removed ids outside `VEO_MODELS`.

## Tests

Greened the Veo suite. This includes fixing **two pre-existing failures** that predate this change (both present on `main` and surfaced when bringing the suite green):

1. **`text_to_video` import collection error** (`test_veo_api_integration.py`, `test_veo_t2v_model_selection.py`). Root cause: these tests imported `models.veo.text_to_video`, which does not exist (and per git history never did) — the legacy REST t2v function was superseded by the unified `generate_video(VideoGenerationRequest)`. (Its i2v sibling `image_to_video` survives because `shop_the_look` still uses it.) Fix is **test-only**: rewrote them to the current `generate_video` API.
2. **`test_veo_generation_flow.py` refactor breakage.** Root cause: it constructed `AppState(user_email=...)` (mesop `@me.stateclass`, no longer accepts kwargs) and asserted the removed synchronous `on_click_veo` path called `generate_video` + `add_media_item_to_firestore` directly. That path was refactored into an async job flow; the MediaItem metadata (incl. resolved model name) is now built in `services.veo_service.create_initial_job`. Fix is **test-only**: rewrote to exercise `create_initial_job`, asserting a supported model logs the correct `model_name` **and** the fail-soft path (a removed id falls back to the raw `model_version_id` rather than raising).

Changes:
- `test_veo_t2v_model_selection.py` — rewritten to assert `generate_video` dispatches each remaining t2v model to the correct genai `model_name` (mocked client), plus a guard that the removed ids are gone.
- `test_veo_api_integration.py`, `test_veo_genai_sdk_integration.py` — rewritten to use `VideoGenerationRequest` + `generate_video` over the remaining models (kept `@pytest.mark.integration`).
- `test_veo_generation_flow.py` — rewritten per above.
- **`test_veo_deprecated_model_fallback.py` (new)** — fail-soft regression test: `get_veo_model_config` / `get_version_id_by_model_name` return `None` (not raise) for removed ids; version/display resolution degrades to a default / "model unavailable".
- `test_veo_i2v_model_selection.py` — **unchanged**; it exercises the legacy `image_to_video` endpoint switch (not `VEO_MODELS` entries) and still passes.

## Docs / config
- `README.md`, `docs-site/.../core/index.md`, `docs-site/.../core/usage.md` — drop "Veo 2".
- `dotenv.template` — `CHARACTER_CONSISTENCY_VEO_MODEL` default now `veo-3.1-fast-generate-001` (matches the V1 repoint; V1 review nit).

## Verification
- Grep: none of the three removed ids remain as a runtime reference in the core app (only the intentional deprecation comment + negative-assertion tests; standalone manual SDK scripts `test/veo2_simple.py`, `test/generate_video.py`, `test/veo_simple_aiplatform.py` still reference `veo-2.0` but are not part of the pytest suite and not app runtime).
- `pytest -m "not integration"` over the touched Veo tests: **21 passed, 9 deselected**. Integration tests collect cleanly over the remaining models only.
- App/config import smoke test passes; `VEO_MODELS` has 3 entries; `DEFAULT_VEO_VERSION_ID` (`3.1-fast`) resolves; dropdown component modules import.
- Env note: sandbox is Python 3.11 (repo pins 3.14); runtime deps were installed manually to run the tests, as prior devs did. Pre-existing, out-of-scope failures on `main` unrelated to this change and unaffected by it: `test_veo_negative_prompt.py` (same `AppState` kwarg breakage), `test_veo_extension.py` (missing `input_video_gcs` fixture), `test_app_imports.py` (sandbox missing `texttospeech_v1beta1`/`fastapi`).