### PR TITLE
chore: remove Imagen from pyproject.toml description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vertex-ai-genmedia-creative-studio"
 version = "1.13.0"
-description = "GenMedia Creative Studio - Veo, Lyria, Nano Banana, Imagen, Gemini, Gemini TTS"
+description = "GenMedia Creative Studio - Veo, Lyria, Nano Banana, Gemini, Gemini TTS"
 readme = "README.md"
 requires-python = ">=3.14, <3.15"
 dependencies = [


### PR DESCRIPTION
## Summary
Updates the core app `pyproject.toml` `description` field to remove **Imagen** from the product list, per owner request.

**Before:**
```
description = "GenMedia Creative Studio - Veo, Lyria, Nano Banana, Imagen, Gemini, Gemini TTS"
```
**After:**
```
description = "GenMedia Creative Studio - Veo, Lyria, Nano Banana, Gemini, Gemini TTS"
```

Only the `description` field changed. `version` (`1.13.0`) and everything else in `pyproject.toml` are untouched. `uv.lock` is unchanged (description is not lock-relevant).

## Note on "Omni" (discrepancy flagged, not silently resolved)
The owner asked to remove both **Omni** and **Imagen** from `pyproject.toml`'s description. However, **"Omni" does not appear in `pyproject.toml`'s description at all** — only "Imagen" was present. So there is no Omni edit to make in this file.

"Omni" *does* appear in `README.md` prose (not a metadata list):
- Line 26 (tagline paragraph): "… Gemini Omni, Veo, Lyria, …"
- Line 31 (feature list): "**Video:** Gemini Omni Flash, Veo 3.1, Veo 3"

Because the owner's request was scoped to `pyproject.toml`'s description, and because fixing these README product names correctly requires a naming decision I shouldn't guess at, I've left `README.md` unchanged and flagged it for owner confirmation rather than bundling an unrequested prose edit into this metadata change.

## Verification
- `uv sync` runs cleanly (exit 0), confirming the TOML is well-formed.

Do not merge — coordinator gates merges.