### PR TITLE
chore: remove relocated experiment stubs (storycraft, VeoStart)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,12 +36,6 @@
 ## Arena
 /experiments/arena/ @GoogleCloudPlatform/google-cloud-aaie @ghchinoy @awaemmanuel
 
-## VeoStart
-/experiments/VeoStart/ @GoogleCloudPlatform/google-cloud-aaie @WafaeBakkali
-
-## Storycraft
-/experiments/storycraft/ @GoogleCloudPlatform/google-cloud-aaie @mblanc
-
 ## Countdown workflow
 /experiments/countdown-workflow/ @GoogleCloudPlatform/google-cloud-aaie @cnemri
 

--- a/docs-site/src/content/docs/core/index.md
+++ b/docs-site/src/content/docs/core/index.md
@@ -83,7 +83,7 @@ Here's a glimpse of what you'll find:
 **Combined Workflows**
 
 - **Countdown Workflow:** An automated two-stage pipeline to create branded countdown videos.
-- **Storycraft:** An AI-powered video storyboard generation platform that transforms text descriptions into complete video narratives.
+- **Storycraft:** An AI-powered video storyboard generation platform that transforms text descriptions into complete video narratives. (Now maintained at [mblanc/storycraft](https://github.com/mblanc/storycraft).)
     - **Creative GenMedia Workflow:** An end-to-end workflow to produce high-quality, on-brand creative media.
     - **Run, Veo, Run:** A real-time, multimodal video generation experiment that creates a branching narrative loop using Veo 3.1 for video extension and Gemini 3 for context awareness.
 

--- a/docs-site/src/content/docs/experiments/overview.md
+++ b/docs-site/src/content/docs/experiments/overview.md
@@ -32,3 +32,10 @@ The experimental folder contains stand-alone applications, demos, and features n
 ## Developer Tools & MCP
 
 * [MCP GenMedia](/vertex-ai-creative-studio/experiments/mcp-genmedia) - Model Context Protocol servers for Genmedia services for AI applications to utilize Veo, Imagen, Lyria, Chirp 3 HD.
+
+## Relocated Experiments
+
+These experiments have moved to their own repositories and are no longer maintained in this repo:
+
+* [Storycraft](https://github.com/mblanc/storycraft) - An AI-powered video storyboard generation platform that transforms text descriptions into complete video narratives.
+* [V-Start (formerly VeoStart)](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/vision/sample-apps/V-Start) - A toolkit that helps users quickly create effective prompts for Veo and evaluate how well generated videos align with their intended prompts.

--- a/experiments/VeoStart/README.md
+++ b/experiments/VeoStart/README.md
@@ -1,5 +1,0 @@
-# V-Start: a toolkit for Veo prompting and eval
-
-VeoStart has moved to [V-Start](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/vision/sample-apps/V-Start)
-
-V-Start is an experimental toolkit that helps users easily and quickly create effective prompts for Veo and evaluate how well generated videos align with their intended prompts. The main goal is to simplify the process of creating high-quality videos with Veo.

--- a/experiments/storycraft/README.md
+++ b/experiments/storycraft/README.md
@@ -1,4 +1,0 @@
-# Storycraft
-
-Storycraft has been moved to a new repository. You can now find it at:
-https://github.com/mblanc/storycraft


### PR DESCRIPTION
## What & why

`experiments/storycraft` and `experiments/VeoStart` were pure tombstone stubs — each contained only a `README.md` pointing to the project's new home, with no actual code. This removes those orphan directories and relocates the "where did this go" pointers into the docs-site, so the relocation info lives in the docs rather than as empty directories under `experiments/`.

## Changes

- **Remove** `experiments/storycraft/` and `experiments/VeoStart/` (confirmed stub-only: `git ls-files` showed only `README.md` in each).
- **docs-site** — add a **Relocated Experiments** section to `docs-site/src/content/docs/experiments/overview.md` pointing to:
  - Storycraft → https://github.com/mblanc/storycraft
  - V-Start (formerly VeoStart) → https://github.com/GoogleCloudPlatform/generative-ai/tree/main/vision/sample-apps/V-Start
- **docs-site** — note Storycraft's new home in the core feature glimpse (`docs-site/src/content/docs/core/index.md`), which previously listed it as an in-repo experiment.
- **CODEOWNERS** — drop the now-dangling entries for the two removed directories.

## Other references checked

- No CI workflow, Makefile, or script references the removed paths.
- The only remaining mention is in `archive/imagen-creative-studio/README.md`, a frozen historical snapshot with no path link — intentionally left untouched.

## Verification

- `docs-site` builds clean (`npm run build` / `astro build`, 53 pages).

Do not merge — coordinator gates merges.