### PR TITLE
fix(Imagen_Product_Recontext): update stale gemini-2.5-flash to gemini-3.5-flash

### DIFF
--- a/experiments/Imagen_Product_Recontext/evaluation_imagen_product_recontext_at_scale.ipynb
+++ b/experiments/Imagen_Product_Recontext/evaluation_imagen_product_recontext_at_scale.ipynb
@@ -314,7 +314,7 @@
     "    parts = [msg1_text1] + [make_part(u) for u in input_uris] + [make_part(output_uri)]\n",
     "    full = \"\"\n",
     "    for chunk in client.models.generate_content_stream(\n",
-    "        model=\"gemini-2.5-flash\",\n",
+    "        model=\"gemini-3.5-flash\",\n",
     "        contents=[types.Content(role=\"user\", parts=parts)],\n",
     "        config=generate_config\n",
     "    ):\n",


### PR DESCRIPTION
## Summary
Updates the stale `gemini-2.5-flash` model reference in the evaluation notebook to `gemini-3.5-flash`, the current core-app default (per `config/default.py`).

## Change
- `experiments/Imagen_Product_Recontext/evaluation_imagen_product_recontext_at_scale.ipynb`: the `generate()` function's `generate_content_stream` call now uses `model="gemini-3.5-flash"`.

The specialized `imagen-product-recontext-preview-06-30` endpoint (the actual purpose of this experiment) is **not** touched — it is not deprecated/stale.

## Verification
- Notebook is still valid JSON (21 cells).
- The modified code cell parses cleanly (`ast.parse`).
- Single-line diff; no other `gemini-2.5-flash` references remain.

Closes #1678