### PR TITLE
fix(promptlandia): set strongest model to gemini-3.7-flash (#1680)

### DIFF
--- a/experiments/promptlandia/GEMINI.md
+++ b/experiments/promptlandia/GEMINI.md
@@ -96,12 +96,12 @@ export SA_ID=sa-promptlandia@${PROJECT_ID}.iam.gserviceaccount.com
 
 **To deploy an unauthenticated service:**
 ```bash
-gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1 --allow-unauthenticated
+gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1,GEMINI_LOCATION=global --allow-unauthenticated
 ```
 
 **To deploy a service secured with IAP:**
 ```bash
-gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1
+gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1,GEMINI_LOCATION=global
 ```
 
 ## Committing

--- a/experiments/promptlandia/GEMINI.md
+++ b/experiments/promptlandia/GEMINI.md
@@ -96,12 +96,12 @@ export SA_ID=sa-promptlandia@${PROJECT_ID}.iam.gserviceaccount.com
 
 **To deploy an unauthenticated service:**
 ```bash
-gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.1-pro-preview,LOCATION=us-central1 --allow-unauthenticated
+gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1 --allow-unauthenticated
 ```
 
 **To deploy a service secured with IAP:**
 ```bash
-gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.1-pro-preview,LOCATION=us-central1
+gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1
 ```
 
 ## Committing

--- a/experiments/promptlandia/README.md
+++ b/experiments/promptlandia/README.md
@@ -44,9 +44,11 @@ The application is configured using environment variables, which can be set in a
 | Variable | Description | Default |
 | :--- | :--- | :--- |
 | `PROJECT_ID` | Your Google Cloud Project ID. | (Required) |
-| `LOCATION` | The Google Cloud region for Vertex AI. | `us-central1` |
-| `MODEL_ID` | The primary Gemini model ID used for generation and improvement. | `gemini-3.7-flash` |
-| `PLANNING_MODEL_ID` | The model ID used specifically for the "thinking thoughts" (planning) step of prompt improvement. | Defaults to `MODEL_ID` |
+| `LOCATION` | The general Google Cloud region (e.g. the Cloud Run deployment region). Kept separate from the Gemini region. | `us-central1` |
+| `GEMINI_LOCATION` | The location used for Gemini model calls. Decoupled from `LOCATION` / the deployment region. | `global` |
+| `MODEL_ID` | The primary/strongest Gemini model ID used for generation, improvement, and planning. | `gemini-3.7-flash` |
+| `PLANNING_MODEL_ID` | The model ID used specifically for the "thinking thoughts" (planning) step of prompt improvement. | Defaults to `MODEL_ID` (the strongest model) |
+| `ALTERNATIVE_MODEL_ID` | A lighter/faster model used for secondary, classification-style steps (e.g. the trimmer's deconstruction step). | `gemini-3.5-flash-lite` |
 
 ## CLI Tools
 
@@ -104,13 +106,13 @@ export SA_ID=sa-promptlandia@${PROJECT_ID}.iam.gserviceaccount.com
 
 #### Using Cloud Run, unauthenticated
 ```bash
-gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1 --allow-unauthenticated
+gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1,GEMINI_LOCATION=global --allow-unauthenticated
 ```
 
 #### Using Cloud Run IAP
 
 ```bash
-gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1
+gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1,GEMINI_LOCATION=global
 ```
 
 #### Add IAP users/groups

--- a/experiments/promptlandia/README.md
+++ b/experiments/promptlandia/README.md
@@ -45,7 +45,7 @@ The application is configured using environment variables, which can be set in a
 | :--- | :--- | :--- |
 | `PROJECT_ID` | Your Google Cloud Project ID. | (Required) |
 | `LOCATION` | The Google Cloud region for Vertex AI. | `us-central1` |
-| `MODEL_ID` | The primary Gemini model ID used for generation and improvement. | `gemini-3.1-pro-preview` |
+| `MODEL_ID` | The primary Gemini model ID used for generation and improvement. | `gemini-3.7-flash` |
 | `PLANNING_MODEL_ID` | The model ID used specifically for the "thinking thoughts" (planning) step of prompt improvement. | Defaults to `MODEL_ID` |
 
 ## CLI Tools
@@ -104,13 +104,13 @@ export SA_ID=sa-promptlandia@${PROJECT_ID}.iam.gserviceaccount.com
 
 #### Using Cloud Run, unauthenticated
 ```bash
-gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.1-pro-preview,LOCATION=us-central1 --allow-unauthenticated
+gcloud run deploy promptlandia --source . --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1 --allow-unauthenticated
 ```
 
 #### Using Cloud Run IAP
 
 ```bash
-gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.1-pro-preview,LOCATION=us-central1
+gcloud alpha run deploy promptlandia --source . --iap --service-account=$SA_ID --region us-central1 --set-env-vars PROJECT_ID=$(gcloud config get project),MODEL_ID=gemini-3.7-flash,LOCATION=us-central1
 ```
 
 #### Add IAP users/groups

--- a/experiments/promptlandia/config/default.py
+++ b/experiments/promptlandia/config/default.py
@@ -36,13 +36,25 @@ class Default:
 
     Attributes:
         PROJECT_ID: The Google Cloud project ID.
-        LOCATION: The Google Cloud location to use for the generative AI model.
-        MODEL_ID: The ID of the generative AI model to use.
+        LOCATION: The general Google Cloud region (e.g. the Cloud Run
+            deployment region). Kept separate from the Gemini region.
+        GEMINI_LOCATION: The location used for Gemini model calls. Defaults to
+            "global" and is intentionally decoupled from LOCATION / the Cloud
+            Run deployment region.
+        MODEL_ID: The ID of the primary/strongest generative AI model to use.
+        PLANNING_MODEL_ID: The model ID used for the prompt-planning /
+            prompt-generation step. Defaults to MODEL_ID (the strongest model).
+        ALTERNATIVE_MODEL_ID: A lighter/faster model used for secondary,
+            classification-style steps (not the core planning/generation flow).
         INIT_VERTEX: Whether to initialize the Vertex AI client.
     """
 
     PROJECT_ID: str = field(default_factory=lambda: os.environ.get("PROJECT_ID"))
     LOCATION: str = os.environ.get("LOCATION", "us-central1")
+    GEMINI_LOCATION: str = os.environ.get("GEMINI_LOCATION", "global")
     MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-3.7-flash")
     PLANNING_MODEL_ID: str = os.environ.get("PLANNING_MODEL_ID")
+    ALTERNATIVE_MODEL_ID: str = os.environ.get(
+        "ALTERNATIVE_MODEL_ID", "gemini-3.5-flash-lite"
+    )
     INIT_VERTEX: bool = True

--- a/experiments/promptlandia/config/default.py
+++ b/experiments/promptlandia/config/default.py
@@ -43,6 +43,6 @@ class Default:
 
     PROJECT_ID: str = field(default_factory=lambda: os.environ.get("PROJECT_ID"))
     LOCATION: str = os.environ.get("LOCATION", "us-central1")
-    MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-3.1-pro-preview")
+    MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-3.7-flash")
     PLANNING_MODEL_ID: str = os.environ.get("PLANNING_MODEL_ID")
     INIT_VERTEX: bool = True

--- a/experiments/promptlandia/models/gemini.py
+++ b/experiments/promptlandia/models/gemini.py
@@ -35,6 +35,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from config.default import Default
 from models.model_setup import ModelSetup
 from models.domain import TrimResult, ImprovementPlan, ImprovementResult
 
@@ -50,6 +51,8 @@ logger = logging.getLogger(__name__)
 client, model_id, planning_model_id = ModelSetup.init()
 MODEL_ID = model_id
 PLANNING_MODEL_ID = planning_model_id
+# Lighter/faster model for secondary, classification-style steps.
+ALTERNATIVE_MODEL_ID = Default().ALTERNATIVE_MODEL_ID
 
 
 def _log_non_text_parts(response):
@@ -216,13 +219,15 @@ def gemini_trim_prompt(prompt: str) -> TrimResult:
     Returns:
         A TrimResult object containing the analysis, trimmed prompt, and duration.
     """
-    logger.info(f"Trimming prompt using model: {MODEL_ID}")
+    logger.info(
+        f"Trimming prompt (deconstruct={ALTERNATIVE_MODEL_ID}, rewrite={MODEL_ID})"
+    )
     start_time = time.perf_counter()
 
-    # Step 1: Deconstruct
+    # Step 1: Deconstruct (classification/extraction step -> lighter model)
     deconstructor_prompt = TRIMMER_DECONSTRUCTOR.format(prompt)
     response_1 = _call_gemini_with_retry(
-        model=MODEL_ID,
+        model=ALTERNATIVE_MODEL_ID,
         contents=deconstructor_prompt,
         config=GenerateContentConfig(
             response_modalities=["TEXT"],

--- a/experiments/promptlandia/models/model_setup.py
+++ b/experiments/promptlandia/models/model_setup.py
@@ -59,7 +59,9 @@ class ModelSetup:
         if not project_id:
             project_id = config.PROJECT_ID
         if not location:
-            location = config.LOCATION
+            # Gemini calls use the dedicated GEMINI_LOCATION (default "global"),
+            # decoupled from the Cloud Run / deployment region (LOCATION).
+            location = config.GEMINI_LOCATION
         if not model_id:
             model_id = config.MODEL_ID
         if not planning_model_id:

--- a/experiments/promptlandia/pages/playground.py
+++ b/experiments/promptlandia/pages/playground.py
@@ -43,7 +43,7 @@ class PageState:
     prompt_tab: bool = True
     response_tab: bool = True
     # Model configs
-    selected_model: str = "gemini-1.5"
+    selected_model: str = "gemini-3.7-flash"
     selected_region: str = "us-east4"
     temperature: float = 1.0
     temperature_for_input: float = 1.0
@@ -146,7 +146,7 @@ def playground_page_content(app_state: me.state):
         with me.box(style=_STYLE_CONFIG_COLUMN):
             me.select(
                 options=[
-                    me.SelectOption(label="Gemini 3.1 Pro Preview", value="gemini-3.1-pro-preview"),
+                    me.SelectOption(label="Gemini 3.7 Flash", value="gemini-3.7-flash"),
                     me.SelectOption(label="Chat-GPT Turbo", value="gpt-3.5-turbo"),
                 ],
                 label="Model",

--- a/experiments/promptlandia/pages/settings.py
+++ b/experiments/promptlandia/pages/settings.py
@@ -80,8 +80,9 @@ def settings_page_content(app_state: me.state):
                         style=me.Style(font_weight="bold"),
                     )
                     me.box(style=me.Style(height=8))
-                    me.text(f"Model: {Default.MODEL_ID}")
-                    me.text(f"Location: {Default.LOCATION}")
+                    me.text(f"Model (strongest): {Default.MODEL_ID}")
+                    me.text(f"Alternative model: {Default.ALTERNATIVE_MODEL_ID}")
+                    me.text(f"Gemini location: {Default.GEMINI_LOCATION}")
 
                 me.box(style=me.Style(height=32))
 

--- a/experiments/promptlandia/services/llm_client.py
+++ b/experiments/promptlandia/services/llm_client.py
@@ -50,7 +50,9 @@ class LLMClient:
         """
         config = Default()
         self.project_id = project_id or config.PROJECT_ID
-        self.location = location or config.LOCATION
+        # Gemini calls use the dedicated GEMINI_LOCATION (default "global"),
+        # decoupled from the Cloud Run / deployment region (LOCATION).
+        self.location = location or config.GEMINI_LOCATION
         self.init_vertex = config.INIT_VERTEX
 
         if not self.project_id or not self.location:

--- a/experiments/promptlandia/services/trimmer.py
+++ b/experiments/promptlandia/services/trimmer.py
@@ -38,7 +38,9 @@ class PromptTrimmer:
             client: An instance of LLMClient. If None, a new one is created.
         """
         self.client = client or LLMClient()
-        self.model_id = Default().MODEL_ID
+        config = Default()
+        self.model_id = config.MODEL_ID
+        self.alternative_model_id = config.ALTERNATIVE_MODEL_ID
 
     def trim_prompt(self, prompt: str) -> TrimResult:
         """Trims a prompt by removing general best practices while keeping task-specific requirements.
@@ -53,13 +55,16 @@ class PromptTrimmer:
         Returns:
             A TrimResult object containing the analysis, trimmed prompt, and duration.
         """
-        logger.info(f"Trimming prompt using model: {self.model_id}")
+        logger.info(
+            f"Trimming prompt (deconstruct={self.alternative_model_id}, "
+            f"rewrite={self.model_id})"
+        )
         start_time = time.perf_counter()
 
-        # Step 1: Deconstruct
+        # Step 1: Deconstruct (classification/extraction step -> lighter model)
         deconstructor_prompt = TRIMMER_DECONSTRUCTOR.format(prompt)
         response_1 = self.client.generate_content(
-            model=self.model_id,
+            model=self.alternative_model_id,
             contents=deconstructor_prompt,
             config=GenerateContentConfig(
                 response_modalities=["TEXT"],

--- a/experiments/promptlandia/terraform/main.tf
+++ b/experiments/promptlandia/terraform/main.tf
@@ -48,8 +48,16 @@ resource "google_cloud_run_v2_service" "promptlandia_service" {
         value = var.model_id
       }
       env {
+        name  = "ALTERNATIVE_MODEL_ID"
+        value = var.alternative_model_id
+      }
+      env {
         name  = "LOCATION"
         value = var.region
+      }
+      env {
+        name  = "GEMINI_LOCATION"
+        value = var.gemini_location
       }
     }
   }

--- a/experiments/promptlandia/terraform/variables.tf
+++ b/experiments/promptlandia/terraform/variables.tf
@@ -16,9 +16,21 @@ variable "service_name" {
 }
 
 variable "model_id" {
-  description = "The ID of the Gemini model to use."
+  description = "The ID of the primary/strongest Gemini model to use."
   type        = string
   default     = "gemini-3.7-flash"
+}
+
+variable "alternative_model_id" {
+  description = "A lighter/faster Gemini model used for secondary, classification-style steps."
+  type        = string
+  default     = "gemini-3.5-flash-lite"
+}
+
+variable "gemini_location" {
+  description = "The location for Gemini model calls. Decoupled from the Cloud Run deployment region (var.region)."
+  type        = string
+  default     = "global"
 }
 
 variable "iap_members" {

--- a/experiments/promptlandia/terraform/variables.tf
+++ b/experiments/promptlandia/terraform/variables.tf
@@ -18,8 +18,7 @@ variable "service_name" {
 variable "model_id" {
   description = "The ID of the Gemini model to use."
   type        = string
-  # TODO: Update to GA model
-  default     = "gemini-3.1-pro-preview"
+  default     = "gemini-3.7-flash"
 }
 
 variable "iap_members" {


### PR DESCRIPTION
## Summary

Configures promptlandia's Gemini models per the owner's spec:

- **Strongest / primary model** = `gemini-3.7-flash` for all core planning &
  generation (improve, checklist, video-checklist, trimmer rewrite, generate,
  and the playground default). Also fixes the stale `gemini-1.5` straggler in
  the playground default (`pages/playground.py`), which matched no dropdown
  option.
- **Gemini region** = `global`, via a **dedicated `GEMINI_LOCATION` config
  variable** decoupled from `LOCATION` / the Cloud Run deployment region (the
  terraform `LOCATION`↔`var.region` coupling made overloading `LOCATION`
  structurally unworkable).
- **Alternative (lighter/faster) model** = `gemini-3.5-flash-lite`, wired into
  the **trimmer's Step 1 deconstruction** — a classification/extraction step
  (categorises prompt content into task-specific vs general, output parsed by
  regex). The Step 2 rewrite (generation) stays on the strongest model, and the
  planning flow stays on the strongest model, per the owner's guidance that
  "the planning model should be the stronger model."

Refs #1680.

## Changes
- `config/default.py`: add `GEMINI_LOCATION` (default `global`) and
  `ALTERNATIVE_MODEL_ID` (default `gemini-3.5-flash-lite`); `MODEL_ID` →
  `gemini-3.7-flash`.
- `models/model_setup.py`, `services/llm_client.py`: Gemini client uses
  `GEMINI_LOCATION`.
- `services/trimmer.py` + legacy `models/gemini.py`: deconstruction step uses
  `ALTERNATIVE_MODEL_ID`; rewrite stays on `MODEL_ID`.
- `pages/playground.py`: default + Gemini dropdown option → `gemini-3.7-flash`.
- `pages/settings.py`: display strongest model, alternative model, Gemini
  location.
- `terraform/`: add `gemini_location` + `alternative_model_id` variables and
  Cloud Run env vars (`LOCATION` stays the deploy region).
- `README.md` / `GEMINI.md`: document the new env vars + deploy commands.

## Open question to owner (not a code decision here)
The playground's `Chat-GPT Turbo` (`gpt-3.5-turbo`) dropdown option is **left
untouched** pending the owner's question about it. Context: the Playground is a
"Get code" snippet demo (it does not call any model); selecting `gpt-3.5-turbo`
just renders an example OpenAI-SDK snippet instead of the Vertex/Gemini one. It
is not wired into any promptlandia AI feature. Reported to the owner separately.

## Testing
`pytest tests/ --ignore=tests/test_e2e.py` → **7 passed, 1 failed**. The single
failure (`test_extract_json_from_sample`, missing `samples/output.md` fixture)
is pre-existing and unrelated. `py_compile` clean on all touched files.

Do **not** merge — coordinator gates merges.