### PR TITLE
fix(babel): update stale Gemini model IDs to gemini-3.5-flash

### DIFF
--- a/experiments/babel/app/config/default.py
+++ b/experiments/babel/app/config/default.py
@@ -48,7 +48,7 @@ class Default:
     GENMEDIA_BUCKET: str = os.environ.get(
         "GENMEDIA_BUCKET", f"{PROJECT_ID}-fabulae/babel"
     )  # without the "gs://"
-    MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-1.5-flash")
+    MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-3.5-flash")
     BABEL_ENDPOINT: str = os.environ.get(
         "BABEL_ENDPOINT", "http://localhost:8080"
     )  # defaults to # "http://localhost:8080"

--- a/experiments/babel/main.go
+++ b/experiments/babel/main.go
@@ -391,7 +391,7 @@ func generateContent(ctx context.Context, prompt string) (string, error) {
 	}
 	defer client.Close()
 
-	gemini := client.GenerativeModel("gemini-1.5-flash")
+	gemini := client.GenerativeModel("gemini-3.5-flash")
 	gemini.SafetySettings = []*genai.SafetySetting{
 		{
 			Category:  genai.HarmCategoryHarassment,

--- a/experiments/babel/speak.go
+++ b/experiments/babel/speak.go
@@ -25,7 +25,7 @@ export GOOGLE_CLOUD_LOCATION={YOUR_LOCATION}
 export GOOGLE_GENAI_USE_VERTEXAI=false
 export GOOGLE_API_KEY={YOUR_API_KEY}
 
-go run samples/generate_audio.go --model=gemini-2.0-flash-exp
+go run samples/generate_audio.go --model=gemini-3.5-flash
 */
 
 import (
@@ -53,7 +53,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&model, "model", "gemini-2.0-flash-exp", "the model name, e.g. gemini-2.0-flash-exp")
+	flag.StringVar(&model, "model", "gemini-3.5-flash", "the model name, e.g. gemini-3.5-flash")
 	flag.StringVar(&outputfile, "output", "", "the filename for output")
 	flag.StringVar(&voiceName, "voice", "", "the voice to use, e.g. Zephyr, Puck, Charon, Kore, Fenrir, Leda, Orus, Aoede")
 	flag.BoolVar(&allVoices, "all", false, "generate audio for all voices")


### PR DESCRIPTION
## Description

experiments/babel: update stale Gemini models (gemini-1.5-flash, gemini-2.0-flash-exp). The fix is minimal: `MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-3.5-flash")` in `default.py`.

## What changed

- Fixed the issue in `experiments/babel/app/config/default.py`.
- Fixed the issue in `experiments/babel/main.go`.
- Fixed the issue in `experiments/babel/speak.go`.

## Testing

Ran the test suite: MODEL_ID=gemini-3.5-flash verified under Python 3.14.6; root suite blocked by 5 pre-existing collection errors + 1 pre-existing omni failure (all files byte-identical to main); Go toolchain absent — trivial literal swaps.

Fixes #1675