### PR TITLE
experiments/creative_podcast_assistant: update stale gemini-2.0-flash models (Closes #1677)

### DIFF
--- a/experiments/creative_podcast_assistant/NEXT_Demo_Speech_to_Text_and_Text_to_Speech_features.ipynb
+++ b/experiments/creative_podcast_assistant/NEXT_Demo_Speech_to_Text_and_Text_to_Speech_features.ipynb
@@ -1185,7 +1185,7 @@
     {
       "cell_type": "code",
       "source": [
-        "MODEL_ID = \"gemini-2.0-flash\"  # @param {type: \"string\"}"
+        "MODEL_ID = \"gemini-3.5-flash\"  # @param {type: \"string\"}"
       ],
       "metadata": {
         "id": "B8Fg1jU5CHbE"
@@ -1651,7 +1651,7 @@
     {
       "cell_type": "code",
       "source": [
-        "MODEL_ID = \"gemini-2.0-flash-exp\"  # @param {type: \"string\"}"
+        "MODEL_ID = \"gemini-3.5-flash\"  # @param {type: \"string\"}"
       ],
       "metadata": {
         "id": "QIgNIlSwE4aO"


### PR DESCRIPTION
## Summary
Updates stale Gemini model references in the `experiments/creative_podcast_assistant` demo notebook (`NEXT_Demo_Speech_to_Text_and_Text_to_Speech_features.ipynb`).

- `gemini-2.0-flash` → `gemini-3.5-flash`
- `gemini-2.0-flash-exp` → `gemini-3.5-flash`

`gemini-3.5-flash` is the current core-app default (`config/default.py`, `MODEL_ID`).

## Out of scope
`Chirp3-HD-*` / `Chirp` TTS voice references are current and were intentionally left unchanged.

## Verification
- Notebook remains valid JSON.
- Both modified code cells still parse as Python.
- Diff is surgical: 2 insertions, 2 deletions.

Closes #1677