### PR TITLE
experiments/creative-genmedia-workflow: update stale gemini-2.0-flash models (#1676)

### DIFF
--- a/experiments/creative-genmedia-workflow/main.py
+++ b/experiments/creative-genmedia-workflow/main.py
@@ -64,8 +64,8 @@ BUTTON_TEXT_COLOUR = "#03045E"
 
 # Initialize Generative Models
 
-model_20_flashlite = "gemini-2.0-flash-lite-001"
-model_20_flash = "gemini-2.0-flash-001"
+model_20_flashlite = "gemini-3.1-flash-lite"
+model_20_flash = "gemini-3.5-flash"
 
 client = genai.Client(vertexai=True, project=PROJECT_ID, location=LOCATION)
 print(f"Using GenAI SDK version: {genai.__version__}")


### PR DESCRIPTION
## Summary
Updates stale Gemini model references in `experiments/creative-genmedia-workflow/main.py`:

- `gemini-2.0-flash-lite-001` → `gemini-3.1-flash-lite`
- `gemini-2.0-flash-001` → `gemini-3.5-flash`

## Verification
- `python3 -m py_compile main.py` passes clean.
- Note: this directory requires GCP env vars to actually run (pre-existing, unrelated to this change), so a compile/import-level check is sufficient for this trivial model-name swap.

Closes #1676