### PR TITLE
experiments/VTO: update stale virtual-try-on-exp-05-31 endpoint

### DIFF
--- a/experiments/VTO/VTOatScale.ipynb
+++ b/experiments/VTO/VTOatScale.ipynb
@@ -105,7 +105,7 @@
         "# Constants\n",
         "PROJECT_ID = \"consumer-genai-experiments\"\n",
         "LOCATION = \"us-central1\"\n",
-        "MODEL_ID = \"virtual-try-on-exp-05-31\"\n",
+        "MODEL_ID = \"virtual-try-on-001\"\n",
         "PRODUCT_IMAGE_FILES = [\"red.jpg\", \"green.png\", \"dress.png\", \"blue.png\", \"yellow.png\"]\n",
         "TARGET_SIZE = (250, 550)\n",
         "model_endpoint = f\"projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{MODEL_ID}\"\n"

--- a/experiments/VTO/lj_virtual_try_on_streamlit.py
+++ b/experiments/VTO/lj_virtual_try_on_streamlit.py
@@ -15,7 +15,7 @@ st.set_page_config(page_title="Virtual Try-On", layout="wide")
 # Constants
 PROJECT_ID = "consumer-genai-experiments"
 LOCATION = "us-central1"
-MODEL_ID = "virtual-try-on-exp-05-31"
+MODEL_ID = "virtual-try-on-001"
 IMAGE_DIR = "/Users/layolin/Documents/VTO/tryon"
 PRODUCT_IMAGE_FILES = ["red.jpg", "green.png", "dress.png", "blue.png", "yellow.png"]
 TARGET_SIZE = (250, 550)


### PR DESCRIPTION
## Summary
Swaps the dated experimental Virtual Try-On endpoint `virtual-try-on-exp-05-31` for `virtual-try-on-001` in the `experiments/VTO` prototype:
- `lj_virtual_try_on_streamlit.py:18`
- `VTOatScale.ipynb` (MODEL_ID constant)

## Target endpoint — how it was confirmed
The issue flagged an open question: VTO isn't enumerated in the core `config/*` model lists, so there's no obvious "latest" source of truth. On inspection, the repo **does** contain a clear in-repo reference:

- `config/default.py:168` → `VTO_MODEL_ID = os.environ.get("VTO_MODEL_ID", "virtual-try-on-001")` — the core app's default VTO model.
- `models/model_setup.py:66` → the core app previously pinned the **identical** `virtual-try-on-exp-05-31` (now commented out) and moved to the parameterized `{model_id}`, i.e. `virtual-try-on-001`, using the **same** `PredictionServiceClient.predict` API these experiment files use.

Because the experiment uses the same raw prediction API as the core app (not the newer genai `recontext_image` SDK), `virtual-try-on-001` is the compatible, current in-repo target. (Note: `test/vto/test_vto_sdk.py` references `virtual-try-on-preview-08-04`, but that's a preview endpoint used via the newer `recontext_image` SDK, so it's a less appropriate match for this predict-API prototype.)

## Out of scope
Per the tracking issue, the hardcoded `PROJECT_ID` and machine-local `IMAGE_DIR` (`/Users/...`) path are prototype-grade and intentionally left unchanged — only the model ID is in scope.

## Verification
- `python3 -m py_compile experiments/VTO/lj_virtual_try_on_streamlit.py` passes.
- `VTOatScale.ipynb` remains valid JSON (targeted one-line edit).

Closes #1679