### PR TITLE
chore: bump Nano Banana image model gemini-2.5-flash-image -> gemini-3.1-flash-image

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -85,7 +85,7 @@ class Default:
     INIT_VERTEX: bool = True
     GEMINI_IMAGE_GEN_MODEL: str = os.environ.get(
         "GEMINI_IMAGE_GEN_MODEL",
-        "gemini-2.5-flash-image",
+        "gemini-3.1-flash-image",
     )
     GEMINI_IMAGE_GEN_LOCATION: str = os.environ.get(
         "GEMINI_IMAGE_GEN_LOCATION",
@@ -247,7 +247,7 @@ class Default:
     )
     OBJECT_ROTATION_IMAGE_MODEL: str = os.environ.get(
         "OBJECT_ROTATION_IMAGE_MODEL",
-        "gemini-2.5-flash-image",
+        "gemini-3.1-flash-image",
     )
 
     image_modifiers: list[str] = field(

--- a/docs-site/src/content/docs/core/installation/environment_variables.md
+++ b/docs-site/src/content/docs/core/installation/environment_variables.md
@@ -31,7 +31,7 @@ Controls which versions of the Gemini models are used for various tasks.
 | Variable | Default | Description |
 | :--- | :--- | :--- |
 | **`MODEL_ID`** | `gemini-3.5-flash` | The primary Gemini model used for general text and reasoning tasks throughout the app. |
-| **`GEMINI_IMAGE_GEN_MODEL`** | `gemini-2.5-flash-image` | The default model used for image generation features (supports `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, or `gemini-2.5-flash-image`). |
+| **`GEMINI_IMAGE_GEN_MODEL`** | `gemini-3.1-flash-image` | The default model used for image generation features (supports `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, or `gemini-2.5-flash-image`). |
 | **`GEMINI_IMAGE_GEN_LOCATION`** | `global` | The region for the Gemini Image Generation API. |
 | **`GEMINI_AUDIO_ANALYSIS_MODEL_ID`** | `gemini-3.1-flash-lite` | The model used specifically for analyzing audio content. |
 | **`GEMINI_WRITERS_WORKSHOP_MODEL_ID`** | `MODEL_ID` | The model used for the Gemini Writers Workshop page. Defaults to `MODEL_ID`. |

--- a/dotenv.template
+++ b/dotenv.template
@@ -61,8 +61,8 @@ PROJECT_ID=
 # GEMINI_LOCATION=global
 
 # [OPTIONAL] The specific model used for image generation features.
-# Default: gemini-2.5-flash-image
-# GEMINI_IMAGE_GEN_MODEL=gemini-2.5-flash-image
+# Default: gemini-3.1-flash-image
+# GEMINI_IMAGE_GEN_MODEL=gemini-3.1-flash-image
 
 # [OPTIONAL] The region for the Gemini Image Generation API.
 # Default: global

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -29,7 +29,7 @@ Controls which versions of the Gemini models are used for various tasks.
 | Variable | Default | Description |
 | :--- | :--- | :--- |
 | **`MODEL_ID`** | `gemini-3.5-flash` | The primary Gemini model used for general text and reasoning tasks throughout the app. |
-| **`GEMINI_IMAGE_GEN_MODEL`** | `gemini-2.5-flash-image` | The default model used for image generation features (supports `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, or `gemini-2.5-flash-image`). |
+| **`GEMINI_IMAGE_GEN_MODEL`** | `gemini-3.1-flash-image` | The default model used for image generation features (supports `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, or `gemini-2.5-flash-image`). |
 | **`GEMINI_IMAGE_GEN_LOCATION`** | `global` | The region for the Gemini Image Generation API. |
 | **`GEMINI_AUDIO_ANALYSIS_MODEL_ID`** | `gemini-3.1-flash-lite` | The model used specifically for analyzing audio content. |
 | **`GEMINI_WRITERS_WORKSHOP_MODEL_ID`** | `MODEL_ID` | The model used for the Gemini Writers Workshop page. Defaults to `MODEL_ID`. |
@@ -89,7 +89,7 @@ Specific configuration for the Object Rotation workflow.
 | Variable | Default | Description |
 | :--- | :--- | :--- |
 | **`OBJECT_ROTATION_VIDEO_MODEL`** | `veo-3.1-generate-001` | The specific Veo model used for 360-degree rotation videos. |
-| **`OBJECT_ROTATION_IMAGE_MODEL`** | `gemini-2.5-flash-image` | The specific Gemini image model used for generating multi-angle views. |
+| **`OBJECT_ROTATION_IMAGE_MODEL`** | `gemini-3.1-flash-image` | The specific Gemini image model used for generating multi-angle views. |
 
 ## 🛋️ Interior Design
 Specific configuration for the Interior Design workflow.

--- a/experiments/veo3-character-consistency/MIGRATION.md
+++ b/experiments/veo3-character-consistency/MIGRATION.md
@@ -40,14 +40,14 @@ mask inpaint/outpaint); the Imagen 4.0 generate models do not offer a like-for-l
 edit/capability call. A straight version bump is therefore not an option.
 
 The forward direction is **Nano Banana** — Gemini prompt-based image editing
-(`gemini-2.5-flash-image`). This is the same decision the **core app** already made
+(`gemini-3.1-flash-image`). This is the same decision the **core app** already made
 and shipped for its Character Consistency feature:
 
 - Precedent: **[PR #1659](https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/pull/1659)**
   ported the core app's Character Consistency edit path off `imagen-3.0-capability-001`
   onto the existing Nano Banana adapter
   (`models.gemini.generate_image_from_prompt_and_images`, backed by
-  `GEMINI_IMAGE_GEN_MODEL = gemini-2.5-flash-image`) rather than doing an
+  `GEMINI_IMAGE_GEN_MODEL = gemini-3.1-flash-image`) rather than doing an
   Imagen-4.0 swap.
 
 What that pattern means for **this experiment** when the work is actually done:

--- a/experiments/veo3-item-consistency/MIGRATION.md
+++ b/experiments/veo3-item-consistency/MIGRATION.md
@@ -41,14 +41,14 @@ mask inpaint/outpaint); the Imagen 4.0 generate models do not offer a like-for-l
 edit/capability call. A straight version bump is therefore not an option.
 
 The forward direction is **Nano Banana** — Gemini prompt-based image editing
-(`gemini-2.5-flash-image`). This is the same decision the **core app** already made
+(`gemini-3.1-flash-image`). This is the same decision the **core app** already made
 and shipped for its Character Consistency feature:
 
 - Precedent: **[PR #1659](https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/pull/1659)**
   ported the core app's Character Consistency edit path off `imagen-3.0-capability-001`
   onto the existing Nano Banana adapter
   (`models.gemini.generate_image_from_prompt_and_images`, backed by
-  `GEMINI_IMAGE_GEN_MODEL = gemini-2.5-flash-image`) rather than doing an
+  `GEMINI_IMAGE_GEN_MODEL = gemini-3.1-flash-image`) rather than doing an
   Imagen-4.0 swap.
 
 What that pattern means for **this experiment** when the work is actually done:

--- a/models/character_consistency.py
+++ b/models/character_consistency.py
@@ -267,7 +267,7 @@ def _generate_gemini_candidates(
     Imagen path passed via ``EditImageConfig``) is folded into the prompt text,
     since the Gemini adapter has no negative-prompt input.
 
-    ``gemini-2.5-flash-image`` returns one image per call, so ``num_candidates``
+    ``gemini-3.1-flash-image`` returns one image per call, so ``num_candidates``
     calls are issued in parallel (mirroring the previous behaviour of returning a
     set of candidates for downstream best-image selection).
 

--- a/test/test_gemini_search_grounding.py
+++ b/test/test_gemini_search_grounding.py
@@ -20,7 +20,7 @@ from google.genai import types
 # Retrieve project and location from environment variables
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT")
 LOCATION = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
-MODEL_ID = "gemini-2.5-flash-image"
+MODEL_ID = "gemini-3.1-flash-image"
 
 if not PROJECT_ID:
     print("Skipping test: GOOGLE_CLOUD_PROJECT not set.")

--- a/workflows/retro_games/RETRO_GAMES_README.md
+++ b/workflows/retro_games/RETRO_GAMES_README.md
@@ -20,7 +20,7 @@ The workflow consists of four main steps:
 
 -   **Models**:
     -   `gemini-2.5-flash` (or configured text model) for scene direction/storyboarding.
-    -   `gemini-2.5-flash-image` (or configured image model) for 8-bit and character sheet generation.
+    -   `gemini-3.1-flash-image` (or configured image model) for 8-bit and character sheet generation.
     -   `veo-3.1-generate-001` (or compatible Veo 3+ model) for video generation.
 -   **Libraries**:
     -   `pillow`: For image compositing in 2-player mode.


### PR DESCRIPTION
## Summary

Bumps the core app's default Gemini image-generation model ("Nano Banana") from `gemini-2.5-flash-image` to **`gemini-3.1-flash-image`** across default config, hardcoded core occurrences, and documentation.

Owner instruction: `gemini-2.5-flash-image -> gemini-3.1-flash-image please and fix.`

## Validated first (validate-first policy)

Before any code change, I ran a cheap live check of `gemini-3.1-flash-image`, **mirroring the core app's existing Nano Banana call shape** (`models/gemini.py::generate_image_from_prompt_and_images`): Vertex AI, `global` endpoint, `generateContent` with `responseModalities=[IMAGE, TEXT]` and `imageConfig.aspectRatio`.

| Model | HTTP | finishReason | Result |
| --- | --- | --- | --- |
| `gemini-3.1-flash-image` (target) | 200 | STOP | valid `image/png` (~950 KB), server-echoed `modelVersion=gemini-3.1-flash-image` |
| `gemini-2.5-flash-image` (control) | 200 | STOP | valid `image/png` (identical harness) |

Corroboration in-repo: `config/gemini_image_models.py` already registers `gemini-3.1-flash-image` with a full capability profile, and the env-var docs already list it as a supported option.

## Changes

- `config/default.py` — `GEMINI_IMAGE_GEN_MODEL` and `OBJECT_ROTATION_IMAGE_MODEL` defaults
- `dotenv.template`, `environment_variables.md`, `docs-site/.../environment_variables.md` — default value refs
- `workflows/retro_games/RETRO_GAMES_README.md` — configured image-model example
- `models/character_consistency.py` — Nano Banana docstring (3.1 also returns one image per call, confirmed live)
- `experiments/veo3-character-consistency/MIGRATION.md`, `experiments/veo3-item-consistency/MIGRATION.md` — core-app precedent refs (per brief)
- `test/test_gemini_search_grounding.py` — stale hardcoded model string (effective model is unchanged; the assignment is shadowed by a later `gemini-3-pro-image` line)

## Intentionally NOT changed

These are still-valid or historical references, not default-target references:

- `config/gemini_image_models.py` model registry — `gemini-2.5-flash-image` remains a valid *selectable* option (still returns HTTP 200); `gemini-3.1-flash-image` is already registered
- The `supports [...]` enumerations in the env-var docs — `gemini-2.5-flash-image` is still a valid option
- `test/godemos-top-models.csv` — historical usage records (bumping would falsify data)
- `experiments/brand_consistency/[Blogpost]...ipynb` — the ref is in saved cell **output** (stdout of a past run), not source

## Verification

- `python -m py_compile` on all touched `.py` files: OK
- `test/test_gemini_image_models.py` (registry): 2 passed
- `test/test_character_consistency_imagen.py` (PR #1659 path): 3 passed, 6 skipped (creds-gated); the one `_live` smoke test requires Vertex creds + full app deps and is designed to run post-merge — its model path is what the live validation above exercised
- Config import confirms both defaults now resolve to `gemini-3.1-flash-image`

Do **not** merge — coordinator gates merges.
