### PR TITLE
fix(countdown-workflow): configure setuptools packaging for flat layout

### DIFF
--- a/experiments/countdown-workflow/pyproject.toml
+++ b/experiments/countdown-workflow/pyproject.toml
@@ -9,3 +9,9 @@ dependencies = [
     "moviepy>=2.2.1",
     "yt-dlp>=2026.7.4",
 ]
+
+[tool.setuptools]
+py-modules = ["main", "config"]
+
+[tool.setuptools.packages.find]
+include = ["utils*"]


### PR DESCRIPTION
## Summary
`pip install -e .` in `experiments/countdown-workflow` failed with:

```
error: Multiple top-level modules discovered in a flat-layout: ['main', 'config'].
```

**Root cause:** `pyproject.toml` declared no `[tool.setuptools]` package/module configuration. With multiple top-level `.py` modules (`main.py`, `config.py`) present in a flat layout, setuptools auto-discovery refuses to guess what to package and aborts the build. This is a genuine build-backend packaging misconfiguration and is **independent of the Python version** — it reproduces on Python 3.12 as well (the `.python-version=3.14` pin is unrelated and left untouched).

## Fix
Declare the directory's actual layout explicitly:

```toml
[tool.setuptools]
py-modules = ["main", "config"]

[tool.setuptools.packages.find]
include = ["utils*"]
```

- `main.py` and `config.py` are the only top-level modules (`ls *.py`).
- `utils/` is a real sub-package the app imports (`from utils.download_utils import ...`); it's captured via `packages.find`.

## Verification
- `uv pip install -e .` → **exit 0** (previously failed). Reproduced original failure and confirmed fix on **Python 3.12** (version-independent).
- `python -m compileall main.py config.py utils` → OK
- `import config`, `import main`, `import utils.download_utils`, `import utils.split_video` → all OK (full-deps install)
- `top_level.txt` correctly lists `config`, `main`, `utils`.
- `.python-version` unchanged (still `3.14`, unrelated to this fix).

Scope: build/packaging fix only. No model references or other code touched.

Closes #1682