### PR TITLE
feat(mcp-genmedia): expose image_size for Gemini image generation

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/README.md
@@ -12,6 +12,8 @@ Generates content (text and/or images) based on a multimodal prompt.
 
 - `prompt` (string, required): The text prompt for content generation.
 - `model` (string, optional): The specific Gemini model to use. Defaults to `gemini-3.1-flash-image`.
+- `aspect_ratio` (string, optional): Aspect ratio of the generated image(s), e.g. `1:1`, `16:9`, `21:9`. Defaults to `1:1`. Supported ratios are model-dependent.
+- `image_size` (string, optional): Size of the generated image(s): `1K`, `2K`, or `4K`. When unset the model's default (`1K`) is used. Supported sizes are model-dependent.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
@@ -50,6 +50,11 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 		aspectRatio = strings.TrimSpace(ar)
 	}
 
+	imageSize := ""
+	if is, ok := request.GetArguments()["image_size"].(string); ok && strings.TrimSpace(is) != "" {
+		imageSize = strings.TrimSpace(is)
+	}
+
 	modelArg, _ := request.GetArguments()["model"].(string)
 	model := "gemini-3.1-flash-image"
 	if modelArg != "" {
@@ -112,6 +117,7 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 		ResponseModalities: []string{"IMAGE", "TEXT"},
 		ImageConfig: &genai.ImageConfig{
 			AspectRatio: aspectRatio,
+			ImageSize:   imageSize,
 		},
 	}
 	contents := &genai.Content{Parts: parts, Role: "USER"}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -103,6 +103,7 @@ func main() {
 		mcp.WithString("prompt", mcp.Required(), mcp.Description("The text prompt for content generation.")),
 		mcp.WithString("model", mcp.DefaultString("gemini-3.1-flash-image"), mcp.Description(common.BuildGeminiImageModelDescription())),
 		mcp.WithString("aspect_ratio", mcp.DefaultString("1:1"), mcp.Description("Aspect ratio of the generated images. Note: supported aspect ratios are model-dependent.")),
+		mcp.WithString("image_size", mcp.Description("Optional. Size of the generated images: 1K, 2K, or 4K. Defaults to 1K when unset. Note: supported sizes are model-dependent.")),
 		mcp.WithArray("images", mcp.Description("Optional. A list of local file paths or GCS URIs for input images."), mcp.Items(map[string]any{"type": "string"})),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save generated image(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated images (e.g., your-bucket/outputs/).")),

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/README.md
@@ -12,6 +12,8 @@ Generates content (text and/or images) based on a multimodal prompt.
 
 - `prompt` (string, required): The text prompt for content generation.
 - `model` (string, optional): The specific NanoBanana (Gemini Image) model to use. Defaults to `gemini-3.1-flash-image`.
+- `aspect_ratio` (string, optional): Aspect ratio of the generated image(s), e.g. `1:1`, `16:9`, `21:9`. Defaults to `1:1`. Supported ratios are model-dependent.
+- `image_size` (string, optional): Size of the generated image(s): `1K`, `2K`, or `4K`. When unset the model's default (`1K`) is used. Supported sizes are model-dependent.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
 - `gcs_bucket_uri` (string, optional): GCS URI prefix to store any generated images.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -49,6 +49,11 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		aspectRatio = strings.TrimSpace(ar)
 	}
 
+	imageSize := ""
+	if is, ok := request.GetArguments()["image_size"].(string); ok && strings.TrimSpace(is) != "" {
+		imageSize = strings.TrimSpace(is)
+	}
+
 	modelArg, _ := request.GetArguments()["model"].(string)
 	model := "gemini-3.1-flash-image"
 	if modelArg != "" {
@@ -117,6 +122,7 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		ResponseModalities: []string{"IMAGE", "TEXT"},
 		ImageConfig: &genai.ImageConfig{
 			AspectRatio: aspectRatio,
+			ImageSize:   imageSize,
 		},
 		Seed: seed,
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -103,6 +103,7 @@ func main() {
 		mcp.WithString("prompt", mcp.Required(), mcp.Description("The text prompt for content generation.")),
 		mcp.WithString("model", mcp.DefaultString("gemini-3.1-flash-image"), mcp.Description(common.BuildGeminiImageModelDescription())),
 		mcp.WithString("aspect_ratio", mcp.DefaultString("1:1"), mcp.Description("Aspect ratio of the generated images. Note: supported aspect ratios are model-dependent.")),
+		mcp.WithString("image_size", mcp.Description("Optional. Size of the generated images: 1K, 2K, or 4K. Defaults to 1K when unset. Note: supported sizes are model-dependent.")),
 		mcp.WithArray("images", mcp.Description("Optional. A list of local file paths or GCS URIs for input media (images, videos, or PDFs)."), mcp.Items(map[string]any{"type": "string"})),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save generated image(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated images (e.g., your-bucket/outputs/).")),


### PR DESCRIPTION
## What

`genai.ImageConfig` has always carried an `ImageSize` field (`1K`, `2K`, `4K`), but neither `mcp-gemini-go` nor `mcp-nanobanana-go` surfaced it — so both servers were effectively pinned to the model default of 1K with no way to ask for more.

`mcp-imagen-go` already exposes an `image_size` parameter, so this brings the two Gemini image servers in line with it and reuses the same parameter name.

## How

The new parameter is parsed exactly like the existing `aspect_ratio` and passed straight through to `ImageConfig`.

It has **no default**: when unset the field stays empty, `omitempty` drops it from the request, and the model applies its own default. Behaviour is unchanged for existing callers. (`mcp-imagen-go` uses `DefaultString("1K")` instead — happy to switch to that for consistency if you'd prefer it.)

## Deliberately left out

Validation against a per-model registry. These two servers don't currently validate `aspect_ratio` against the registry's `SupportedAspectRatios` either, so pass-through matches the surrounding code. Adding `SupportedImageSizes` to `GeminiImageModelInfo` and validating both parameters seems reasonable, but it asserts per-model capabilities that deserve their own change.

## Docs

Both server READMEs now document `image_size` **and** `aspect_ratio`. The tool parameter lists had omitted `aspect_ratio` entirely, which makes the READMEs read as though these servers can't control image geometry at all — that's what sent me to the source in the first place.

## Verification

Against Vertex AI with `gemini-3-pro-image`:

| server | request | output |
|---|---|---|
| `mcp-nanobanana-go` | `aspect_ratio 16:9` + `image_size 2K` | 2752x1536 |
| `mcp-gemini-go` | `aspect_ratio 21:9` + `image_size 2K` | 3168x1344 |
| both | neither set (control) | 1024x1024 |

`go vet` clean and the existing tests pass for both modules.

No new unit test: the parameter is read and passed inside the request handler with no seam that can be exercised without a live client, which is why the existing `aspect_ratio` has none either. Glad to add one if you'd like the config construction extracted into a testable helper.