### PR TITLE
docs(mcp-genmedia): clarify image_size default wording + document no-default policy

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
@@ -50,6 +50,11 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 		aspectRatio = strings.TrimSpace(ar)
 	}
 
+	// No-default policy (intentional): unlike mcp-imagen-go, image_size is not
+	// registered with a DefaultString. When unset it stays empty and is dropped by
+	// omitempty, so the model applies its own default (currently 1K). This is a
+	// deliberate passthrough choice so the tool never asserts a size the model may
+	// not support; keep it defaulting to the empty string here.
 	imageSize := ""
 	if is, ok := request.GetArguments()["image_size"].(string); ok && strings.TrimSpace(is) != "" {
 		imageSize = strings.TrimSpace(is)

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/main.go
@@ -103,7 +103,7 @@ func main() {
 		mcp.WithString("prompt", mcp.Required(), mcp.Description("The text prompt for content generation.")),
 		mcp.WithString("model", mcp.DefaultString("gemini-3.1-flash-image"), mcp.Description(common.BuildGeminiImageModelDescription())),
 		mcp.WithString("aspect_ratio", mcp.DefaultString("1:1"), mcp.Description("Aspect ratio of the generated images. Note: supported aspect ratios are model-dependent.")),
-		mcp.WithString("image_size", mcp.Description("Optional. Size of the generated images: 1K, 2K, or 4K. Defaults to 1K when unset. Note: supported sizes are model-dependent.")),
+		mcp.WithString("image_size", mcp.Description("Optional. Size of the generated images: 1K, 2K, or 4K. When unset, the model's default (currently 1K) applies. Note: supported sizes are model-dependent.")),
 		mcp.WithArray("images", mcp.Description("Optional. A list of local file paths or GCS URIs for input images."), mcp.Items(map[string]any{"type": "string"})),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save generated image(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated images (e.g., your-bucket/outputs/).")),

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -49,6 +49,11 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 		aspectRatio = strings.TrimSpace(ar)
 	}
 
+	// No-default policy (intentional): unlike mcp-imagen-go, image_size is not
+	// registered with a DefaultString. When unset it stays empty and is dropped by
+	// omitempty, so the model applies its own default (currently 1K). This is a
+	// deliberate passthrough choice so the tool never asserts a size the model may
+	// not support; keep it defaulting to the empty string here.
 	imageSize := ""
 	if is, ok := request.GetArguments()["image_size"].(string); ok && strings.TrimSpace(is) != "" {
 		imageSize = strings.TrimSpace(is)

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/main.go
@@ -103,7 +103,7 @@ func main() {
 		mcp.WithString("prompt", mcp.Required(), mcp.Description("The text prompt for content generation.")),
 		mcp.WithString("model", mcp.DefaultString("gemini-3.1-flash-image"), mcp.Description(common.BuildGeminiImageModelDescription())),
 		mcp.WithString("aspect_ratio", mcp.DefaultString("1:1"), mcp.Description("Aspect ratio of the generated images. Note: supported aspect ratios are model-dependent.")),
-		mcp.WithString("image_size", mcp.Description("Optional. Size of the generated images: 1K, 2K, or 4K. Defaults to 1K when unset. Note: supported sizes are model-dependent.")),
+		mcp.WithString("image_size", mcp.Description("Optional. Size of the generated images: 1K, 2K, or 4K. When unset, the model's default (currently 1K) applies. Note: supported sizes are model-dependent.")),
 		mcp.WithArray("images", mcp.Description("Optional. A list of local file paths or GCS URIs for input media (images, videos, or PDFs)."), mcp.Items(map[string]any{"type": "string"})),
 		mcp.WithString("output_directory", mcp.Description("Optional. Local directory to save generated image(s) to.")),
 		mcp.WithString("gcs_bucket_uri", mcp.Description("Optional. GCS URI prefix to store generated images (e.g., your-bucket/outputs/).")),


### PR DESCRIPTION
Fast-follow to #1733 (merged).

## What
1. **Wording fix** — the `image_size` tool descriptions in `mcp-gemini-go/main.go` and `mcp-nanobanana-go/main.go` said *"Defaults to 1K when unset"*, which reads as though the tool forces a 1K default. It does not: `image_size` is registered with no `DefaultString`, stays empty when unset, and is dropped by `omitempty` so the **model** applies its own default (currently 1K). Reworded to *"When unset, the model's default (currently 1K) applies."*
2. **Policy note** — added a short comment next to the `image_size` parsing in both handlers documenting that the **no-default (passthrough) policy is intentional** — the tool deliberately never asserts an image size the model may not support. This confirms/keeps the existing behavior rather than adopting `mcp-imagen-go`'s `DefaultString("1K")`.

## Notes
- The two READMEs already carried the corrected wording, so no README change was needed.
- No behavior change — descriptions and a comment only.
- `go vet ./...` and `go build ./...` pass clean in both `mcp-gemini-go` and `mcp-nanobanana-go`.

Context: addresses recommendations #1 (wording nit) and #2 (confirm no-default policy) from the review of #1733. The registry-validation item (#3) is tracked as a separate issue.