### PR TITLE
fix(mcp-genmedia): add SupportedImageSizes and validate Gemini image params (#1746)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -142,6 +142,7 @@ type GeminiImageModelInfo struct {
 	CanonicalName         string
 	Aliases               []string
 	SupportedAspectRatios []string
+	SupportedImageSizes   []string // mirrors ImagenModelInfo; empty means image_size is unsupported/ignored
 	Description           string
 }
 
@@ -150,26 +151,30 @@ var SupportedGeminiImageModels = map[string]GeminiImageModelInfo{
 	"gemini-3.1-flash-image": {
 		CanonicalName:         "gemini-3.1-flash-image",
 		Aliases:               []string{"Nano Banana 2"},
-		SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9"},
+		SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "1:4", "4:1", "4:3", "4:5", "5:4", "1:8", "8:1", "9:16", "16:9", "21:9", "9:21"},
+		SupportedImageSizes:   []string{"512", "1K", "2K", "4K"}, // 4K is Preview
 		Description:           "Gemini 3.1 Flash Image, or Nano Banana 2.",
 	},
 	"gemini-3.1-flash-lite-image": {
 		CanonicalName:         "gemini-3.1-flash-lite-image",
 		Aliases:               []string{"Nano Banana 2 Lite"},
-		SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "4:3", "9:16", "16:9", "21:9"},
+		SupportedAspectRatios: []string{"1:1", "1:4", "4:1", "1:8", "8:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"},
+		SupportedImageSizes:   []string{"1K"},
 		Description:           "Gemini 3.1 Flash Lite Image, or Nano Banana 2 Lite, is optimized for high-speed, cost-effective image generation at 1K resolution.",
 	},
 
 	"gemini-3-pro-image": {
 		CanonicalName:         "gemini-3-pro-image",
 		Aliases:               []string{"Nano Banana Pro", "Gemini 3 Pro Image"},
-		SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"},
+		SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "1:4", "4:1", "4:3", "4:5", "5:4", "1:8", "8:1", "9:16", "16:9", "21:9", "9:21"},
+		SupportedImageSizes:   []string{"1K", "2K", "4K"}, // 4K is Preview
 		Description:           "Gemini 3 Pro Image, or Gemini 3 Pro (with Nano Banana), is designed to tackle the most challenging image generation by incorporating state-of-the-art reasoning capabilities. It's the best model for complex and multi-turn image generation and editing, having improved accuracy and enhanced image quality.",
 	},
 	"gemini-2.5-flash-image": {
 		CanonicalName:         "gemini-2.5-flash-image",
 		Aliases:               []string{"Nano Banana", "nano-banana"},
-		SupportedAspectRatios: []string{"1:1", "3:4", "4:3", "9:16", "16:9"},
+		SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"},
+		SupportedImageSizes:   []string{}, // no resolution control: image_size is silently ignored by the API (verified empirically)
 		Description:           "Gemini 2.5 Flash Image, or Nano Banana, is optimized for image understanding and generation and offers a balance of price and performance.",
 	},
 }
@@ -196,7 +201,8 @@ func ResolveGeminiImageModel(modelInput string, allowUnsafe bool) (GeminiImageMo
 		// Return a permissive fallback struct for experimental models
 		return GeminiImageModelInfo{
 			CanonicalName:         modelInput,
-			SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9"},
+			SupportedAspectRatios: []string{"1:1", "3:2", "2:3", "3:4", "1:4", "4:1", "4:3", "4:5", "5:4", "1:8", "8:1", "9:16", "16:9", "21:9", "9:21"},
+			SupportedImageSizes:   []string{"512", "1K", "2K", "4K"},
 		}, true
 	}
 
@@ -216,6 +222,9 @@ func BuildGeminiImageModelDescription() string {
 	for _, name := range sortedNames {
 		info := SupportedGeminiImageModels[name]
 		fmt.Fprintf(&sb, "- *%s* (Ratios: %s)", info.CanonicalName, strings.Join(info.SupportedAspectRatios, ", "))
+		if len(info.SupportedImageSizes) > 0 {
+			fmt.Fprintf(&sb, " (Sizes: %s)", strings.Join(info.SupportedImageSizes, ", "))
+		}
 		if len(info.Aliases) > 0 {
 			fmt.Fprintf(&sb, " Aliases: *%s*", strings.Join(info.Aliases, "*, *"))
 		}
@@ -420,7 +429,6 @@ func BuildVeoModelDescription() string {
 	return sb.String()
 }
 
-
 // --- Lyria Model Configuration ---
 
 // LyriaModelInfo holds the details for a specific Lyria model.
@@ -473,7 +481,7 @@ func ResolveLyriaModel(modelInput string, allowUnsafe bool) (LyriaModelInfo, boo
 		// Default to Interactions API as it's the newer path for upcoming models.
 		return LyriaModelInfo{
 			CanonicalName: modelInput,
-			EndpointType:  "interactions", 
+			EndpointType:  "interactions",
 		}, true
 	}
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestGeminiImageModelAspectRatios pins the corrected, doc-verified aspect-ratio
+// lists for every supported Gemini image model. These lists gate the handler
+// validation added for issue #1746: a stale list would wrongly downgrade a
+// user's valid aspect ratio to 1:1.
+func TestGeminiImageModelAspectRatios(t *testing.T) {
+	want := map[string][]string{
+		"gemini-3.1-flash-image":      {"1:1", "3:2", "2:3", "3:4", "1:4", "4:1", "4:3", "4:5", "5:4", "1:8", "8:1", "9:16", "16:9", "21:9", "9:21"},
+		"gemini-3.1-flash-lite-image": {"1:1", "1:4", "4:1", "1:8", "8:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"},
+		"gemini-3-pro-image":          {"1:1", "3:2", "2:3", "3:4", "1:4", "4:1", "4:3", "4:5", "5:4", "1:8", "8:1", "9:16", "16:9", "21:9", "9:21"},
+		"gemini-2.5-flash-image":      {"1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"},
+	}
+	for model, ratios := range want {
+		info, ok := SupportedGeminiImageModels[model]
+		if !ok {
+			t.Errorf("model %q missing from SupportedGeminiImageModels", model)
+			continue
+		}
+		if !reflect.DeepEqual(info.SupportedAspectRatios, ratios) {
+			t.Errorf("model %q aspect ratios = %v, want %v", model, info.SupportedAspectRatios, ratios)
+		}
+	}
+}
+
+// TestGeminiImageModelSizes pins the SupportedImageSizes field added for #1746.
+// gemini-2.5-flash-image has no resolution control (empirically verified: an
+// image_size value is silently ignored by the API), so its list is empty.
+func TestGeminiImageModelSizes(t *testing.T) {
+	want := map[string][]string{
+		"gemini-3.1-flash-image":      {"512", "1K", "2K", "4K"},
+		"gemini-3.1-flash-lite-image": {"1K"},
+		"gemini-3-pro-image":          {"1K", "2K", "4K"},
+		"gemini-2.5-flash-image":      {},
+	}
+	for model, sizes := range want {
+		info, ok := SupportedGeminiImageModels[model]
+		if !ok {
+			t.Errorf("model %q missing from SupportedGeminiImageModels", model)
+			continue
+		}
+		if len(info.SupportedImageSizes) != len(sizes) {
+			t.Errorf("model %q image sizes = %v, want %v", model, info.SupportedImageSizes, sizes)
+			continue
+		}
+		if len(sizes) > 0 && !reflect.DeepEqual(info.SupportedImageSizes, sizes) {
+			t.Errorf("model %q image sizes = %v, want %v", model, info.SupportedImageSizes, sizes)
+		}
+	}
+}
+
+// TestResolveGeminiImageModelAlias confirms alias resolution still returns the
+// canonical entry (with its populated SupportedImageSizes).
+func TestResolveGeminiImageModelAlias(t *testing.T) {
+	info, found := ResolveGeminiImageModel("nano-banana", false)
+	if !found {
+		t.Fatal("expected alias 'nano-banana' to resolve")
+	}
+	if info.CanonicalName != "gemini-2.5-flash-image" {
+		t.Errorf("CanonicalName = %q, want gemini-2.5-flash-image", info.CanonicalName)
+	}
+	if len(info.SupportedImageSizes) != 0 {
+		t.Errorf("gemini-2.5-flash-image SupportedImageSizes = %v, want empty", info.SupportedImageSizes)
+	}
+}
+
+// TestResolveGeminiImageModelUnsafeFallback confirms the permissive fallback for
+// experimental models carries a populated SupportedImageSizes superset so a
+// caller-supplied image_size is not stripped by the handler validation.
+func TestResolveGeminiImageModelUnsafeFallback(t *testing.T) {
+	info, found := ResolveGeminiImageModel("some-future-image-model", true)
+	if !found {
+		t.Fatal("expected unsafe fallback to resolve when allowUnsafe=true")
+	}
+	if info.CanonicalName != "some-future-image-model" {
+		t.Errorf("CanonicalName = %q, want some-future-image-model", info.CanonicalName)
+	}
+	if len(info.SupportedImageSizes) == 0 {
+		t.Error("expected unsafe fallback to carry a permissive SupportedImageSizes list")
+	}
+
+	if _, found := ResolveGeminiImageModel("some-future-image-model", false); found {
+		t.Error("expected unknown model to NOT resolve when allowUnsafe=false")
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,6 +34,29 @@ import (
 
 	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
 )
+
+// validateGeminiImageParams checks the requested aspect_ratio and image_size
+// against a resolved model's declared capabilities, mirroring the
+// mcp-imagen-go fallback pattern: an unsupported aspect_ratio falls back to
+// "1:1", and an image_size that the model does not support (or does not
+// support at all) is dropped so the API applies its own default. It returns
+// the (possibly adjusted) aspect_ratio and image_size.
+func validateGeminiImageParams(info common.GeminiImageModelInfo, model, aspectRatio, imageSize string) (string, string) {
+	if !slices.Contains(info.SupportedAspectRatios, aspectRatio) {
+		log.Printf("Warning: Requested aspect ratio '%s' is not supported by model %s. Supported ratios are: %v. Falling back to '1:1'.", aspectRatio, model, info.SupportedAspectRatios)
+		aspectRatio = "1:1"
+	}
+	if imageSize != "" {
+		if len(info.SupportedImageSizes) == 0 {
+			log.Printf("Warning: image_size parameter ('%s') provided, but model %s does not support it. The parameter will be ignored.", imageSize, model)
+			imageSize = ""
+		} else if !slices.Contains(info.SupportedImageSizes, imageSize) {
+			log.Printf("Warning: Requested image size '%s' is not supported by model %s. Supported sizes are: %v. The parameter will be ignored.", imageSize, model, info.SupportedImageSizes)
+			imageSize = ""
+		}
+	}
+	return aspectRatio, imageSize
+}
 
 func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tr := otel.Tracer(serviceName)
@@ -58,11 +82,14 @@ func geminiGenerateContentHandler(client *genai.Client, ctx context.Context, req
 	modelArg, _ := request.GetArguments()["model"].(string)
 	model := "gemini-3.1-flash-image"
 	if modelArg != "" {
-		if resolvedInfo, found := common.ResolveGeminiImageModel(modelArg, appConfig.AllowUnsafeModels); found {
-			model = resolvedInfo.CanonicalName
-		} else {
-			model = modelArg
-		}
+		model = modelArg
+	}
+	// Resolve the model (including the default) so aspect_ratio/image_size can be
+	// validated against its declared capabilities. Unknown models that cannot be
+	// resolved (AllowUnsafeModels disabled) are passed through untouched.
+	if resolvedInfo, found := common.ResolveGeminiImageModel(model, appConfig.AllowUnsafeModels); found {
+		model = resolvedInfo.CanonicalName
+		aspectRatio, imageSize = validateGeminiImageParams(resolvedInfo, model, aspectRatio, imageSize)
 	}
 
 	outputDir := ""

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers_validate_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/handlers_validate_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
+)
+
+func TestValidateGeminiImageParams(t *testing.T) {
+	withSizes := common.GeminiImageModelInfo{
+		CanonicalName:         "gemini-3.1-flash-image",
+		SupportedAspectRatios: []string{"1:1", "16:9", "9:21"},
+		SupportedImageSizes:   []string{"1K", "2K", "4K"},
+	}
+	noSizes := common.GeminiImageModelInfo{
+		CanonicalName:         "gemini-2.5-flash-image",
+		SupportedAspectRatios: []string{"1:1", "16:9"},
+		SupportedImageSizes:   []string{},
+	}
+
+	tests := []struct {
+		name          string
+		info          common.GeminiImageModelInfo
+		aspectRatio   string
+		imageSize     string
+		wantAspect    string
+		wantImageSize string
+	}{
+		{
+			name:          "valid aspect and size pass through",
+			info:          withSizes,
+			aspectRatio:   "16:9",
+			imageSize:     "2K",
+			wantAspect:    "16:9",
+			wantImageSize: "2K",
+		},
+		{
+			name:          "unsupported aspect falls back to 1:1",
+			info:          withSizes,
+			aspectRatio:   "3:1",
+			imageSize:     "1K",
+			wantAspect:    "1:1",
+			wantImageSize: "1K",
+		},
+		{
+			name:          "unsupported size is dropped",
+			info:          withSizes,
+			aspectRatio:   "1:1",
+			imageSize:     "8K",
+			wantAspect:    "1:1",
+			wantImageSize: "",
+		},
+		{
+			name:          "size dropped when model supports none",
+			info:          noSizes,
+			aspectRatio:   "16:9",
+			imageSize:     "2K",
+			wantAspect:    "16:9",
+			wantImageSize: "",
+		},
+		{
+			name:          "empty size stays empty",
+			info:          noSizes,
+			aspectRatio:   "1:1",
+			imageSize:     "",
+			wantAspect:    "1:1",
+			wantImageSize: "",
+		},
+		{
+			name:          "newly-supported aspect ratio is not downgraded",
+			info:          withSizes,
+			aspectRatio:   "9:21",
+			imageSize:     "",
+			wantAspect:    "9:21",
+			wantImageSize: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAspect, gotSize := validateGeminiImageParams(tt.info, tt.info.CanonicalName, tt.aspectRatio, tt.imageSize)
+			if gotAspect != tt.wantAspect {
+				t.Errorf("aspectRatio = %q, want %q", gotAspect, tt.wantAspect)
+			}
+			if gotSize != tt.wantImageSize {
+				t.Errorf("imageSize = %q, want %q", gotSize, tt.wantImageSize)
+			}
+		})
+	}
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -32,6 +33,29 @@ import (
 
 	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
 )
+
+// validateGeminiImageParams checks the requested aspect_ratio and image_size
+// against a resolved model's declared capabilities, mirroring the
+// mcp-imagen-go fallback pattern: an unsupported aspect_ratio falls back to
+// "1:1", and an image_size that the model does not support (or does not
+// support at all) is dropped so the API applies its own default. It returns
+// the (possibly adjusted) aspect_ratio and image_size.
+func validateGeminiImageParams(info common.GeminiImageModelInfo, model, aspectRatio, imageSize string) (string, string) {
+	if !slices.Contains(info.SupportedAspectRatios, aspectRatio) {
+		log.Printf("Warning: Requested aspect ratio '%s' is not supported by model %s. Supported ratios are: %v. Falling back to '1:1'.", aspectRatio, model, info.SupportedAspectRatios)
+		aspectRatio = "1:1"
+	}
+	if imageSize != "" {
+		if len(info.SupportedImageSizes) == 0 {
+			log.Printf("Warning: image_size parameter ('%s') provided, but model %s does not support it. The parameter will be ignored.", imageSize, model)
+			imageSize = ""
+		} else if !slices.Contains(info.SupportedImageSizes, imageSize) {
+			log.Printf("Warning: Requested image size '%s' is not supported by model %s. Supported sizes are: %v. The parameter will be ignored.", imageSize, model, info.SupportedImageSizes)
+			imageSize = ""
+		}
+	}
+	return aspectRatio, imageSize
+}
 
 func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tr := otel.Tracer(serviceName)
@@ -57,11 +81,14 @@ func nanobananaGenerateContentHandler(client *genai.Client, ctx context.Context,
 	modelArg, _ := request.GetArguments()["model"].(string)
 	model := "gemini-3.1-flash-image"
 	if modelArg != "" {
-		if resolvedInfo, found := common.ResolveGeminiImageModel(modelArg, appConfig.AllowUnsafeModels); found {
-			model = resolvedInfo.CanonicalName
-		} else {
-			model = modelArg
-		}
+		model = modelArg
+	}
+	// Resolve the model (including the default) so aspect_ratio/image_size can be
+	// validated against its declared capabilities. Unknown models that cannot be
+	// resolved (AllowUnsafeModels disabled) are passed through untouched.
+	if resolvedInfo, found := common.ResolveGeminiImageModel(model, appConfig.AllowUnsafeModels); found {
+		model = resolvedInfo.CanonicalName
+		aspectRatio, imageSize = validateGeminiImageParams(resolvedInfo, model, aspectRatio, imageSize)
 	}
 
 	seed, err := common.ParseOptionalNonNegativeInt32(request.GetArguments(), "seed")

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_validate_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-nanobanana-go/handlers_validate_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	common "github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
+)
+
+func TestValidateGeminiImageParams(t *testing.T) {
+	withSizes := common.GeminiImageModelInfo{
+		CanonicalName:         "gemini-3.1-flash-image",
+		SupportedAspectRatios: []string{"1:1", "16:9", "9:21"},
+		SupportedImageSizes:   []string{"1K", "2K", "4K"},
+	}
+	noSizes := common.GeminiImageModelInfo{
+		CanonicalName:         "gemini-2.5-flash-image",
+		SupportedAspectRatios: []string{"1:1", "16:9"},
+		SupportedImageSizes:   []string{},
+	}
+
+	tests := []struct {
+		name          string
+		info          common.GeminiImageModelInfo
+		aspectRatio   string
+		imageSize     string
+		wantAspect    string
+		wantImageSize string
+	}{
+		{
+			name:          "valid aspect and size pass through",
+			info:          withSizes,
+			aspectRatio:   "16:9",
+			imageSize:     "2K",
+			wantAspect:    "16:9",
+			wantImageSize: "2K",
+		},
+		{
+			name:          "unsupported aspect falls back to 1:1",
+			info:          withSizes,
+			aspectRatio:   "3:1",
+			imageSize:     "1K",
+			wantAspect:    "1:1",
+			wantImageSize: "1K",
+		},
+		{
+			name:          "unsupported size is dropped",
+			info:          withSizes,
+			aspectRatio:   "1:1",
+			imageSize:     "8K",
+			wantAspect:    "1:1",
+			wantImageSize: "",
+		},
+		{
+			name:          "size dropped when model supports none",
+			info:          noSizes,
+			aspectRatio:   "16:9",
+			imageSize:     "2K",
+			wantAspect:    "16:9",
+			wantImageSize: "",
+		},
+		{
+			name:          "empty size stays empty",
+			info:          noSizes,
+			aspectRatio:   "1:1",
+			imageSize:     "",
+			wantAspect:    "1:1",
+			wantImageSize: "",
+		},
+		{
+			name:          "newly-supported aspect ratio is not downgraded",
+			info:          withSizes,
+			aspectRatio:   "9:21",
+			imageSize:     "",
+			wantAspect:    "9:21",
+			wantImageSize: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAspect, gotSize := validateGeminiImageParams(tt.info, tt.info.CanonicalName, tt.aspectRatio, tt.imageSize)
+			if gotAspect != tt.wantAspect {
+				t.Errorf("aspectRatio = %q, want %q", gotAspect, tt.wantAspect)
+			}
+			if gotSize != tt.wantImageSize {
+				t.Errorf("imageSize = %q, want %q", gotSize, tt.wantImageSize)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the follow-up to #1733 tracked in #1746: teaches the Gemini image MCP
servers about per-model **resolution** support and fixes the stale aspect-ratio
data, then adds client-side validation mirroring the existing `mcp-imagen-go`
pattern.

### What changed
- **`mcp-common/models.go`**
  - Added `SupportedImageSizes []string` to `GeminiImageModelInfo` (mirrors `ImagenModelInfo`).
  - Corrected/completed `SupportedAspectRatios` for all four Gemini image models against the live Google Cloud model docs.
  - Populated `SupportedImageSizes` per model. `4K` is a **Preview** feature on `gemini-3.1-flash-image` and `gemini-3-pro-image`; `gemini-3.1-flash-lite-image` is `1K`-only.
  - Updated the permissive unsafe-model fallback and the tool description builder to include sizes.
- **`mcp-gemini-go/handlers.go`** and **`mcp-nanobanana-go/handlers.go`**
  - Capture the resolved model info and validate `aspect_ratio` (unsupported → falls back to `1:1`) and `image_size` (unsupported, or unsupported-by-model → dropped so the API applies its default), mirroring `mcp-imagen-go/imagen.go`.
- **Tests** for the corrected ratio lists, the new `SupportedImageSizes` field, the unsafe fallback, and the handler validation logic.

> ⚠️ Correcting the aspect-ratio lists is a **prerequisite** for adding aspect-ratio validation: against the old stale lists a user requesting a now-valid ratio like `1:4` would be wrongly downgraded to `1:1`.

### `gemini-2.5-flash-image` (original Nano Banana)
This model has **no resolution control**, so its `SupportedImageSizes` is empty
(an empty list means `image_size` is ignored). Verified two ways:
- **Docs:** the model page lists supported aspect ratios (`1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9`) and **no** resolution/`image_size` field.
- **Empirically** (live Vertex `generateContent`): passing `imageConfig.imageSize=2K` returns **HTTP 200** but the image comes back at the default **1024×1024** — i.e. `image_size` is *silently ignored*, not honored (and, unlike the Gemini-3.x models, not hard-rejected).

### Verification
- `go build ./...`, `go vet ./...`, `go test ./...` pass for `mcp-common`, `mcp-gemini-go`, and `mcp-nanobanana-go`.
- Aspect-ratio and resolution data cross-checked against the live Google Cloud model docs; `gemini-2.5-flash-image` resolution behavior confirmed with a live API call (mirroring this project's established empirical-verification practice).

Credit to @ivank for identifying the `SupportedImageSizes` gap in #1733.

Closes #1746
