### PR TITLE
feat(omni): default to gemini-omni-1.1-flash-preview and expose resolution

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -156,10 +156,12 @@ class Default:
     # Gemini Omni
     DEFAULT_OMNI_MODEL_NAME: str = os.environ.get(
         "DEFAULT_OMNI_MODEL_NAME",
-        "gemini-omni-flash-preview",
+        "gemini-omni-1.1-flash-preview",
     )
     OMNI_LOCATION: str = os.environ.get("OMNI_LOCATION", "global")
-    OMNI_MODEL_ID: str = os.environ.get("OMNI_MODEL_ID", "gemini-omni-flash-preview")
+    OMNI_MODEL_ID: str = os.environ.get(
+        "OMNI_MODEL_ID", "gemini-omni-1.1-flash-preview"
+    )
     OMNI_PROJECT_ID: str = os.environ.get("OMNI_PROJECT_ID", PROJECT_ID)
     OMNI_TIMEOUT_MS: int = int(os.environ.get("OMNI_TIMEOUT_MS", "600000"))
 

--- a/config/omni_models.py
+++ b/config/omni_models.py
@@ -36,6 +36,19 @@ class OmniModelConfig:
 # Single source of truth for all Omni model configurations.
 OMNI_MODELS: list[OmniModelConfig] = [
     OmniModelConfig(
+        version_id="gemini-omni-1.1-flash-preview",
+        model_name="gemini-omni-1.1-flash-preview",
+        display_name="Gemini Omni 1.1 Flash (Preview)",
+        supported_modes=["t2v", "i2v", "ref2v", "edit"],
+        supported_aspect_ratios=["16:9", "9:16"],
+        resolutions=["360p", "720p", "1080p", "4k"],
+        min_duration=3,
+        max_duration=10,
+        default_duration=10,
+        max_samples=1,  # Quota limits focus on 1 sample
+        default_samples=1,
+    ),
+    OmniModelConfig(
         version_id="gemini-omni-flash-preview",
         model_name="gemini-omni-flash-preview",
         display_name="Gemini Omni Flash (Preview)",
@@ -77,5 +90,5 @@ from config.default import Default
 cfg = Default()
 DEFAULT_OMNI_VERSION_ID = (
     get_version_id_by_model_name(cfg.DEFAULT_OMNI_MODEL_NAME)
-    or "gemini-omni-flash-preview"
+    or "gemini-omni-1.1-flash-preview"
 )

--- a/docs-site/src/content/docs/core/installation/environment_variables.md
+++ b/docs-site/src/content/docs/core/installation/environment_variables.md
@@ -45,9 +45,9 @@ Configuration for the Gemini Omni Flash multimodal video interaction model.
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
-| **`DEFAULT_OMNI_MODEL_NAME`** | `gemini-omni-flash-preview` | The fallback model identifier for Gemini Omni when starting a session. |
+| **`DEFAULT_OMNI_MODEL_NAME`** | `gemini-omni-1.1-flash-preview` | The fallback model identifier for Gemini Omni when starting a session. |
 | **`OMNI_LOCATION`** | `global` | Region for the Gemini Omni API endpoint. |
-| **`OMNI_MODEL_ID`** | `gemini-omni-flash-preview` | The standard Gemini Omni model ID. |
+| **`OMNI_MODEL_ID`** | `gemini-omni-1.1-flash-preview` | The standard Gemini Omni model ID. |
 | **`OMNI_PROJECT_ID`** | `PROJECT_ID` | Allows using a different GCP project for Gemini Omni quota if needed. |
 | **`OMNI_TIMEOUT_MS`** | `600000` | Client-side HTTP timeout in milliseconds (default 10 minutes) for long-running video generation and editing requests. |
 

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -43,9 +43,9 @@ Configuration for the Gemini Omni Flash multimodal video interaction model.
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
-| **`DEFAULT_OMNI_MODEL_NAME`** | `gemini-omni-flash-preview` | The fallback model identifier for Gemini Omni when starting a session. |
+| **`DEFAULT_OMNI_MODEL_NAME`** | `gemini-omni-1.1-flash-preview` | The fallback model identifier for Gemini Omni when starting a session. |
 | **`OMNI_LOCATION`** | `global` | Region for the Gemini Omni API endpoint. |
-| **`OMNI_MODEL_ID`** | `gemini-omni-flash-preview` | The standard Gemini Omni model ID. |
+| **`OMNI_MODEL_ID`** | `gemini-omni-1.1-flash-preview` | The standard Gemini Omni model ID. |
 | **`OMNI_PROJECT_ID`** | `PROJECT_ID` | Allows using a different GCP project for Gemini Omni quota if needed. |
 | **`OMNI_TIMEOUT_MS`** | `600000` | Client-side HTTP timeout in milliseconds (default 10 minutes) for long-running video generation and editing requests. |
 

--- a/models/omni.py
+++ b/models/omni.py
@@ -86,6 +86,13 @@ def generate_omni_video(request: OmniVideoGenerationRequest) -> tuple[str, str]:
                 "model": model_config.model_name,
                 "input": input_parts,
             }
+            # Request the desired output resolution via the Interactions API
+            # video response_format. Aspect ratio and duration continue to be
+            # conveyed through the prompt text (see _modify_prompt_for_omni).
+            if request.resolution:
+                call_args["response_format"] = [
+                    {"type": "video", "resolution": request.resolution},
+                ]
             if request.previous_interaction_id:
                 call_args["previous_interaction_id"] = request.previous_interaction_id
 

--- a/pages/omni.py
+++ b/pages/omni.py
@@ -78,7 +78,9 @@ def omni_page() -> None:
                     me.text(f"Mode: {state.omni_mode}")
                     me.text(f"Model: {state.omni_model}")
                     me.text(
-                        f"Aspect Ratio: {state.aspect_ratio} | Duration: {state.video_length}s",
+                        f"Aspect Ratio: {state.aspect_ratio} | "
+                        f"Resolution: {state.resolution} | "
+                        f"Duration: {state.video_length}s",
                     )
                     with dialog_actions():
                         me.button("Close", on_click=close_info_dialog, type="flat")
@@ -384,6 +386,22 @@ def render_settings_panel(state: PageState, _app_state: AppState) -> None:
         disabled=chat_started,
     )
 
+    selected_model = get_omni_model_config(state.omni_model)
+    resolution_options = (
+        selected_model.resolutions if selected_model else [state.resolution]
+    )
+    me.text("Resolution", type="body-2")
+    me.select(
+        label="Resolution",
+        options=[
+            me.SelectOption(label=_resolution_label(r), value=r)
+            for r in resolution_options
+        ],
+        value=state.resolution,
+        on_selection_change=on_resolution_change,
+        disabled=chat_started,
+    )
+
     me.text(f"Video Duration: {state.video_length}s", type="body-2")
     me.slider(
         min=3,
@@ -584,10 +602,21 @@ def on_mode_change(e: me.SelectSelectionChangeEvent) -> None:
     yield
 
 
+def _resolution_label(resolution: str) -> str:
+    """Return a display label for a resolution value (e.g. '4k' -> '4K')."""
+    return "4K" if resolution == "4k" else resolution
+
+
 def on_model_change(e: me.SelectSelectionChangeEvent) -> None:
     """Handle model version selection changes."""
     state = me.state(PageState)
     state.omni_model = e.value
+    # Keep the selected resolution valid for the newly selected model.
+    model_config = get_omni_model_config(e.value)
+    if model_config and state.resolution not in model_config.resolutions:
+        state.resolution = (
+            model_config.resolutions[0] if model_config.resolutions else "720p"
+        )
     yield
 
 
@@ -595,6 +624,13 @@ def on_aspect_ratio_change(e: me.SelectSelectionChangeEvent) -> None:
     """Handle aspect ratio selection changes."""
     state = me.state(PageState)
     state.aspect_ratio = e.value
+    yield
+
+
+def on_resolution_change(e: me.SelectSelectionChangeEvent) -> None:
+    """Handle resolution selection changes."""
+    state = me.state(PageState)
+    state.resolution = e.value
     yield
 
 

--- a/scripts/emit_sample_telemetry.py
+++ b/scripts/emit_sample_telemetry.py
@@ -115,7 +115,7 @@ def emit_samples():
 
     # 8. Gemini Omni
     with track_model_call(
-        "gemini-omni-flash-preview",
+        "gemini-omni-1.1-flash-preview",
         billing_units={
             "video_seconds_generated": 10,
             "sample_count": 1,

--- a/scripts/smoke_telemetry.sh
+++ b/scripts/smoke_telemetry.sh
@@ -126,7 +126,7 @@ EXPECTED_MODELS = {
     "imagen": "Imagen Image Generation (/imagen)",
     "banana": "Gemini Image / Nano Banana (/nano-banana)",
     "veo": "Veo Video Generation (/veo)",
-    "omni": "Gemini Omni Flash (/gemini-omni)",
+    "omni": "Gemini Omni 1.1 Flash (/gemini-omni)",
 }
 
 observed_names = [str(c.get("model_name", "")).lower() for c in model_calls]

--- a/test/eap_omni_agent_platform.py
+++ b/test/eap_omni_agent_platform.py
@@ -114,7 +114,7 @@ def show_video(video_bytes):
 
 """### Load the video generation model"""
 
-omni_model = "gemini-omni-flash-preview"
+omni_model = "gemini-omni-1.1-flash-preview"
 
 """## Video generation
 
@@ -127,7 +127,8 @@ With Gemini Omni Flash, you can generate videos directly from text prompts via t
 
 Notes on output videos:
 - **Audio generation:** Audio will be generated alongside the output video.
-- **Resolution:** 720p
+- **Resolution:** 360p, 720p (default), 1080p, or 4k. Specify a non-default
+  resolution via `response_format=[{"type": "video", "resolution": "1080p"}]`.
 """
 
 prompt = "A head-on shot of a woman sitting at a desk behind a closed laptop against a pale green wall. She opens the laptop and begins typing on the keyboard. As she types the words 'This is Omni' appear in a curved formation on the wall above her head in a typewriter font. She then gets up from the chair at the desk and touches the writing so that the 'This is Omni' text unfolds into a straight line."

--- a/test/test_omni.py
+++ b/test/test_omni.py
@@ -39,7 +39,7 @@ def test_build_input_parts_t2v() -> None:
         aspect_ratio="16:9",
         resolution="720p",
         omni_mode="t2v",
-        model_version_id="gemini-omni-flash-preview",
+        model_version_id="gemini-omni-1.1-flash-preview",
     )
     parts = _build_input_parts(req)
     assert parts == [{"type": "text", "text": "A cute cat playing with yarn"}]
@@ -53,7 +53,7 @@ def test_build_input_parts_i2v() -> None:
         aspect_ratio="16:9",
         resolution="720p",
         omni_mode="i2v",
-        model_version_id="gemini-omni-flash-preview",
+        model_version_id="gemini-omni-1.1-flash-preview",
         reference_image_gcs="gs://bucket/image.png",
         reference_image_mime_type="image/png",
     )
@@ -75,7 +75,7 @@ def test_build_input_parts_ref2v() -> None:
         aspect_ratio="16:9",
         resolution="720p",
         omni_mode="ref2v",
-        model_version_id="gemini-omni-flash-preview",
+        model_version_id="gemini-omni-1.1-flash-preview",
         r2v_references=[
             APIReferenceImage(gcs_uri="gs://bucket/ref1.jpg", mime_type="image/jpeg"),
             APIReferenceImage(gcs_uri="gs://bucket/ref2.jpg", mime_type="image/jpeg"),
@@ -104,7 +104,7 @@ def test_build_input_parts_edit() -> None:
         aspect_ratio="16:9",
         resolution="720p",
         omni_mode="edit",
-        model_version_id="gemini-omni-flash-preview",
+        model_version_id="gemini-omni-1.1-flash-preview",
         reference_image_gcs="gs://bucket/ref.png",
         reference_image_mime_type="image/png",
         reference_video_gcs="gs://bucket/base.mp4",
@@ -149,7 +149,7 @@ def test_build_input_parts_chat(mock_download: MagicMock) -> None:
         aspect_ratio="16:9",
         resolution="720p",
         omni_mode="edit",
-        model_version_id="gemini-omni-flash-preview",
+        model_version_id="gemini-omni-1.1-flash-preview",
         previous_interaction_id="int-123",
         chat_history_json=json.dumps(history),
     )
@@ -204,9 +204,9 @@ def test_generate_omni_video_success(
         prompt="Cinematic city sunset",
         duration_seconds=10,
         aspect_ratio="16:9",
-        resolution="720p",
+        resolution="1080p",
         omni_mode="t2v",
-        model_version_id="gemini-omni-flash-preview",
+        model_version_id="gemini-omni-1.1-flash-preview",
     )
 
     mock_client = MagicMock()
@@ -232,6 +232,11 @@ def test_generate_omni_video_success(
     assert interaction_id == "new-interaction-id"
 
     mock_client.interactions.create.assert_called_once()
+    # Resolution is passed through to the Interactions API via response_format.
+    _, call_kwargs = mock_client.interactions.create.call_args
+    assert call_kwargs["response_format"] == [
+        {"type": "video", "resolution": "1080p"},
+    ]
     mock_save.assert_called_once_with("encoded_video_data")
 
 
@@ -367,3 +372,75 @@ def test_on_video_select(mock_state: MagicMock) -> None:
 
     assert mock_page_state.reference_video_gcs == "gs://bucket/library/vid.mp4"
     assert "vid.mp4" in mock_page_state.reference_video_uri
+
+
+def test_omni_registry_default_and_legacy_model() -> None:
+    """The 1.1 model is the default and the legacy model remains selectable."""
+    from config.omni_models import (
+        DEFAULT_OMNI_VERSION_ID,
+        get_omni_model_config,
+    )
+
+    assert DEFAULT_OMNI_VERSION_ID == "gemini-omni-1.1-flash-preview"
+
+    new_model = get_omni_model_config("gemini-omni-1.1-flash-preview")
+    assert new_model is not None
+    assert new_model.resolutions == ["360p", "720p", "1080p", "4k"]
+
+    # Legacy model kept selectable (Q1) and constrained to 720p.
+    legacy_model = get_omni_model_config("gemini-omni-flash-preview")
+    assert legacy_model is not None
+    assert legacy_model.resolutions == ["720p"]
+
+
+@patch("pages.omni.me.state")
+def test_on_resolution_change(mock_state: MagicMock) -> None:
+    """Resolution selection updates page state."""
+    from pages.omni import on_resolution_change
+
+    mock_page_state = MagicMock()
+    mock_state.return_value = mock_page_state
+
+    event = MagicMock()
+    event.value = "1080p"
+
+    list(on_resolution_change(event))
+
+    assert mock_page_state.resolution == "1080p"
+
+
+@patch("pages.omni.me.state")
+def test_on_model_change_resets_unsupported_resolution(mock_state: MagicMock) -> None:
+    """Switching to the legacy model resets a resolution it doesn't support."""
+    from pages.omni import on_model_change
+
+    mock_page_state = MagicMock()
+    mock_page_state.resolution = "4k"
+    mock_state.return_value = mock_page_state
+
+    event = MagicMock()
+    event.value = "gemini-omni-flash-preview"
+
+    list(on_model_change(event))
+
+    assert mock_page_state.omni_model == "gemini-omni-flash-preview"
+    # 4k is not supported by the legacy model; it falls back to its first option.
+    assert mock_page_state.resolution == "720p"
+
+
+@patch("pages.omni.me.state")
+def test_on_model_change_keeps_supported_resolution(mock_state: MagicMock) -> None:
+    """Switching models keeps a resolution the new model supports."""
+    from pages.omni import on_model_change
+
+    mock_page_state = MagicMock()
+    mock_page_state.resolution = "1080p"
+    mock_state.return_value = mock_page_state
+
+    event = MagicMock()
+    event.value = "gemini-omni-1.1-flash-preview"
+
+    list(on_model_change(event))
+
+    assert mock_page_state.omni_model == "gemini-omni-1.1-flash-preview"
+    assert mock_page_state.resolution == "1080p"


### PR DESCRIPTION
## Summary

Bumps the default Gemini Omni model in the main GMCS app to **`gemini-omni-1.1-flash-preview`** and exposes the model's expanded output resolutions (360p/720p/1080p/4k).

- **Default bump:** `config/default.py` (`DEFAULT_OMNI_MODEL_NAME`, `OMNI_MODEL_ID`) and `config/omni_models.py` (registry + fallback) now default to `gemini-omni-1.1-flash-preview`.
- **Old model kept:** the prior `gemini-omni-flash-preview` entry remains selectable in the UI dropdown (constrained to 720p), so operators can pin it via env override and users can still choose it.
- **Resolution exposed:** a Resolution selector is added to `pages/omni.py`, scoped per the selected model's registry entry, wired through `state/omni_state.py` → `models/omni.py`. The request now sets the Interactions API `response_format=[{"type": "video", "resolution": <res>}]`. Aspect ratio and duration continue to be conveyed via prompt text, unchanged.
- **Docs/tests/telemetry:** `environment_variables.md` (x2), `test/test_omni.py`, `test/eap_omni_agent_platform.py`, and telemetry sample scripts updated.

## Validation (empirical, live)

Live-checked against project `ghchinoy-genai-sa` (enterprise, `global`) on the real Interactions API:

- `gemini-omni-1.1-flash-preview` is reachable (no 403/404/allow-list error) and generated video.
- Resolution is an **honored request parameter** via `response_format` (SDK type `VideoResponseFormat`):
  - `360p` → 640×360
  - `720p` → 1280×720
  - `1080p` → 1920×1080

## Testing

- `uv run pytest test/test_omni.py` — 21 passed (adds coverage for the registry default + legacy retention, resolution passthrough, and the resolution/model-change handlers).
- CI gate `uv run pytest test/test_app_imports.py test/test_telemetry.py` — passed.

## Notes

- Companion Omni MCP server (Go) default bump is a separate PR (cross-linked once opened).
- Planning/design reference: `vaics-sync/omni-1.1-flash/plan.md`.

Do not merge without owner review.