### PR TITLE
feat(mcp-genmedia): default omni MCP to gemini-omni-1.1-flash-preview

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/models.go
@@ -491,7 +491,7 @@ func ResolveLyriaModel(modelInput string, allowUnsafe bool) (LyriaModelInfo, boo
 // --- Omni Model Configuration ---
 
 // DefaultOmniModel is the canonical default Gemini Omni model ID.
-const DefaultOmniModel = "gemini-omni-flash-preview"
+const DefaultOmniModel = "gemini-omni-1.1-flash-preview"
 
 // OmniModelInfo holds the details for a specific Gemini Omni model. Omni models
 // (text/image/video in, text+video out) are reachable only via the Vertex
@@ -499,15 +499,27 @@ const DefaultOmniModel = "gemini-omni-flash-preview"
 type OmniModelInfo struct {
 	CanonicalName string
 	Aliases       []string
-	Description   string
+	// SupportedResolutions lists the video output resolutions the model can emit
+	// (mirrors GeminiImageModelInfo.SupportedImageSizes). This is capability
+	// metadata surfaced in the tool description; the resolution request parameter
+	// itself is not yet wired into the tool (see follow-up).
+	SupportedResolutions []string
+	Description          string
 }
 
 // SupportedOmniModels is the single source of truth for all supported Omni models.
 var SupportedOmniModels = map[string]OmniModelInfo{
+	"gemini-omni-1.1-flash-preview": {
+		CanonicalName:        "gemini-omni-1.1-flash-preview",
+		Aliases:              []string{"Gemini Omni 1.1 Flash", "Omni 1.1", "Omni"},
+		SupportedResolutions: []string{"360p", "720p", "1080p", "4k"},
+		Description:          "Gemini Omni 1.1 Flash (Preview): text/image/video in, text+video out, via the Vertex Interactions API (global only). Supports 360p/720p/1080p/4k video output.",
+	},
 	"gemini-omni-flash-preview": {
-		CanonicalName: "gemini-omni-flash-preview",
-		Aliases:       []string{"Gemini Omni Flash", "Omni"},
-		Description:   "Gemini Omni Flash (Preview): text/image/video in, text+video out, via the Vertex Interactions API (global only).",
+		CanonicalName:        "gemini-omni-flash-preview",
+		Aliases:              []string{"Gemini Omni Flash"},
+		SupportedResolutions: []string{"720p"},
+		Description:          "Gemini Omni Flash (Preview): text/image/video in, text+video out, via the Vertex Interactions API (global only).",
 	},
 }
 
@@ -558,6 +570,9 @@ func BuildOmniModelDescription() string {
 		}
 		if info.Description != "" {
 			fmt.Fprintf(&sb, " - %s", info.Description)
+		}
+		if len(info.SupportedResolutions) > 0 {
+			fmt.Fprintf(&sb, " Supported resolutions: %s.", strings.Join(info.SupportedResolutions, ", "))
 		}
 		sb.WriteString("\n")
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common/omni_test.go
@@ -262,9 +262,12 @@ func TestResolveOmniModel(t *testing.T) {
 		want  string
 		found bool
 	}{
-		{"", "gemini-omni-flash-preview", true},
+		{"", "gemini-omni-1.1-flash-preview", true},
+		{"gemini-omni-1.1-flash-preview", "gemini-omni-1.1-flash-preview", true},
+		{"Omni", "gemini-omni-1.1-flash-preview", true},
+		// Legacy model kept selectable via explicit ID / alias (Q1).
 		{"gemini-omni-flash-preview", "gemini-omni-flash-preview", true},
-		{"Omni", "gemini-omni-flash-preview", true},
+		{"Gemini Omni Flash", "gemini-omni-flash-preview", true},
 		{"nonexistent-model", "", false},
 	}
 	for _, c := range cases {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-gemini-go/omni_handlers.go
@@ -15,7 +15,7 @@
 // Package main implements an MCP server for Google's Gemini models.
 //
 // This file adds the Gemini Omni video-generation capability to the all-in-one
-// mcp-gemini-go server. Omni (gemini-omni-flash-preview) is reachable only
+// mcp-gemini-go server. Omni (gemini-omni-1.1-flash-preview) is reachable only
 // through the Vertex Interactions API, so the handler is a THIN wrapper around
 // the shared common.ParseOmniToolArgs / common.GenerateOmniVideo /
 // common.RenderOmniResult helpers — the identical calls mcp-omni-go's standalone

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/README.md
@@ -1,7 +1,7 @@
 # MCP Omni Server
 
 This tool provides video generation (with optional embedded audio) using Google's
-Gemini Omni model (`gemini-omni-flash-preview`) via the **Vertex Interactions API**.
+Gemini Omni model (`gemini-omni-1.1-flash-preview`) via the **Vertex Interactions API**.
 It is one of the MCP tools for Google Cloud Genmedia services, acting as an MCP
 server component to allow LLMs and other MCP clients to generate videos from a text
 prompt, optionally conditioned on input images and/or videos.
@@ -26,9 +26,11 @@ The server exposes the following tool:
 *   **Parameters**:
     *   `prompt` (string, required): The text prompt describing the video to generate.
     *   `model` (string, optional): Model to use. Can be the canonical model ID
-        (`gemini-omni-flash-preview`) or a common alias (e.g. `Omni`,
-        `Gemini Omni Flash`). See `mcp-common/models.go` for the supported list.
-        Defaults to `gemini-omni-flash-preview`.
+        (`gemini-omni-1.1-flash-preview`) or a common alias (e.g. `Omni`,
+        `Gemini Omni 1.1 Flash`). The prior `gemini-omni-flash-preview` remains
+        selectable via its ID or the `Gemini Omni Flash` alias. See
+        `mcp-common/models.go` for the supported list.
+        Defaults to `gemini-omni-1.1-flash-preview`.
     *   `images` (array of string, optional): Up to 10 input images to condition
         generation on. Each entry is a local file path or a `gs://` URI. The MIME
         type is inferred from the file extension: `image/png`, `image/jpeg`,

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/main.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/main.go
@@ -14,7 +14,7 @@
 
 // Package main implements an MCP server for Google's Gemini Omni video model.
 //
-// Omni (gemini-omni-flash-preview) is reachable only through the Vertex
+// Omni (gemini-omni-1.1-flash-preview) is reachable only through the Vertex
 // Interactions API, so this server calls the shared common.GenerateOmniVideo
 // helper (which owns the Interactions client) rather than the shared genai.Client.
 


### PR DESCRIPTION
## Summary

Bumps the Omni MCP server default model to **`gemini-omni-1.1-flash-preview`** across the shared `mcp-common` registry (both `mcp-omni-go` and `mcp-gemini-go` inherit it).

- **Default bump:** `DefaultOmniModel` → `gemini-omni-1.1-flash-preview`; new entry added to `SupportedOmniModels`.
- **Old model kept (Q1):** `gemini-omni-flash-preview` remains resolvable via its canonical ID or the `Gemini Omni Flash` alias. The generic `Omni` alias now resolves to the new default.
- **Capability metadata:** adds `SupportedResolutions []string` to `OmniModelInfo` (mirroring `GeminiImageModelInfo.SupportedImageSizes` from #1750). New model advertises `360p/720p/1080p/4k`; legacy advertises `720p`. These are surfaced in the `omni_video_generation` tool `model`-arg description so MCP clients can see each model's supported resolutions.
- **Docs:** `mcp-omni-go/README.md` and header comments updated to the new default.

## Scope decision: resolution request-parameter wiring is a fast-follow

Live validation confirmed resolution is an *honored* Interactions API request parameter (via `response_format=[{"type":"video","resolution":...}]`; 360p→640×360, 720p→1280×720, 1080p→1920×1080). The **main GMCS app PR wires this end-to-end** (UI selector → request).

On the Go MCP side, the omni tool currently exposes **no** output-format parameters at all (no aspect ratio, duration, or resolution). Adding `resolution` as a request parameter means a new wire-contract field (`response_format`), a new tool arg, and per-model validation across **both** servers with its own live verification matrix. Consistent with the project's established split (image_size validation was landed in #1750 separately from its original feature PR), this default-bump PR ships the **capability metadata + default bump**, and the request-parameter wiring is scoped as an explicit fast-follow so the default bump stays minimal and low-risk. This PR advertises the supported resolutions today; a follow-up adds the selectable request field.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` — clean for `mcp-common`, `mcp-omni-go`, `mcp-gemini-go`.
- Liveness: built `mcp-omni-go` and drove `initialize` + `tools/list` over stdio — `omni_video_generation` present; model description shows the new default (aliases + 360p/720p/1080p/4k) and the retained legacy model.
- `TestResolveOmniModel` updated: empty/`Omni` → new default; legacy ID + `Gemini Omni Flash` alias still resolve.

## Notes

- Companion main-app PR: #1753 (defaults the GMCS app and fully wires the resolution selector).
- Planning/design reference: `vaics-sync/omni-1.1-flash/plan.md`.

Do not merge without owner review.