### PR TITLE
docs(docs-site): add mcp-omni-go entry and apply Catppuccin theme

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import catppuccin from '@catppuccin/starlight';
 
 // https://astro.build/config
 export default defineConfig({
@@ -11,6 +12,11 @@ export default defineConfig({
 			title: 'GenMedia Creative Studio',
 			favicon: '/favicon.ico',
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio' }],
+			// Bright Catppuccin theme: Latte (light) forward, with Mocha for dark mode.
+			plugins: [catppuccin({
+				light: { flavor: 'latte', accent: 'blue' },
+				dark: { flavor: 'mocha', accent: 'blue' },
+			})],
 			sidebar: [
 				{
 					label: 'Core Application',
@@ -84,6 +90,7 @@ export default defineConfig({
 										{ label: 'mcp-chirp3-go', slug: 'experiments/mcp-genmedia/mcp-chirp3-go' },
 										{ label: 'mcp-nanobanana-go', slug: 'experiments/mcp-genmedia/mcp-nanobanana-go' },
 										{ label: 'mcp-gemini-go', slug: 'experiments/mcp-genmedia/mcp-gemini-go' },
+										{ label: 'mcp-omni-go', slug: 'experiments/mcp-genmedia/mcp-omni-go' },
 										{ label: 'mcp-avtool-go', slug: 'experiments/mcp-genmedia/mcp-avtool-go' },
 									]
 								},

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/starlight": "^0.41.0",
+        "@catppuccin/starlight": "^2.1.0",
         "astro": "^7.0.2",
         "sharp": "^0.35.0"
       }
@@ -72,9 +73,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -90,9 +88,6 @@
       "integrity": "sha512-HPbvWqbxFxyaoQJhLxCaSjtYBx9KBo7JGVzEFZCmMl968a2PsSH0UfiODYgYPXofTOIsIH2aoCcrHXML0IA3ig==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -110,9 +105,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -128,9 +120,6 @@
       "integrity": "sha512-5v5YymudsxMHp3NBLCS8BUlu5CRqeLtWD9cKS/4nIhIEHCbpz9okmVV6I0HWqmBAPhWYcDa3vw/vltYPrOQCTA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -278,9 +267,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -293,9 +279,6 @@
       "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -310,9 +293,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -325,9 +305,6 @@
       "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -622,9 +599,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -636,9 +610,6 @@
       "integrity": "sha512-wRaKSHCRXwzAZwlieCiv3u8pWEE2t9FmhZ0X59YZvHCGin56YUBOTyEQqSOrRfXs6fhUb8ylprisGYJC6J8mFQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "optional": true,
       "os": [
@@ -652,9 +623,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -666,9 +634,6 @@
       "integrity": "sha512-ZSu+a07Efn8sOeA1k9ZM9CO9J3sAeG37Sf2YYxi/unFGgkFe+Y8MHDQlUNtngpC8pkYIjkojkLFT6v1yiHNxOg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "optional": true,
       "os": [
@@ -726,6 +691,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@catppuccin/starlight": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@catppuccin/starlight/-/starlight-2.1.0.tgz",
+      "integrity": "sha512-S5zr0WMHUZgsKzoAebj48DAT5r96jRgJSNftNEIoSi9Nk9KatxP5IUntYqmX5B2L5PGfvKO/oEjINuLLaiRn0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/starlight": "^0.41.1"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.38",
+        "astro": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@clack/core": {
@@ -1368,9 +1346,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1386,9 +1361,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1406,9 +1378,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1424,9 +1393,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1444,9 +1410,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1462,9 +1425,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1482,9 +1442,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1501,9 +1458,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1519,9 +1473,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1545,9 +1496,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1569,9 +1517,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1595,9 +1540,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1619,9 +1561,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1645,9 +1584,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1670,9 +1606,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1694,9 +1627,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2068,9 +1998,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2086,9 +2013,6 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2106,9 +2030,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2124,9 +2045,6 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2144,9 +2062,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2162,9 +2077,6 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4266,9 +4178,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4288,9 +4197,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4312,9 +4218,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4334,9 +4237,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -73,6 +73,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -88,6 +91,9 @@
       "integrity": "sha512-HPbvWqbxFxyaoQJhLxCaSjtYBx9KBo7JGVzEFZCmMl968a2PsSH0UfiODYgYPXofTOIsIH2aoCcrHXML0IA3ig==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -105,6 +111,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -120,6 +129,9 @@
       "integrity": "sha512-5v5YymudsxMHp3NBLCS8BUlu5CRqeLtWD9cKS/4nIhIEHCbpz9okmVV6I0HWqmBAPhWYcDa3vw/vltYPrOQCTA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -267,6 +279,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -279,6 +294,9 @@
       "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -293,6 +311,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -305,6 +326,9 @@
       "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -599,6 +623,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "optional": true,
       "os": [
         "linux"
@@ -610,6 +637,9 @@
       "integrity": "sha512-wRaKSHCRXwzAZwlieCiv3u8pWEE2t9FmhZ0X59YZvHCGin56YUBOTyEQqSOrRfXs6fhUb8ylprisGYJC6J8mFQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -623,6 +653,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "optional": true,
       "os": [
         "linux"
@@ -634,6 +667,9 @@
       "integrity": "sha512-ZSu+a07Efn8sOeA1k9ZM9CO9J3sAeG37Sf2YYxi/unFGgkFe+Y8MHDQlUNtngpC8pkYIjkojkLFT6v1yiHNxOg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -1346,6 +1382,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1361,6 +1400,9 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1378,6 +1420,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1393,6 +1438,9 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1410,6 +1458,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1425,6 +1476,9 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1442,6 +1496,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1458,6 +1515,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1473,6 +1533,9 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1496,6 +1559,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1517,6 +1583,9 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1540,6 +1609,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1561,6 +1633,9 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1584,6 +1659,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1606,6 +1684,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1627,6 +1708,9 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1998,6 +2082,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,6 +2100,9 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2030,6 +2120,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2045,6 +2138,9 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2062,6 +2158,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,6 +2176,9 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4178,6 +4280,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4197,6 +4302,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4218,6 +4326,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4237,6 +4348,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.0",
+    "@catppuccin/starlight": "^2.1.0",
     "astro": "^7.0.2",
     "sharp": "^0.35.0"
   }

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
@@ -68,6 +68,7 @@ The servers are configured primarily through environment variables. Key variable
 *   **Gemini Image** Generate and edit images from text prompts.
 *   **Gemini TTS** Synthesize high-quality audio from text.
 *   **Veo:** Create videos from text or images.
+*   **Gemini Omni:** Generate video (with optional embedded audio) from a text prompt, optionally conditioned on input images and/or videos, via the Vertex Interactions API.
 *   **Lyria:** Generate music from text prompts.
 *   **Chirp 3 HD:** Synthesize high-quality audio from text.
 *   **Imagen:** Generate and edit images from text prompts.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-omni-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-omni-go/index.md
@@ -1,0 +1,111 @@
+---
+title: "MCP Omni Server"
+---
+
+This tool provides video generation (with optional embedded audio) using Google's Gemini Omni model (`gemini-omni-1.1-flash-preview`) via the **Vertex Interactions API**. It is one of the MCP tools for Google Cloud Genmedia services, acting as an MCP server component to allow LLMs and other MCP clients to generate videos from a text prompt, optionally conditioned on input images and/or videos.
+
+Unlike the other genmedia servers (which use the Vertex `genai` client), Omni is reachable only through the Interactions API, so this server calls the shared `common.GenerateOmniVideo` helper (which owns the Interactions client) rather than a `genai.Client`. The Interactions endpoint is **global-only**: `LOCATION` defaults to `global` and the API call is always made against the `global` endpoint.
+
+## MCP Tool Definitions
+
+The server exposes the following tool:
+
+### 1. `omni_video_generation`
+
+*   **Description**: Generates video (with optional embedded audio) from a text prompt, optionally conditioned on input images and/or videos, using Google's Gemini Omni model via the Vertex Interactions API. Returns MP4(s) saved locally and/or to GCS.
+*   **Handler**: `omniVideoGenerationHandler`
+*   **Parameters**:
+    *   `prompt` (string, required): The text prompt describing the video to generate.
+    *   `model` (string, optional): Model to use. Can be the canonical model ID (`gemini-omni-1.1-flash-preview`) or a common alias (e.g. `Omni`, `Gemini Omni 1.1 Flash`). The prior `gemini-omni-flash-preview` remains selectable via its ID or the `Gemini Omni Flash` alias. See `mcp-common/models.go` for the supported list. Defaults to `gemini-omni-1.1-flash-preview`.
+    *   `images` (array of string, optional): Up to 10 input images to condition generation on. Each entry is a local file path or a `gs://` URI. The MIME type is inferred from the file extension: `image/png`, `image/jpeg`, `image/webp`, `image/gif`, `image/heic`, `image/heif`.
+    *   `videos` (array of string, optional): Input videos to reference or edit. Each entry is a local file path or a `gs://` URI (e.g. `video/mp4`, `video/webm`, `video/quicktime`).
+    *   `sample_count` (number, optional): Number of videos to generate (1-3, default 1). Clamped to the model maximum of 3.
+    *   `temperature` (number, optional): Sampling temperature, `0.0`-`2.0` (higher = more varied). Sent in `generation_config`.
+    *   `top_p` (number, optional): Nucleus sampling probability mass, `0.0`-`1.0`. Sent in `generation_config`.
+    *   `output_directory` (string, optional): Local directory to save the generated video(s) to. Filenames (`omni_<timestamp>_<n>.mp4`) are generated automatically unless `output_filename` is set.
+    *   `output_filename` (string, optional): Base name for the output(s), e.g. `clip.mp4`. The extension is forced to the true video type and, when more than one video is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).
+    *   `gcs_bucket_uri` (string, optional): GCS URI prefix to store generated video(s) (e.g., `your-bucket/outputs/`). If not provided and `GENMEDIA_BUCKET` is set, `gs://<GENMEDIA_BUCKET>/omni_outputs/` is used. For each uploaded video a best-effort V4 signed HTTPS URL is also returned (see `OMNI_SIGNED_URL_EXPIRY_HOURS`).
+
+## Authentication
+
+This server uses **Application Default Credentials (ADC)** to authenticate to the Vertex Interactions API — run `gcloud auth application-default login` locally, or rely on the attached service account when running on Google Cloud. The Interactions API is invoked against the **`global`** location only; per-region overrides do not apply to the Interactions call itself.
+
+## Environment Variable Configuration
+
+The tool utilizes the following environment variables:
+
+*   `GOOGLE_CLOUD_PROJECT` (string): **Required**. Your Google Cloud Project ID. The application will terminate if this is not set. Note: `PROJECT_ID` is also supported as a fallback.
+    *   **Override**: You can override this globally for this specific server by setting `OMNI_PROJECT_ID`.
+*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location. For Omni this defaults to `global` and the Interactions call is always made against the `global` endpoint.
+    *   **Fallback**: `LOCATION` is also supported as a fallback for `GOOGLE_CLOUD_LOCATION`.
+    *   **Override**: You can override this globally for this specific server by setting `OMNI_LOCATION`.
+*   `GENMEDIA_BUCKET` (string): An optional default Google Cloud Storage bucket to use for GCS outputs if the `gcs_bucket_uri` parameter is not specified in the tool request. The path `omni_outputs/` will be appended to this bucket.
+    *   Default: `""` (empty string).
+*   `OMNI_SIGNED_URL_EXPIRY_HOURS` (number): Validity, in hours, of the V4 signed HTTPS URL returned for each uploaded video. Clamped to `168` (the V4 maximum); `0` disables signed-URL generation (the `gs://` URI is still returned). Signing under ADC without a private key requires `roles/iam.serviceAccountTokenCreator` on the runtime service account (non-fatal if absent).
+    *   Default: `24`
+*   `PORT` (string, for HTTP transport): The port for the HTTP server to listen on.
+    *   Default: `"8080"`
+
+## Transports Supported
+
+*   `stdio` (default)
+*   `sse` (Server-Sent Events)
+*   `http` (Streamable HTTP)
+
+CORS is enabled for the HTTP transport, allowing all origins by default.
+
+## Run
+
+Build the tool using `go build` or `go install`.
+
+*   **STDIO (Default)**:
+    ```bash
+    ./mcp-omni-go
+    # or
+    ./mcp-omni-go -transport stdio
+    ```
+*   **HTTP**:
+    ```bash
+    ./mcp-omni-go -transport http
+    # Optionally set PORT environment variable, e.g., PORT=8084 ./mcp-omni-go -transport http
+    ```
+    The MCP server will be available at `http://localhost:<PORT>/mcp`.
+*   **SSE (Server-Sent Events)**:
+    ```bash
+    ./mcp-omni-go -transport sse
+    # SSE server typically runs on port 8081 by default in this configuration.
+    ```
+    The MCP server will be available at `http://localhost:8081`.
+
+## Examples
+
+### Text-to-Video (`omni_video_generation`)
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "omni_video_generation",
+    "arguments": {
+      "prompt": "A majestic eagle soaring over a mountain range at sunset.",
+      "sample_count": 1,
+      "gcs_bucket_uri": "your-gcs-bucket/omni_outputs",
+      "output_directory": "./omni_videos"
+    }
+  }
+}
+```
+
+### Image-conditioned generation (`omni_video_generation`)
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "omni_video_generation",
+    "arguments": {
+      "prompt": "Animate this landscape with a gentle breeze and flowing river.",
+      "images": ["gs://your-gcs-bucket/source_images/landscape.png"],
+      "output_directory": "./omni_videos"
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary

Two docs-site changes in one PR (per request):

1. **Add `mcp-omni-go` to the docs site.** The Starlight docs site listed every
   sibling MCP genmedia server (`mcp-veo-go`, `mcp-imagen-go`, `mcp-lyria-go`,
   `mcp-chirp3-go`, `mcp-nanobanana-go`, `mcp-gemini-go`, `mcp-avtool-go`) but was
   missing `mcp-omni-go`. This adds a new page at
   `docs-site/src/content/docs/experiments/mcp-genmedia/mcp-omni-go/index.md`
   following the exact structure of its siblings, adds it to the **Servers** group
   in the sidebar (`astro.config.mjs`), and lists **Gemini Omni** in the MCP
   overview capabilities list.

   Content is sourced from the shipped server (`experiments/mcp-genmedia/mcp-genmedia-go/mcp-omni-go/README.md`
   and handlers), not invented — it documents the single `omni_video_generation`
   tool, the default model `gemini-omni-1.1-flash-preview` and its aliases (with the
   prior `gemini-omni-flash-preview` still selectable), the Vertex Interactions API
   (global-only) path, all tool parameters, env vars, transports, and examples.

2. **Apply a bright Catppuccin theme.** Uses the standard `@catppuccin/starlight`
   plugin (v2.1.0). Configured **Latte** for light mode (the "bright" flavor
   requested) and **Mocha** for dark mode, both with the **blue** accent.

### Dark-mode note
"Bright" was specified but dark-mode handling wasn't. Starlight ships a light/dark
toggle, so I kept both: **Latte (light)** as the bright, light-mode-forward default
and **Mocha (dark)** as a reasonable dark counterpart. Happy to drop dark mode or
switch the dark flavor if preferred.

## Verification
- `npm run build` in `docs-site/` completes cleanly (54 pages built) with the new
  page and theme.
- Confirmed the built output contains the `mcp-omni-go` page (with the
  `omni_video_generation` tool), the sidebar/overview entries, and the Catppuccin
  Latte + Mocha palette (incl. blue accent) in the generated CSS.

## Notes
- The page title is `MCP Omni Server` (no version string), matching the README H1
  and the descriptive style of most sibling pages; sibling version conventions are
  inconsistent (only veo carries an explicit version), so a possibly-stale number
  was intentionally omitted.
- The `mcp-omni-go` docs dir is force-added because the repo `.gitignore` pattern
  `**/mcp-*-go` (intended for Go binaries) also matches it — same handling as the
  existing sibling doc dirs.

**Review-and-update PR — please do not auto-merge; leaving for independent review.**
