### PR TITLE
docs: Imagen deprecation note, env var sync, mcp-gemini-go params, misc completeness fixes

### DIFF
--- a/docs-site/src/content/docs/core/changelog.md
+++ b/docs-site/src/content/docs/core/changelog.md
@@ -45,6 +45,9 @@ If you have an active local feature branch with unmerged commits:
 
 ## Recent Updates
 
+### Transitioning to Nano Banana as Imagen is Deprecated (August 2026)
+* **Models:** We are in the process of transitioning to Nano Banana (Gemini Image Generation, `gemini-2.5-flash-image`) as Imagen has been deprecated. All Imagen models were shut down across Google — including Vertex AI — around August 17, 2026. See the [Imagen models migration guide](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev) for the replacement mapping.
+
 ### Starlight Documentation Hub (May 2026)
 * **Docs:** Migrated all deployment guides, architecture diagrams, and MCP tool instructions to a centralized Starlight (Astro) documentation hub.
 * **UI:** Streamlined the root `README.md` to serve as a clean landing page pointing to the new docs.

--- a/docs-site/src/content/docs/core/index.md
+++ b/docs-site/src/content/docs/core/index.md
@@ -53,11 +53,11 @@ title: "GenMedia Creative Studio | Google Cloud AI"
 > **Browser Compatibility:** For the best experience, we recommend using Google Chrome. Some features may not work as expected on other browsers, such as Safari or Firefox.
 
 
-GenMedia Creative Studio is a web application showcasing Google Cloud's generative media - Gemini Omni, Veo, Lyria, Chirp, Gemini 2.5 Flash Image Generation (nano-banana), and Gemini TTS along with custom workflows and techniques for creative exploration and inspiration. We're looking forward to see what you create!
+GenMedia Creative Studio is a web application showcasing Google Cloud's generative media - Gemini Omni, Veo, Lyria, Chirp, Gemini Image Generation (Nano Banana), and Gemini TTS along with custom workflows and techniques for creative exploration and inspiration. We're looking forward to see what you create!
 
 Current featureset
 
-- Image: Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite), Gemini 3.1 Flash Image Generation (Nano Banana 2), Gemini 3 Pro Image (Nano Banana Pro), Imagen 3, Imagen 4, Virtual Try-On
+- Image: Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite), Gemini 3.1 Flash Image Generation (Nano Banana 2), Gemini 3 Pro Image (Nano Banana Pro), Virtual Try-On (Imagen was [deprecated across Google, including Vertex AI, around August 17, 2026](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev) — use Nano Banana instead)
 - Video: Gemini Omni Flash, Veo 3.1, Veo 3
 - Music: Lyria
 - Speech: Chirp 3 HD, Gemini Text to Speech

--- a/docs-site/src/content/docs/core/index.md
+++ b/docs-site/src/content/docs/core/index.md
@@ -57,7 +57,7 @@ GenMedia Creative Studio is a web application showcasing Google Cloud's generati
 
 Current featureset
 
-- Image: Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite), Gemini 3.1 Flash Image Generation (Nano Banana 2), Gemini 3 Pro Image (Nano Banana Pro), Virtual Try-On (Imagen was [deprecated across Google, including Vertex AI, around August 17, 2026](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev) — use Nano Banana instead)
+- Image: Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite), Gemini 3.1 Flash Image Generation (Nano Banana 2), Gemini 3 Pro Image (Nano Banana Pro), Virtual Try-On. (Imagen was [deprecated across Google, including Vertex AI, around August 17, 2026](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev) — use Nano Banana instead.)
 - Video: Gemini Omni Flash, Veo 3.1, Veo 3
 - Music: Lyria
 - Speech: Chirp 3 HD, Gemini Text to Speech

--- a/docs-site/src/content/docs/core/installation/environment_variables.md
+++ b/docs-site/src/content/docs/core/installation/environment_variables.md
@@ -16,6 +16,7 @@ These variables define the fundamental operating context of the application.
 | :--- | :--- | :--- |
 | **`PROJECT_ID`** | *None* (Required) | The Google Cloud Project ID where resources (Google Cloud AI, Firestore, Storage) are located. |
 | **`LOCATION`** | `us-central1` | The default GCP region for most services (Google Cloud AI, etc.). |
+| **`VERTEX_API_VERSION`** | `v1beta1` | The Vertex AI API version used for all `google-genai` client initializations. Override to switch the API surface in one place. |
 | **`APP_ENV`** | `""` (Empty) | Defines the environment name (e.g., `dev`, `godemos`). This is used as a metadata tag on the Config page. |
 | **`GMCS_OVERRIDE_PATH`** | *None* | **(Development Only)** An absolute path to a directory containing configuration overrides. If a file exists in this path (e.g., `config/about_content.json`), the app will prioritize it over the local version. |
 | **`API_BASE_URL`** | `http://localhost:{PORT}` | The base URL for the application's backend APIs. |
@@ -31,6 +32,8 @@ Controls which versions of the Gemini models are used for various tasks.
 | Variable | Default | Description |
 | :--- | :--- | :--- |
 | **`MODEL_ID`** | `gemini-3.5-flash` | The primary Gemini model used for general text and reasoning tasks throughout the app. |
+| **`GEMINI_LOCATION`** | `global` | Region for Gemini 3.x model calls. Gemini 3.x is served only from the `global` endpoint (and the us/eu multi-regions), so this is kept separate from `LOCATION`. |
+| **`GEMINI_TTS_LOCATION`** | `global` | Region for Gemini text-to-speech (TTS) model calls. |
 | **`GEMINI_IMAGE_GEN_MODEL`** | `gemini-3.1-flash-image` | The default model used for image generation features (supports `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, or `gemini-2.5-flash-image`). |
 | **`GEMINI_IMAGE_GEN_LOCATION`** | `global` | The region for the Gemini Image Generation API. |
 | **`GEMINI_AUDIO_ANALYSIS_MODEL_ID`** | `gemini-3.1-flash-lite` | The model used specifically for analyzing audio content. |
@@ -82,6 +85,23 @@ Specific configuration for the Virtual Try-On feature.
 | **`VTO_MODEL_ID`** | `virtual-try-on-001` | The specific VTO model version. |
 | **`GENMEDIA_VTO_MODEL_COLLECTION_NAME`** | `genmedia-vto-model` | Firestore collection for VTO model data. |
 | **`GENMEDIA_VTO_CATALOG_COLLECTION_NAME`** | `genmedia-vto-catalog` | Firestore collection for VTO product catalog data. |
+
+## 🔄 Object Rotation
+Specific configuration for the Object Rotation workflow.
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| **`OBJECT_ROTATION_VIDEO_MODEL`** | `veo-3.1-generate-001` | The specific Veo model used for 360-degree rotation videos. |
+| **`OBJECT_ROTATION_IMAGE_MODEL`** | `gemini-3.1-flash-image` | The specific Gemini image model used for generating multi-angle views. |
+
+## 🛋️ Interior Design
+Specific configuration for the Interior Design workflow.
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| **`INTERIOR_DESIGN_VIDEO_MODEL`** | `veo-3.1-lite-generate-001` | The specific Veo model used for 3D walkthrough video segments. |
+| **`INTERIOR_DESIGN_IMAGE_MODEL`** | `gemini-3-pro-image` | The specific Gemini image model used for floor plan to 3D and styled images. |
+| **`INTERIOR_DESIGN_VIDEO_DURATION`** | `6` | The duration in seconds for each generated video segment. |
 
 ## 🎵 Lyria (Music Generation)
 Configuration for the Lyria music generation model.

--- a/docs-site/src/content/docs/core/usage.md
+++ b/docs-site/src/content/docs/core/usage.md
@@ -15,6 +15,7 @@ Interact directly with the raw generative models to create single-modality outpu
 
 *   **Image Generation:** 
     *   **Gemini Image Generation:** Generate high-quality images from text prompts using Gemini (Nano Banana), including Gemini 3.1 Flash-Lite for rapid creation and iteration at 1K resolution.
+    *   **Imagen (deprecated):** Imagen image generation, editing, and upscaling — all Imagen models — were shut down across Google, including Vertex AI, around August 17, 2026. Use **Gemini Image Generation (Nano Banana, `gemini-2.5-flash-image`)** instead. See the [Imagen models migration guide](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev) for the model replacement mapping.
 *   **Video Generation:** 
     *   **Gemini Omni:** Create, animate, reference, and iteratively edit video in a multi-turn chat workspace using Gemini Omni Flash.
     *   **Veo:** Create high-fidelity videos from text or image prompts using Veo 3 and Veo 3.1.

--- a/docs-site/src/content/docs/experiments/arena/index.md
+++ b/docs-site/src/content/docs/experiments/arena/index.md
@@ -4,7 +4,7 @@ title: "Image Generation Arena & Leaderboard"
 
 This is an example of an arena & leaderboard to compare different image generation tools.
 
-Currently, it uses Flux1, Stable Diffusion, Imagen 2, Imagen 3, image generation models with Gemini 2.0 experimental's image output model forthcoming.
+It supports comparing images from a range of image generation models, including Flux1, Stable Diffusion, and Gemini image models (Nano Banana). Note that Imagen models were [deprecated across Google, including Vertex AI, around August 17, 2026](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev); use Gemini Image Generation (Nano Banana) as the replacement.
 
 The application is written in [Mesop](https://google.github.io/mesop/), a python UX framework, with the [Studio Scaffold starter](https://github.com/ghchinoy/studio-scaffold).
 

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
@@ -14,6 +14,8 @@ Generates content (text and/or images) based on a multimodal prompt.
 
 - `prompt` (string, required): The text prompt for content generation.
 - `model` (string, optional): The specific Gemini model to use. Defaults to `gemini-3.1-flash-image`.
+- `aspect_ratio` (string, optional): Aspect ratio of the generated image(s), e.g. `1:1`, `16:9`, `21:9`. Defaults to `1:1`. Supported ratios are model-dependent; unsupported values fall back to `1:1`.
+- `image_size` (string, optional): Size of the generated image(s): `1K`, `2K`, or `4K`. When unset the model's default (`1K`) is used. Supported sizes are model-dependent; unsupported values are ignored.
 - `images` (string array, optional): A list of local file paths or GCS URIs for input images.
 - `output_directory` (string, optional): Local directory to save any generated image(s) to.
 - `output_filename` (string, optional): Base name for the output(s), e.g. `hero.png`. The extension is forced to the true image type and, when more than one image is generated, a `_1..n` suffix is inserted before the extension. Applied identically to local files and GCS objects. See [Naming Outputs](../index.md#naming-outputs-output_filename).

--- a/docs-site/src/content/docs/experiments/overview.md
+++ b/docs-site/src/content/docs/experiments/overview.md
@@ -28,6 +28,7 @@ The experimental folder contains stand-alone applications, demos, and features n
 ## Audio & Voice
 
 * [Babel](/vertex-ai-creative-studio/experiments/babel) - Experiment with Chirp 3 HD voices.
+* [Creative Podcast Assistant](https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/tree/main/experiments/creative_podcast_assistant) - A demo notebook showcasing speech-to-text and text-to-speech features for creating a podcast with generative media.
 
 ## Developer Tools & MCP
 

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -14,6 +14,7 @@ These variables define the fundamental operating context of the application.
 | :--- | :--- | :--- |
 | **`PROJECT_ID`** | *None* (Required) | The Google Cloud Project ID where resources (Vertex AI, Firestore, Storage) are located. |
 | **`LOCATION`** | `us-central1` | The default GCP region for most services (Vertex AI, etc.). |
+| **`VERTEX_API_VERSION`** | `v1beta1` | The Vertex AI API version used for all `google-genai` client initializations. Override to switch the API surface in one place. |
 | **`APP_ENV`** | `""` (Empty) | Defines the environment name (e.g., `dev`, `godemos`). This is used as a metadata tag on the Config page. |
 | **`GMCS_OVERRIDE_PATH`** | *None* | **(Development Only)** An absolute path to a directory containing configuration overrides. If a file exists in this path (e.g., `config/about_content.json`), the app will prioritize it over the local version. |
 | **`API_BASE_URL`** | `http://localhost:{PORT}` | The base URL for the application's backend APIs. |
@@ -29,6 +30,8 @@ Controls which versions of the Gemini models are used for various tasks.
 | Variable | Default | Description |
 | :--- | :--- | :--- |
 | **`MODEL_ID`** | `gemini-3.5-flash` | The primary Gemini model used for general text and reasoning tasks throughout the app. |
+| **`GEMINI_LOCATION`** | `global` | Region for Gemini 3.x model calls. Gemini 3.x is served only from the `global` endpoint (and the us/eu multi-regions), so this is kept separate from `LOCATION`. |
+| **`GEMINI_TTS_LOCATION`** | `global` | Region for Gemini text-to-speech (TTS) model calls. |
 | **`GEMINI_IMAGE_GEN_MODEL`** | `gemini-3.1-flash-image` | The default model used for image generation features (supports `gemini-3.1-flash-lite-image`, `gemini-3.1-flash-image`, `gemini-3-pro-image`, or `gemini-2.5-flash-image`). |
 | **`GEMINI_IMAGE_GEN_LOCATION`** | `global` | The region for the Gemini Image Generation API. |
 | **`GEMINI_AUDIO_ANALYSIS_MODEL_ID`** | `gemini-3.1-flash-lite` | The model used specifically for analyzing audio content. |


### PR DESCRIPTION
Follow-up to the docs-site completeness audit from #1756. Docs-only; no application code (`pages/`, `models/`) touched.

## What changed

### 1. Imagen deprecation (docs-only)
All Imagen models — generation, editing, and upscale — were shut down across Google, including Vertex AI, around **2026-08-17** (verified via live Vertex AI API calls; every configured Imagen model ID returns 404 while Gemini/Nano Banana return 200). This PR:
- Adds a deprecation note in `core/usage.md` under Image Generation, pointing users to **Nano Banana (Gemini Image Generation, `gemini-2.5-flash-image`)** and linking the [Imagen models migration guide](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev).
- Removes stale "Imagen 3, Imagen 4" from the `core/index.md` featureset and fixes the self-inconsistent Nano Banana intro line.
- Refreshes the dated model list in `experiments/arena/index.md`.
- Does **not** document Imagen Upscale as a working feature (it also 404s), and does **not** add a new "how to use Imagen" tutorial page.

> Note: the underlying **code** fix (guarding/redirecting the ~6 app surfaces that route through the dead Imagen SDK calls) is a separate, larger effort and is intentionally **out of scope** here.

### 2. Env var doc sync (both copies)
- Adds `GEMINI_LOCATION` (`global`), `GEMINI_TTS_LOCATION` (`global`), and `VERTEX_API_VERSION` (`v1beta1`) to **both** the root `environment_variables.md` and the docs-site copy (defaults verified against `config/default.py`).
- Adds the 5 vars missing from the docs-site copy specifically: `INTERIOR_DESIGN_IMAGE_MODEL`, `INTERIOR_DESIGN_VIDEO_DURATION`, `INTERIOR_DESIGN_VIDEO_MODEL`, `OBJECT_ROTATION_IMAGE_MODEL`, `OBJECT_ROTATION_VIDEO_MODEL`.

**Standing policy (owner-confirmed):** going forward, any env var change must update **both** copies (root + docs-site).

### 3. `mcp-gemini-go` params
Documents the `aspect_ratio` and `image_size` params for `gemini_image_generation` (shipped in #1746/#1750), matching the server README/handler behavior (supported values are model-dependent; unsupported aspect ratios fall back to `1:1`, unsupported sizes are ignored).

### 4. `creative_podcast_assistant`
Adds a one-line mention of the demo notebook under Audio & Voice in the experiments overview.

### 5. Fast-follow release note
Adds an entry to the existing `core/changelog.md` "Recent Updates" section on the Nano Banana transition.

## Verification
- `npm ci && npm run build` in `docs-site/` — ✅ 54 pages built, no errors, no broken links (Node 22.12 via portable install; sandbox default is Node 20).
- `package-lock.json` not touched.
