### PR TITLE
docs: fix trailing-slash link consistency and smoke-test server count (follow-up to #1766)

### DIFF
--- a/docs-site/src/content/docs/experiments/agent-tools/index.md
+++ b/docs-site/src/content/docs/experiments/agent-tools/index.md
@@ -15,7 +15,7 @@ time — **Agent Plugins**, gathered together in one place.
 :::note[Scope today]
 Right now this directory holds **one** artifact: a cross-server smoke test for the
 media-generation MCP servers (described below). It does **not** move or replace the
-existing [MCP Servers for Genmedia](/vertex-ai-creative-studio/experiments/mcp-genmedia) —
+existing [MCP Servers for Genmedia](/vertex-ai-creative-studio/experiments/mcp-genmedia/) —
 those stay where they are and continue to be the way you run the servers. Bringing
 Agent Skills and Agent Plugins into this directory is future work, and the exact
 approach is still being decided; nothing here should be read as a committed migration
@@ -28,7 +28,7 @@ The Model Context Protocol (MCP) servers are the shipped, production way to give
 agent access to Google Cloud genmedia. Each server can be run independently, and
 they cover image, video, speech, music, and audio/video compositing.
 
-➡️ **See the [MCP Servers for Genmedia](/vertex-ai-creative-studio/experiments/mcp-genmedia)
+➡️ **See the [MCP Servers for Genmedia](/vertex-ai-creative-studio/experiments/mcp-genmedia/)
 overview** for the full list of servers, installation, configuration, and
 per-server documentation.
 

--- a/experiments/agent_tools/README.md
+++ b/experiments/agent_tools/README.md
@@ -12,8 +12,9 @@ servers.
 
 ## `smoke_generate_and_verify.sh`
 
-A consolidated **generate-and-verify** smoke test across the eight
-`mcp-genmedia-go` servers. For each server it fires one realistic
+A consolidated **generate-and-verify** smoke test across seven of the eight
+`mcp-genmedia-go` servers (Imagen is intentionally excluded — see below). For
+each covered server it fires one realistic
 media-generation `tools/call` (via the external
 [`mcptools`](https://github.com/f/mcptools) CLI) and then **verifies that a
 real media artifact was produced** — a non-empty local file, or a GCS object


### PR DESCRIPTION
## What

Small follow-up to #1766 addressing the two non-blocking nits from the independent
post-merge review (`1766-review.md`). No functional/content changes to the new page's
substance.

### Changes
- **docs-site** (`experiments/agent-tools/index.md`): normalize the two in-content
  "MCP Servers for Genmedia" links to a trailing slash
  (`/experiments/mcp-genmedia/`), matching the Starlight sidebar and the Agent Skills
  link convention. Cosmetic; both targets already resolved.
- **`experiments/agent_tools/README.md`**: the intro said the smoke test runs "across
  the **eight** `mcp-genmedia-go` servers", but the test covers **seven** — Imagen is
  intentionally excluded (models 404 since 2026-08-17), and the table already lists
  seven. Corrected to "seven of the eight". Pre-existing wording from #1765; the
  docs-site page correctly never asserted a count.

## Verification
- `npm run build` in `docs-site/` clean — **55 pages**, new page renders, all
  cross-link targets resolve in `dist/`.

Docs-only.
