### PR TITLE
fix(mcp-lyria-go): parse nested model_output audio content (#1768)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions.go
@@ -48,11 +48,14 @@ func generateAudioWithInteractions(ctx context.Context, modelID string, prompt s
 		sherlogLink = resp.SherlogLink
 	}
 
-	// Lyria returns flat audio ({type:"audio", mime_type, data}); the live shape
-	// arrives in outputs[], but tolerate steps[] as well.
-	audioBytes, found, err := extractFlatAudio(resp.Outputs)
+	// Lyria audio arrives in one of two observed shapes: a flat step
+	// ({type:"audio", mime_type, data}) or a nested model_output step whose
+	// audio part lives in content[] ({type:"model_output", content:[{type:"audio",
+	// ...}]}). It may land in outputs[] or steps[]; scan both, tolerating either
+	// shape.
+	audioBytes, found, err := extractAudio(resp.Outputs)
 	if !found && err == nil {
-		audioBytes, found, err = extractFlatAudio(resp.Steps)
+		audioBytes, found, err = extractAudio(resp.Steps)
 	}
 	if err != nil {
 		return nil, "", err
@@ -63,11 +66,14 @@ func generateAudioWithInteractions(ctx context.Context, modelID string, prompt s
 	return audioBytes, sherlogLink, nil
 }
 
-// extractFlatAudio scans a flat outputs[]/steps[] slice for the first audio
-// entry and returns its base64-decoded bytes. found is false when no audio
-// entry is present; a present-but-undecodable entry surfaces the decode error
-// verbatim, matching the pre-seam behavior.
-func extractFlatAudio(steps []common.Step) ([]byte, bool, error) {
+// extractAudio scans an outputs[]/steps[] slice for the first audio entry and
+// returns its base64-decoded bytes. It handles both observed shapes: a flat step
+// carrying the audio directly (s.Type == "audio", s.Data), and a nested step
+// (e.g. type "model_output") whose audio lives in a content[] part (p.Type ==
+// "audio", p.Data). found is false when no audio entry is present; a
+// present-but-undecodable entry surfaces the decode error verbatim, matching the
+// pre-seam behavior.
+func extractAudio(steps []common.Step) ([]byte, bool, error) {
 	for _, s := range steps {
 		if s.Type == "audio" && s.Data != "" {
 			decoded, err := base64.StdEncoding.DecodeString(s.Data)
@@ -75,6 +81,15 @@ func extractFlatAudio(steps []common.Step) ([]byte, bool, error) {
 				return nil, true, fmt.Errorf("failed to decode base64 audio data: %w", err)
 			}
 			return decoded, true, nil
+		}
+		for _, p := range s.Content {
+			if p.Type == "audio" && p.Data != "" {
+				decoded, err := base64.StdEncoding.DecodeString(p.Data)
+				if err != nil {
+					return nil, true, fmt.Errorf("failed to decode base64 audio data: %w", err)
+				}
+				return decoded, true, nil
+			}
 		}
 	}
 	return nil, false, nil

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions_char_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-lyria-go/interactions_char_test.go
@@ -174,6 +174,41 @@ func flatAudioResponse(mimeType string, audio []byte) string {
 	}`, mimeType, b64)
 }
 
+// nestedModelOutputAudioResponse builds the live Interactions shape where the
+// audio arrives inside a nested "model_output" step's content[] (issue #1768),
+// rather than as a flat top-level audio step.
+func nestedModelOutputAudioResponse(mimeType string, audio []byte) string {
+	b64 := base64.StdEncoding.EncodeToString(audio)
+	return fmt.Sprintf(`{
+		"id": "lyria-char-nested-1",
+		"object": "interaction",
+		"status": "completed",
+		"role": "model",
+		"steps": [{
+			"type": "model_output",
+			"content": [{"type": "audio", "mime_type": %q, "data": %q}]
+		}]
+	}`, mimeType, b64)
+}
+
+// TestChar_Lyria3_NestedModelOutputAudioDecoded pins the fix for issue #1768:
+// audio nested inside a "model_output" step's content[] (the live Vertex AI
+// Interactions shape) is found and decoded to the exact original bytes, instead
+// of failing with "no audio output found in response".
+func TestChar_Lyria3_NestedModelOutputAudioDecoded(t *testing.T) {
+	audio := []byte{0x49, 0x44, 0x33, 0x04, 0x00, 0x11, 0x22, 0x33, 0xAB, 0xCD}
+	ts, _ := newInteractionsTestServer(t, nestedModelOutputAudioResponse("audio/mpeg", audio), "")
+	ctx := fakeADCContext(t, ts, &common.Config{ProjectID: testProjectID})
+
+	got, _, err := generateAudioWithInteractions(ctx, "lyria-3-clip-preview", "prompt")
+	if err != nil {
+		t.Fatalf("generateAudioWithInteractions returned error: %v", err)
+	}
+	if string(got) != string(audio) {
+		t.Errorf("decoded audio = %v, want %v", got, audio)
+	}
+}
+
 // TestChar_Lyria3_RequestEnvelope pins the CURRENT request envelope of the
 // Lyria-3 Interactions route: POST to the global interactions path with body
 // {model, input:[{type:"text", text:<prompt>}], store:false} and the


### PR DESCRIPTION
## Summary
Fixes #1768. `lyria_generate_music` (default `lyria-3-clip-preview`) failed with
`interactions API failed: no audio output found in response` even though generation
succeeded.

## Root cause
`extractFlatAudio` in `mcp-lyria-go/interactions.go` only inspected top-level steps
where `s.Type == "audio"`. The live Vertex AI Interactions API returns a
`"model_output"` step whose audio part is nested inside `s.Content`:

```json
{ "steps": [ { "type": "model_output",
  "content": [ { "type": "audio", "mime_type": "audio/mpeg", "data": "..." } ] } ] }
```

Because the nested `Content` was never scanned, the audio was dropped.

## Change
- Rename `extractFlatAudio` → `extractAudio` and additionally scan each step's
  `Content[]` parts for `p.Type == "audio"`, decoding the first match. The existing
  flat-step path is preserved unchanged.
- Add a characterization test (`TestChar_Lyria3_NestedModelOutputAudioDecoded`)
  covering the nested `model_output` shape.

## Verification
- `go build ./...` and `go test ./...` pass in `mcp-lyria-go`.
- **Live-verified** against a real Vertex AI project via
  `./experiments/agent_tools/smoke_generate_and_verify.sh lyria`:
  `lyria_generate_music` now produces a verified audio artifact
  (~740 KB `audio/mpeg`, generated in ~8.5s) — previously this smoke test reported
  Lyria as FAIL.