### PR TITLE
feat(mcp-genmedia-go): support 0/all for Install All in install.sh (#1769)

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
@@ -146,11 +146,86 @@ setup_agent_skills() {
 }
 
 #
+# Function to print usage information.
+#
+usage() {
+  cat <<EOF
+Usage: ./install.sh [OPTION]
+
+Interactively install or upgrade the Go MCP servers in this project.
+
+Options:
+  -a, --all    Install all MCP servers non-interactively (no menu).
+  -h, --help   Show this help message and exit.
+
+With no option, an interactive menu is shown. At the menu prompt you can
+enter a server's number, or enter '0', 'a', or 'all' to install everything.
+EOF
+}
+
+#
+# Function to install all discovered MCP servers.
+#
+install_all() {
+  echo -e "${BLUE}Installing all MCP servers...${NC}"
+  for d in $(find_mcp_servers); do
+    echo "Installing $d..."
+    # Run go mod tidy to prevent checksum mismatch errors
+    if ! (cd "$d" && go mod tidy && go install); then
+      echo -e "${RED}ERROR: Failed to install $d. Please check the output above for details.${NC}"
+      exit 1
+    fi
+    codesign_go_binary "$d"
+  done
+  echo -e "${GREEN}All MCP servers have been installed successfully.${NC}"
+  echo -e "\n${YELLOW}Reminder: Ensure ${BLUE}\$HOME/go/bin${YELLOW} is in your PATH to run the installed servers.${NC}"
+  setup_agent_skills
+}
+
+#
+# Function to install a single MCP server.
+#
+install_one() {
+  local server="$1"
+  echo -e "${BLUE}Installing $server...${NC}"
+  # Run go mod tidy to prevent checksum mismatch errors
+  if (cd "$server" && go mod tidy && go install); then
+    codesign_go_binary "$server"
+    echo -e "${GREEN}$server has been installed successfully.${NC}"
+    echo -e "\n${YELLOW}Reminder: Ensure ${BLUE}\$HOME/go/bin${YELLOW} is in your PATH to run the installed server.${NC}"
+    setup_agent_skills
+  else
+    echo -e "${RED}ERROR: Failed to install $server. Please check the output above for details.${NC}"
+    exit 1
+  fi
+}
+
+#
 # Main function.
 #
 # This is the main entry point of the script. It calls the other functions to
 # perform the installation process.
 main() {
+
+  # Parse command-line options.
+  local install_all_flag=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -a|--all)
+        install_all_flag=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo -e "${RED}Unknown option: $1${NC}"
+        usage
+        exit 1
+        ;;
+    esac
+  done
 
   # Fallback to PROJECT_ID if GOOGLE_CLOUD_PROJECT is not set
   if [[ -z "${GOOGLE_CLOUD_PROJECT}" ]] && [[ -n "${PROJECT_ID}" ]]; then
@@ -173,42 +248,37 @@ main() {
   check_go_installation
   check_path
 
+  # Non-interactive path: --all installs everything and exits.
+  if [[ "$install_all_flag" -eq 1 ]]; then
+    install_all
+    return
+  fi
+
   echo -e "${BLUE}Please choose an MCP server to install:${NC}"
+  echo -e "${YELLOW}(enter '0', 'a', or 'all' to install everything)${NC}"
   select server in $(find_mcp_servers) "Install All" "Exit"; do
+    # Accept '0', 'a', or 'all' (case-insensitive) as aliases for "Install All",
+    # regardless of the number 'select' assigns to that menu item. REPLY holds
+    # the raw text the user typed. tr keeps this portable to bash 3.2 (macOS).
+    reply_lc=$(printf '%s' "$REPLY" | tr '[:upper:]' '[:lower:]')
+    case "$reply_lc" in
+      0|a|all)
+        install_all
+        break
+        ;;
+    esac
     case $server in
       "Install All")
-        echo -e "${BLUE}Installing all MCP servers...${NC}"
-        for d in $(find_mcp_servers); do
-          echo "Installing $d..."
-          # Run go mod tidy to prevent checksum mismatch errors
-          if ! (cd "$d" && go mod tidy && go install); then
-            echo -e "${RED}ERROR: Failed to install $d. Please check the output above for details.${NC}"
-            exit 1
-          fi
-          codesign_go_binary "$d"
-        done
-        echo -e "${GREEN}All MCP servers have been installed successfully.${NC}"
-        echo -e "\n${YELLOW}Reminder: Ensure ${BLUE}\$HOME/go/bin${YELLOW} is in your PATH to run the installed servers.${NC}"
-        setup_agent_skills
+        install_all
         break
         ;;
       "Exit")
         echo "Exiting."
         exit 0
         ;;
-      *) 
+      *)
         if [ -n "$server" ]; then
-          echo -e "${BLUE}Installing $server...${NC}"
-                    # Run go mod tidy to prevent checksum mismatch errors
-          if (cd "$server" && go mod tidy && go install); then
-            codesign_go_binary "$server"
-            echo -e "${GREEN}$server has been installed successfully.${NC}"
-            echo -e "\n${YELLOW}Reminder: Ensure ${BLUE}\$HOME/go/bin${YELLOW} is in your PATH to run the installed server.${NC}"
-            setup_agent_skills
-          else
-            echo -e "${RED}ERROR: Failed to install $server. Please check the output above for details.${NC}"
-            exit 1
-          fi
+          install_one "$server"
         else
           echo -e "${RED}Invalid selection.${NC}"
         fi
@@ -218,4 +288,4 @@ main() {
   done
 }
 
-main
+main "$@"

--- a/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/install.sh
@@ -260,6 +260,7 @@ main() {
     # Accept '0', 'a', or 'all' (case-insensitive) as aliases for "Install All",
     # regardless of the number 'select' assigns to that menu item. REPLY holds
     # the raw text the user typed. tr keeps this portable to bash 3.2 (macOS).
+    local reply_lc
     reply_lc=$(printf '%s' "$REPLY" | tr '[:upper:]' '[:lower:]')
     case "$reply_lc" in
       0|a|all)


### PR DESCRIPTION
## Summary
Fixes #1769. The interactive `select` menu in `install.sh` numbers `Install All`
as the last item, so entering `0` (a common CLI convention for "all") failed with
`Invalid selection.`. There was also no way to install everything non-interactively.

## Changes
- **Menu aliases:** accept `0`, `a`, or `all` (case-insensitive) at the menu prompt
  as aliases for "Install All", regardless of the number `select` assigns that item.
  The prompt now advertises this. Uses `tr` (not `${VAR,,}`) so it stays portable to
  bash 3.2 on macOS.
- **Non-interactive flag:** add `-a` / `--all` to install every server without the
  menu, plus a `-h` / `--help` usage message. Unknown options print usage and exit 1.
- **Refactor:** extract the install-all and install-one logic into `install_all()`
  and `install_one()` so the flag path and the menu path share one implementation
  (no behavior change to the existing numeric-selection and Exit paths).

## Manual verification
`go install` was stubbed so the menu dispatch could be exercised without recompiling:
- `0`, `a`, `all`, `ALL` → Install All ✓
- numeric server selection (`1`) → installs that server ✓
- `8` (the Install All menu item) → Install All ✓
- Exit item number → exits ✓
- out-of-range / junk input → `Invalid selection.` ✓
- `./install.sh --all` and `./install.sh -a` → install all non-interactively ✓
- `./install.sh --help` → usage; `./install.sh --bogus` → usage + exit 1 ✓
- `bash -n install.sh` passes.