### PR TITLE
chore(mcp-avtool-go): go mod tidy

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.mod
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.mod
@@ -20,7 +20,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
 	cloud.google.com/go/monitoring v1.29.0 // indirect
-	cloud.google.com/go/storage v1.65.0 // indirect
+	cloud.google.com/go/storage v1.66.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 // indirect

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.sum
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/go.sum
@@ -16,8 +16,8 @@ cloud.google.com/go/longrunning v1.2.0 h1:WjYH3YHBGCxGJP9M4dWGHBfXr/cFIjMkNgWcJj
 cloud.google.com/go/longrunning v1.2.0/go.mod h1:5KMQALFGOCtFoi2xSOA1u3H7WKlhmckgiyFw7+LGQp0=
 cloud.google.com/go/monitoring v1.29.0 h1:AHhDsFaSax1/4k+qlIDX/SDGe6hggnfXJ9dkgD9qBPY=
 cloud.google.com/go/monitoring v1.29.0/go.mod h1:72NOVjJXHY/HBfoLT0+qlCZBT059+9VXLeAnL2PeeVM=
-cloud.google.com/go/storage v1.65.0 h1:McbFt5j+hTNx+dkFuzq7teakIKcpqGp/cJZRxMyfvAc=
-cloud.google.com/go/storage v1.65.0/go.mod h1:UsS9OgFg/XHOSYakQ8ZtLWWeyGkk1WnmD/GsGfN0BHM=
+cloud.google.com/go/storage v1.66.0 h1:HwYx7m9Md/rzphAFshUeAWS3hNFsJQTgFrAu4RIRwpg=
+cloud.google.com/go/storage v1.66.0/go.mod h1:UsS9OgFg/XHOSYakQ8ZtLWWeyGkk1WnmD/GsGfN0BHM=
 cloud.google.com/go/trace v1.16.0 h1:GmQovzFc5F0CNfl0VLgL64aoTtu7xsM0YajW2GlG9+E=
 cloud.google.com/go/trace v1.16.0/go.mod h1:r+bdAn16dKLSV1G2D5v3e58IlQlizfxWrUfjx7kM7X0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.33.0 h1:l7+6kwRMJNwdCvYdDl7Eax+wzEYHSnNY7zrrfbhDdTA=


### PR DESCRIPTION
## Summary
Repairs pre-existing `go.mod`/`go.sum` drift in `mcp-avtool-go` that was breaking the
**MCP GenMedia Go CI `build-and-test`** gate on `main` (and therefore on every open PR).

The CI loop tests each module in isolation (`go.work` removed) and runs `mcp-avtool-go`
**first**; it failed with:

```
go: updates to go.mod needed; to update it: go mod tidy
go test failed
```

and exited before reaching any other module. This is unrelated to any feature change —
it's base-branch dependency drift, most likely from a recent bot dependency-bump merge.

## Change
`go mod tidy` in `experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/` only. This
aligns the indirect `cloud.google.com/go/storage` requirement (`v1.65.0` → `v1.66.0`)
with `go.sum`. No source changes.

## Verification
Reproduced CI's isolated environment locally (`GOWORK=off`, Go toolchain, ffmpeg installed):
- `mcp-avtool-go`: `go mod tidy -diff` now clean, `go test ./...` and `go build ./...` **pass**.
- Ran the **full** CI module loop (avtool, chirp3, common, gemini, imagen, lyria, veo,
  nanobanana, omni): all `go test` + `go build` **green**. (Only `mcp-avtool-go` actually
  blocked `go test`; the other modules' `go test` already ran, so no further module needed
  tidying to make the gate green.)