### PR TITLE
feat(agent_tools): Track A1 — genmedia plugin scaffold with nanobanana (mcp.json)

### DIFF
--- a/experiments/agent_tools/.claude-plugin/marketplace.json
+++ b/experiments/agent_tools/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "vaics-agent-tools",
+  "owner": {
+    "name": "ghchinoy",
+    "url": "https://github.com/ghchinoy"
+  },
+  "description": "Agent tooling for GoogleCloudPlatform/vertex-ai-creative-studio: genmedia MCP servers packaged as installable Agent Plugins.",
+  "metadata": {
+    "pluginRoot": "./plugins"
+  },
+  "plugins": [
+    {
+      "name": "genmedia",
+      "source": "./plugins/genmedia",
+      "description": "Google Cloud genmedia MCP servers (vertical slice: Nanobanana image generation) bundled for one-command install with a download-on-launch binary launcher."
+    }
+  ]
+}

--- a/experiments/agent_tools/plugins/genmedia/.gitignore
+++ b/experiments/agent_tools/plugins/genmedia/.gitignore
@@ -1,0 +1,9 @@
+# Runtime download cache written by bin/genmedia-launch when a client sets
+# GENMEDIA_CACHE (or a CLAUDE_PLUGIN_ROOT-based cache) inside the plugin tree.
+# The downloaded server binaries must never be committed.
+.cache/
+
+# The repo-root .gitignore ignores every `bin/` directory. Re-include the
+# committed launcher script (only the download cache above is ignored).
+!bin/
+!bin/genmedia-launch

--- a/experiments/agent_tools/plugins/genmedia/.mcp.json
+++ b/experiments/agent_tools/plugins/genmedia/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "nanobanana": {
+      "type": "stdio",
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/genmedia-launch",
+      "args": ["mcp-nanobanana-go", "--transport", "stdio"],
+      "env": {
+        "GENMEDIA_RELEASE_TAG": "v3.18.0"
+      }
+    }
+  }
+}

--- a/experiments/agent_tools/plugins/genmedia/README.md
+++ b/experiments/agent_tools/plugins/genmedia/README.md
@@ -1,0 +1,132 @@
+# genmedia — Agent Plugin (vertical slice)
+
+Packages the Google Cloud **genmedia** MCP servers as an installable
+[Agent Plugin](https://agent-plugins.org) so an Agent-Plugins-aware client can
+install one plugin and get the servers **launchable** — no manual binary build
+and no hand-edited MCP client config.
+
+This directory is **Track A phase A1**: a proven vertical slice wiring **only the
+`nanobanana` image-generation server**. The remaining six genmedia servers
+(veo, chirp3, gemini, lyria, avtool, omni) are added in later phases using the
+same launcher and manifest.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `plugin.json` | Agent Plugins v1.0.0 manifest (closed schema). |
+| `mcp.json` | Agent Plugins v1.0.0 MCP launch descriptor (`nanobanana`, stdio). Spec-canonical form. |
+| `.mcp.json` | **Claude Code**-native MCP descriptor (see [Client compatibility](#client-compatibility)). |
+| `bin/genmedia-launch` | POSIX download-on-launch launcher (linux/darwin). |
+| `.gitignore` | Keeps the runtime download cache out of git. |
+
+## How it works — download on launch
+
+Agent Plugins have **no install/fetch phase**: `mcp.json` describes *how to
+launch* a server, not *how to obtain* it, and its `command` is a fixed string
+that cannot select a per-OS/arch binary at runtime. The genmedia servers are
+distributed as a **single GoReleaser release** containing all seven binaries per
+platform. `bin/genmedia-launch` bridges that gap. On first launch of a server it:
+
+1. **Detects** OS/arch (`uname`) → maps to the release asset
+   `genmedia-mcp-servers_<os>_<arch>.tar.gz`.
+2. **Downloads** that tarball + the release `checksums.txt` from the pinned
+   GitHub Release (default tag **`v3.18.0`**).
+3. **Verifies** the tarball's SHA-256 against **both** a value pinned inside the
+   launcher **and** the downloaded `checksums.txt`. A mismatch on either aborts
+   before anything runs — this rejects a corrupted download *and* a
+   moved/re-tagged release.
+4. **Extracts** the seven server binaries into a persistent writable cache.
+5. **Execs** the requested server, which speaks MCP over stdio.
+
+First launch downloads one tarball (~80 MB) once; every server then runs from
+that single extraction, and subsequent launches are **exec-only** (no
+re-download). The binary embeds its version (`-X main.version`), so provenance is
+checkable — the pinned `v3.18.0` binaries report `Version: 3.18.0`.
+
+### Pinning / updating the server version
+
+The release is pinned in two coordinated places — the launcher's `PINNED_TAG`
+(+ its `PINNED_SHA256_*` values) and the `GENMEDIA_RELEASE_TAG` env value in the
+manifests. **Bumping the version means updating both together.** Setting
+`GENMEDIA_RELEASE_TAG` to a *different* tag downloads that release and verifies
+it against its own `checksums.txt` only (the launcher warns that no pinned SHA is
+available for an off-pin tag).
+
+## Credentials & configuration
+
+Secrets and project config are **never** baked into the distributable manifest.
+The manifests set only non-secret operational values (the pinned release tag).
+You supply the genmedia runtime configuration through **your own environment**:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT` | **Yes** | GCP project for Vertex AI calls. |
+| Application Default Credentials (ADC) | **Yes** | `gcloud auth application-default login`, or a service-account identity. |
+| `GENMEDIA_BUCKET` | Optional | Default GCS destination (`gs://bucket/prefix`). Enables "GCS mode". |
+| `LOCATION` | Optional | Vertex region; defaults per server (e.g. `global`/`us-central1`). |
+
+### Output modes (same convention as the smoke suite and `ai-pop`)
+
+- **Local mode (default):** pass `output_directory` to a tool; the artifact is
+  written to that local path.
+- **GCS mode:** pass `gcs_bucket_uri` (or set `GENMEDIA_BUCKET`); the artifact is
+  written to GCS. In GCS mode the server returns an MCP `resource_link` content
+  type that some clients cannot render even though the file was written — always
+  **verify by destination listing** (`gcloud storage ls <prefix>`), not by
+  reading the tool's rendered response.
+
+## Install
+
+### Claude Code (validated end to end)
+
+```bash
+# From a checkout of this repo, add this directory as a marketplace:
+claude plugin marketplace add /path/to/vertex-ai-creative-studio/experiments/agent_tools
+claude plugin install genmedia@vaics-agent-tools
+
+# Confirm the server launches and connects (first run downloads the release):
+claude mcp list        # -> plugin:genmedia:nanobanana ... ✔ Connected
+```
+
+Then, in a Claude Code session (with `GOOGLE_CLOUD_PROJECT` set and ADC
+available), the `nanobanana_image_generation` tool is callable and writes a real
+image to your requested `output_directory` / `gcs_bucket_uri`.
+
+### Other clients
+
+Any Agent-Plugins-aware client reads `mcp.json`; the launcher is client-agnostic.
+Native repackaging for Gemini CLI / Antigravity, and manual-config fallback docs
+for other clients, are later phases (design §5.4 / A5).
+
+## Client compatibility
+
+Two MCP descriptors ship here because the ecosystem hasn't fully converged:
+
+- **`mcp.json`** — the Agent Plugins v1.0.0 canonical form: relative
+  `command: ./bin/genmedia-launch`, `cwd: ${PLUGIN_ROOT}`, cache under
+  `${PLUGIN_DATA}`.
+- **`.mcp.json`** — what **Claude Code (v2.1.222)** actually reads. Claude Code
+  resolves `command` against the process working directory (not `${PLUGIN_ROOT}`)
+  and provides its own `${CLAUDE_PLUGIN_ROOT}` placeholder, so it needs
+  `command: ${CLAUDE_PLUGIN_ROOT}/bin/genmedia-launch`. Claude Code's plugin
+  marketplace manifest also requires an `owner` object (see
+  `../../.claude-plugin/marketplace.json`).
+
+Both point at the **same launcher** and the **same pinned release** — only the
+thin descriptor differs. Keeping both means the plugin is spec-conformant *and*
+works today in the known-good client.
+
+## Containment
+
+Per Agent Plugins §4.1, every path a client resolves stays inside the plugin
+root. The `command` is inside the plugin (`./bin/genmedia-launch`); downloaded
+binaries are written only to the client-designated writable cache
+(`${PLUGIN_DATA}` for spec clients, or `~/.cache/genmedia/bin` as a standalone
+fallback) — never via a `../` escape, and the launcher creates no symlinks.
+
+## Scope (A1)
+
+Only `nanobanana` is wired. `lyria` is deliberately deferred (a client-side
+audio-parsing fix rides in a later pinned release); `avtool` needs `ffmpeg` at
+runtime; Windows launcher parity is phase A4.

--- a/experiments/agent_tools/plugins/genmedia/bin/genmedia-launch
+++ b/experiments/agent_tools/plugins/genmedia/bin/genmedia-launch
@@ -1,0 +1,190 @@
+#!/usr/bin/env sh
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ---------------------------------------------------------------------------
+# genmedia-launch — download-on-launch bridge for the genmedia MCP servers.
+#
+# Agent Plugins mcp.json points its `command` at this script (a path INSIDE the
+# plugin root) because the spec has no fetch phase and `command` is a fixed,
+# non-templated string that cannot select an OS/arch binary at runtime. This
+# script fills exactly that gap: it detects the platform, downloads the matching
+# GoReleaser tarball from the pinned GitHub Release, verifies its SHA-256
+# against BOTH a value pinned in this script AND the release's own
+# checksums.txt, extracts the bundled server binaries into a client-managed
+# writable cache, and execs the requested server speaking MCP over stdio.
+#
+#   genmedia-launch <server-binary> [server-args...]
+#     e.g. genmedia-launch mcp-nanobanana-go --transport stdio
+#
+# CONTAINMENT (Agent Plugins §4.1): this script lives inside the plugin root and
+# is reached via `command: ./bin/genmedia-launch` with `cwd: ${PLUGIN_ROOT}`.
+# Downloaded binaries are written ONLY under $GENMEDIA_CACHE, which the plugin
+# manifest sets to ${PLUGIN_DATA}/bin — the client-designated persistent
+# writable directory. No path here resolves outside those two locations; there
+# are no `../` escapes and no symlinks are created.
+#
+# STDOUT DISCIPLINE: stdout is the MCP stdio transport. Every diagnostic this
+# script emits goes to STDERR so it never corrupts the JSON-RPC stream. Only the
+# exec'd server ever writes to stdout.
+# ---------------------------------------------------------------------------
+
+set -eu
+
+log() { printf 'genmedia-launch: %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# --- Pinned release --------------------------------------------------------
+# The release tag whose SHA-256s are pinned below. Bumping the pinned release
+# means updating BOTH this tag and the PINNED_SHA256_* values together.
+PINNED_TAG="v3.18.0"
+
+# Expected SHA-256 of each per-platform tarball for PINNED_TAG. Sourced from the
+# release's genmedia-mcp-servers_<version>_checksums.txt and embedded here so a
+# moved/re-tagged release (not just a corrupted download) is rejected.
+PINNED_SHA256_darwin_amd64="b9cb5a15d36468c9c6286bdaa66120f675f4f08b6be485f81ceb3ec4fcbb4b8b"
+PINNED_SHA256_darwin_arm64="738341f24f0887cdcfb9f696e8e50eeb3e20247cec809aff1988f528d13e4582"
+PINNED_SHA256_linux_amd64="ee50975330e67936fe63ee0d88a5982233fdaff6ee83dd65ec2d8b296a443b14"
+PINNED_SHA256_linux_arm64="9ae511298fbf28f578f75ee59ff6c94fb9fb9a4dbec5e26916ed80fc3b4003f7"
+PINNED_SHA256_windows_amd64="226b0fffef826e5fd9478dcdf138ba2a029b29b87da6b16179f0d2d355143fdc"
+PINNED_SHA256_windows_arm64="0027490699868059a5e9712298b7f60058fe769886457d255b80507b4957fdbb"
+
+RELEASE_BASE="https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/releases/download"
+
+# --- Args ------------------------------------------------------------------
+[ "$#" -ge 1 ] || die "usage: genmedia-launch <server-binary> [server-args...]"
+server="$1"
+shift
+
+# --- Release selection -----------------------------------------------------
+# GENMEDIA_RELEASE_TAG selects the release tag (default: the pinned tag). The
+# checksums.txt filename uses the version with the leading 'v' stripped.
+tag="${GENMEDIA_RELEASE_TAG:-$PINNED_TAG}"
+version="${tag#v}"
+
+# --- Cache location --------------------------------------------------------
+# GENMEDIA_CACHE is set by mcp.json to ${PLUGIN_DATA}/bin. Fall back to an
+# XDG-style path for standalone/manual invocation outside a plugin client.
+cache_root="${GENMEDIA_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/genmedia/bin}"
+cache="${cache_root}/${version}"
+bin="${cache}/${server}"
+
+# --- Fast path: already cached ---------------------------------------------
+if [ -x "$bin" ]; then
+  exec "$bin" "$@"
+fi
+
+# --- Platform detection ----------------------------------------------------
+os_raw="$(uname -s)"
+arch_raw="$(uname -m)"
+
+case "$os_raw" in
+  Linux)  os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) die "unsupported OS '$os_raw' (linux/darwin only in this phase; Windows is tracked as phase A4)" ;;
+esac
+
+case "$arch_raw" in
+  x86_64|amd64)        arch="amd64" ;;
+  aarch64|arm64)       arch="arm64" ;;
+  *) die "unsupported architecture '$arch_raw' (amd64/arm64 only)" ;;
+esac
+
+platform="${os}_${arch}"
+tarball="genmedia-mcp-servers_${platform}.tar.gz"
+checksums="genmedia-mcp-servers_${version}_checksums.txt"
+tarball_url="${RELEASE_BASE}/${tag}/${tarball}"
+checksums_url="${RELEASE_BASE}/${tag}/${checksums}"
+
+# --- Tooling ---------------------------------------------------------------
+if command -v curl >/dev/null 2>&1; then
+  fetch() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() { wget -q "$1" -O "$2"; }
+else
+  die "need curl or wget to download the release asset"
+fi
+
+# Portable SHA-256: prefer sha256sum, fall back to `shasum -a 256` (macOS).
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  die "need sha256sum or shasum to verify the download"
+fi
+
+command -v tar >/dev/null 2>&1 || die "need tar to extract the release asset"
+
+# --- Download + verify + extract into a private temp dir -------------------
+mkdir -p "$cache_root"
+tmp="$(mktemp -d "${cache_root}/.dl.XXXXXX")" || die "cannot create temp dir under $cache_root"
+# shellcheck disable=SC2064
+trap "rm -rf \"$tmp\"" EXIT INT TERM
+
+log "server '$server' not cached for ${tag} (${platform}); downloading ${tarball}"
+fetch "$tarball_url" "${tmp}/${tarball}" || die "download failed: $tarball_url"
+fetch "$checksums_url" "${tmp}/${checksums}" || die "download failed: $checksums_url"
+
+actual="$(sha256_of "${tmp}/${tarball}")"
+[ -n "$actual" ] || die "could not compute SHA-256 of ${tarball}"
+
+# 1) Cross-check against the release's own checksums.txt (defends against a
+#    corrupted download).
+expected_txt="$(awk -v f="$tarball" '$2==f {print $1}' "${tmp}/${checksums}")"
+[ -n "$expected_txt" ] || die "no entry for ${tarball} in ${checksums}"
+[ "$actual" = "$expected_txt" ] || die "checksum mismatch vs ${checksums}: expected ${expected_txt}, got ${actual}"
+
+# 2) Cross-check against the SHA-256 pinned in THIS script (defends against a
+#    moved/re-tagged release). Only possible when the requested tag is the
+#    pinned tag; an explicit override to another tag degrades to checksums.txt
+#    verification only, with a clear warning.
+if [ "$tag" = "$PINNED_TAG" ]; then
+  eval "expected_pin=\${PINNED_SHA256_${platform}:-}"
+  [ -n "${expected_pin:-}" ] || die "no pinned SHA-256 for platform ${platform}"
+  [ "$actual" = "$expected_pin" ] || die "checksum mismatch vs pinned value for ${platform}: expected ${expected_pin}, got ${actual}"
+  log "checksum verified (pinned + checksums.txt): ${actual}"
+else
+  log "WARNING: GENMEDIA_RELEASE_TAG=${tag} differs from pinned ${PINNED_TAG}; verified against checksums.txt only (no pinned SHA available)."
+fi
+
+log "extracting ${tarball}"
+tar -xzf "${tmp}/${tarball}" -C "$tmp" || die "extraction failed: $tarball"
+
+# --- Publish into the cache atomically -------------------------------------
+# Extract to a temp dir then move into place so a partially populated cache is
+# never visible. If a concurrent first launch won the race, reuse its result.
+if [ ! -x "$bin" ]; then
+  staging="${tmp}/staged"
+  mkdir -p "$staging"
+  # Move the flat binaries (tarball has all servers at its root, no subdirs).
+  for f in "$tmp"/mcp-*; do
+    [ -e "$f" ] || continue
+    chmod +x "$f" 2>/dev/null || true
+    mv -f "$f" "$staging/" 2>/dev/null || true
+  done
+  mkdir -p "$cache"
+  for f in "$staging"/mcp-*; do
+    [ -e "$f" ] || continue
+    mv -f "$f" "$cache/" 2>/dev/null || true
+  done
+fi
+
+[ -x "$bin" ] || die "server binary '$server' not found in ${tarball} after extraction"
+
+rm -rf "$tmp"
+trap - EXIT INT TERM
+
+exec "$bin" "$@"

--- a/experiments/agent_tools/plugins/genmedia/mcp.json
+++ b/experiments/agent_tools/plugins/genmedia/mcp.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "nanobanana": {
+      "type": "stdio",
+      "command": "./bin/genmedia-launch",
+      "args": ["mcp-nanobanana-go", "--transport", "stdio"],
+      "env": {
+        "GENMEDIA_RELEASE_TAG": "v3.18.0",
+        "GENMEDIA_CACHE": "${PLUGIN_DATA}/bin"
+      },
+      "cwd": "${PLUGIN_ROOT}"
+    }
+  }
+}

--- a/experiments/agent_tools/plugins/genmedia/plugin.json
+++ b/experiments/agent_tools/plugins/genmedia/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "genmedia",
+  "version": "3.18.0",
+  "description": "Google Cloud genmedia MCP servers bundled as launchable MCP servers. This vertical slice wires the Nanobanana image-generation server; the remaining genmedia servers are added in later phases.",
+  "author": {
+    "name": "ghchinoy",
+    "url": "https://github.com/ghchinoy"
+  },
+  "homepage": "https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/tree/main/experiments/agent_tools/plugins/genmedia",
+  "repository": "https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio",
+  "license": "Apache-2.0",
+  "keywords": ["genmedia", "mcp", "nanobanana", "image-generation", "gemini", "vertex-ai"]
+}


### PR DESCRIPTION
## Track A1 — genmedia Agent Plugin vertical slice (nanobanana)

First slice of Track A (design: `experiments/agent_tools` plugins design). Packages the genmedia MCP servers as an installable [Agent Plugin](https://agent-plugins.org) so an Agent-Plugins-aware client installs one plugin and gets the servers **launchable** — no manual binary build, no hand-edited MCP config. This slice wires **only `nanobanana`** to prove the whole mechanism before fan-out (A2 adds the other six to the same `mcp.json`, reusing the one launcher).

### What's here
- `experiments/agent_tools/plugins/genmedia/`
  - `plugin.json` — Agent Plugins v1.0.0 manifest (closed schema), pinned to `v3.18.0`.
  - `mcp.json` — agent-plugins.org canonical MCP launch descriptor (nanobanana, stdio).
  - `.mcp.json` — **Claude Code**-native descriptor (`${CLAUDE_PLUGIN_ROOT}`); see divergence note below.
  - `bin/genmedia-launch` — POSIX download-on-launch launcher (linux/darwin).
  - `README.md`, `.gitignore`.
- `experiments/agent_tools/.claude-plugin/marketplace.json` — the repo's first marketplace index, under `experiments/agent_tools/`.

### The launcher (the one genuinely new artifact)
Agent Plugins have no fetch phase and `command` can't select a per-OS/arch binary, so `bin/genmedia-launch` bridges the gap: detect platform → download the pinned GitHub Release tarball → **verify SHA-256 against BOTH values pinned in the launcher AND the release `checksums.txt`** (rejects a corrupted download *and* a moved/re-tagged release) → extract → exec. First launch downloads one ~80 MB tarball; subsequent launches are exec-only. All diagnostics go to stderr so the MCP stdio channel stays clean.

### Version pinning
Pinned to release **`v3.18.0`** (latest stable with confirmed working assets — verified the workflow completed and all 6 tarballs + checksums are downloadable). Note the asset-bearing release tag is `v3.18.0` (the `mcp-v3.18.0` tag carries no binary assets).

### Validated end to end in Claude Code v2.1.222 (real client)
- `claude plugin marketplace add … && claude plugin install genmedia@vaics-agent-tools` → installed, enabled.
- `claude mcp list` → `plugin:genmedia:nanobanana … ✔ Connected` from a **cold cache** (full download → checksum → extract → exec → MCP handshake through Claude Code's own launch).
- In-session `tools/call` of `nanobanana_image_generation` produced a **verified 1024×1024 PNG** (~2 MB) in both local and GCS modes (GCS verified by destination listing; server returns `resource_link`).
- **Negative test:** a tampered pinned SHA-256 aborts before the server runs and caches nothing.
- **Containment (§4.1):** no `../` escapes, no symlinks; downloads land only in the client-managed cache.

### Client-compatibility finding (feeds the design)
agent-plugins.org format is **not** yet first-class in Claude Code 2.1.222 as assumed. Claude Code reads `.mcp.json` (not `mcp.json`), resolves `command` against the process cwd (needing `${CLAUDE_PLUGIN_ROOT}` rather than a relative command + `cwd:${PLUGIN_ROOT}`), and its marketplace manifest requires an `owner` object. Both descriptors ship here (spec-canonical `mcp.json` + Claude-native `.mcp.json`) pointing at the same launcher and release — only the thin descriptor differs.

### Scope
A1 only. `lyria` deferred (client-side audio-parse fix rides a later pinned release), `avtool` needs `ffmpeg`, Windows launcher parity is A4, native Gemini/Antigravity repackaging is A5, docs-site update is a separate PR.
