### PR TITLE
feat(agent_tools): Track B1 — genmedia-image skill (nanobanana)

### DIFF
--- a/experiments/agent_tools/.claude-plugin/marketplace.json
+++ b/experiments/agent_tools/.claude-plugin/marketplace.json
@@ -12,7 +12,10 @@
     {
       "name": "genmedia",
       "source": "./plugins/genmedia",
-      "description": "Google Cloud genmedia MCP servers (vertical slice: Nanobanana image generation) bundled for one-command install with a download-on-launch binary launcher."
+      "description": "Google Cloud genmedia MCP servers (vertical slice: Nanobanana image generation) bundled for one-command install with a download-on-launch binary launcher, plus workflow skills that call the genmedia tools.",
+      "skills": [
+        "./plugins/genmedia/skills/genmedia-image"
+      ]
     }
   ]
 }

--- a/experiments/agent_tools/plugins/genmedia/README.md
+++ b/experiments/agent_tools/plugins/genmedia/README.md
@@ -18,7 +18,22 @@ same launcher and manifest.
 | `mcp.json` | Agent Plugins v1.0.0 MCP launch descriptor (`nanobanana`, stdio). Spec-canonical form. |
 | `.mcp.json` | **Claude Code**-native MCP descriptor (see [Client compatibility](#client-compatibility)). |
 | `bin/genmedia-launch` | POSIX download-on-launch launcher (linux/darwin). |
+| `skills/genmedia-image/SKILL.md` | Agent Skill: generate images via `nanobanana_image_generation` (see [Skills](#skills)). |
 | `.gitignore` | Keeps the runtime download cache out of git. |
+
+## Skills
+
+Alongside the launchable servers, this plugin ships **Agent Skills** — prose
+workflow expertise that *calls* the genmedia MCP tools (modeled on the `ai-pop`
+precedent). A skill assumes the relevant MCP server is already configured (this
+plugin's `mcp.json` / `.mcp.json`, or a manual MCP config).
+
+| Skill | Tool | Purpose |
+|---|---|---|
+| `genmedia-image` | `nanobanana_image_generation` | Generate a still image from a text prompt (optionally guided by reference images), with control over aspect ratio, resolution, and local vs GCS output; verifies the artifact by existence. |
+
+More genmedia skills (video, speech, and goal-driven orchestrators) are added in
+later phases.
 
 ## How it works — download on launch
 

--- a/experiments/agent_tools/plugins/genmedia/skills/genmedia-image/SKILL.md
+++ b/experiments/agent_tools/plugins/genmedia/skills/genmedia-image/SKILL.md
@@ -82,5 +82,9 @@ Credentials (ADC) in its environment for Vertex AI calls.
      ```sh
      gcloud storage ls "gs://<gcs_bucket_uri prefix>"
      ```
+     Note: if you relied on the `GENMEDIA_BUCKET` environment variable instead of
+     passing `gcs_bucket_uri` explicitly, the server writes under a
+     `nanobanana_outputs/` subprefix — list `gs://<GENMEDIA_BUCKET>/nanobanana_outputs/`,
+     not the bare bucket.
    * If no artifact is found, treat the generation as failed and surface the
      tool response for debugging rather than reporting success.

--- a/experiments/agent_tools/plugins/genmedia/skills/genmedia-image/SKILL.md
+++ b/experiments/agent_tools/plugins/genmedia/skills/genmedia-image/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: genmedia-image
+description: Generate images from a text prompt (optionally guided by reference images) using the genmedia Nanobanana MCP server's nanobanana_image_generation tool. Use when a task needs a still image produced from a description, with control over aspect ratio, resolution, and local vs GCS output, and verified by confirming the artifact was actually written.
+license: Apache-2.0
+---
+
+# genmedia Image
+
+This skill generates images by calling the `nanobanana_image_generation` tool
+exposed by the genmedia **Nanobanana** MCP server. It is a Tier-1 primitive: one
+tool, one job. It supports both local workspace execution and remote / managed
+agent execution via GCS staging, and it always verifies that a real artifact was
+produced — never that the call merely returned without error.
+
+**Prerequisite:** the genmedia Nanobanana MCP server must already be configured
+in your client (e.g. via this plugin's `mcp.json` / `.mcp.json`, or a manual MCP
+config). The server needs `GOOGLE_CLOUD_PROJECT` and Application Default
+Credentials (ADC) in its environment for Vertex AI calls.
+
+## Instructions
+
+1. **Resolve Output Storage Mode:**
+   * **Local Mode (Default):** Pass `output_directory` pointing to the target
+     local workspace directory. The artifact is written to that local path.
+   * **Managed Agent / GCS Mode:** When executing inside a managed agent
+     container where the MCP server runs remotely on Cloud Run, pass
+     `gcs_bucket_uri` (a GCS URI prefix such as `your-bucket/outputs/`) — or set
+     the `GENMEDIA_BUCKET` environment variable — pointing to the mounted GCS
+     environment bucket.
+   * Do not pass both modes' destinations for the same call unless you
+     intentionally want output in both places.
+
+2. **Formulate Imagery Parameters:**
+   * **`prompt`** (required): a detailed text description. Favor concrete style,
+     subject, lighting, and composition language (e.g. *"a photorealistic red
+     panda sitting in a bamboo forest, golden hour lighting"*).
+   * **`model`** (optional): defaults to `gemini-3.1-flash-image`. Leave unset
+     unless you have a specific model requirement.
+   * **`aspect_ratio`** (optional): defaults to `1:1`. Supported ratios are
+     model-dependent (common values include `1:1`, `3:4`, `4:3`, `9:16`,
+     `16:9`). Choose the ratio that matches the intended use (e.g. `16:9` for a
+     hero banner, `9:16` for a vertical/mobile frame).
+   * **`image_size`** (optional): `1K`, `2K`, or `4K`. Defaults to `1K` when
+     unset. Supported sizes are model-dependent.
+   * **`output_filename`** (optional): a client-predictable base name (e.g.
+     `hero.png`). The extension is forced to the true output media type. When a
+     single image is produced the name is used as-is; when multiple images are
+     produced they are suffixed `_1`, `_2`, … before the extension. An existing
+     file/object of the same name is overwritten.
+   * **`seed`** (optional): a non-negative integer for best-effort reproducible
+     generation.
+
+3. **Reference Images (optional, `images`):**
+   * To guide generation with existing media, pass `images` as a list of
+     **local file paths or GCS URIs** (images, and — where the model supports it
+     — videos or PDFs). Use this for edits, style transfer, character
+     consistency, or compositing from source frames.
+   * Ensure every referenced path/URI actually exists before the call; a
+     missing reference produces a degraded or failed result.
+
+4. **Invoke the tool:**
+   * Call `nanobanana_image_generation` with the parameters assembled above.
+   * **Local Mode example params:**
+     `{ "prompt": "...", "aspect_ratio": "16:9", "output_directory": "./out", "output_filename": "hero.png" }`
+   * **GCS Mode example params:**
+     `{ "prompt": "...", "aspect_ratio": "16:9", "gcs_bucket_uri": "your-bucket/outputs/", "output_filename": "hero.png" }`
+   * **Reference-guided example params:**
+     `{ "prompt": "same character, new pose", "images": ["./refs/character.png"], "output_directory": "./out", "output_filename": "pose.png" }`
+
+5. **Verify the Artifact By Existence (do not trust the response alone):**
+   * A tool call that returns without an error is **not** proof an image was
+     written. In some clients and in GCS mode the server returns a
+     `resource_link` content type that cannot be rendered even though the file
+     was written — never assume inline data.
+   * **Local Mode:** confirm the file exists and is a real, non-empty image, and
+     inspect its type:
+     ```sh
+     file "<output_directory>/<output_filename>"   # e.g. "... PNG image data, 1024 x 1024"
+     ```
+   * **GCS Mode:** confirm the object exists at the destination prefix by
+     listing it — do **not** parse the tool response:
+     ```sh
+     gcloud storage ls "gs://<gcs_bucket_uri prefix>"
+     ```
+   * If no artifact is found, treat the generation as failed and surface the
+     tool response for debugging rather than reporting success.


### PR DESCRIPTION
## Track B1 — first genmedia Agent Skill (`genmedia-image`)

Phase 2 of the sequential A1→B1 dispatch (A1 = #1773, merged). This adds the
first **Agent Skill** to the existing `genmedia` plugin — the Tier-1 primitive
`genmedia-image`, wired to `nanobanana_image_generation` (the tool A1 validated
live). Modeled directly on the `ai-pop-visual-designer` precedent in
`ghchinoy/agent-skills`.

Co-ships in the **one** `genmedia` plugin (design §5.2, owner Q6) — not a
separate plugin.

### What's in this PR
- **`plugins/genmedia/skills/genmedia-image/SKILL.md`** — spec-conformant
  frontmatter (`name` matches dir, `description` 347 chars, `license`); prose
  instructions covering:
  - Local Mode (`output_directory`) vs Managed Agent / GCS Mode
    (`gcs_bucket_uri` / `GENMEDIA_BUCKET`);
  - the real nanobanana params (`prompt`, `model`, `aspect_ratio`, `image_size`,
    reference images via `images`, `output_filename`, `seed`);
  - **verify the artifact by existence** (`file` locally / `gcloud storage ls`
    for GCS) — never trust the response alone (GCS returns an unrenderable
    `resource_link`).
- **`.claude-plugin/marketplace.json`** — adds the skill path to the `genmedia`
  plugin entry.
- **`plugins/genmedia/README.md`** — documents the new skill.

### Validation (live, this environment: go 1.26, mcptools, gcloud + ADC, `GOOGLE_CLOUD_PROJECT=ghchinoy-genai-sa`)
Acting as a client following the skill's own instructions, built
`mcp-nanobanana-go` and called the tool:
- ✅ **Local Mode** — `aspect_ratio:16:9` → real **1376×768 PNG, 2.0 MB** on disk; verified by existence.
- ✅ **Reference images (`images` arg)** — fed the generated PNG back as a reference → real **1024×1024 PNG, 1.9 MB**.
- ✅ **GCS Mode** — mcptools errored with `unsupported content type: resource_link` (the documented quirk) while the object was **actually written** — verified by `gcloud storage ls` (1.89 MiB PNG). This is exactly the verify-by-destination-listing idiom the skill mandates. (Test object cleaned up afterward.)
- ✅ Frontmatter spec-checked (no illegal top-level fields; `name`==dir; description length in range); `marketplace.json` parses.

### Scope
Only `genmedia-image`. Tier-1 fan-out (video/omni/speech) is B2; the Tier-2
orchestrator is B3; `genmedia-music` is blocked on #1768 (B4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)