### PR TITLE
docs(agent_tools): editorial pass — remove internal phase jargon from user-facing docs

### DIFF
--- a/experiments/agent_tools/.claude-plugin/marketplace.json
+++ b/experiments/agent_tools/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "genmedia",
       "source": "./plugins/genmedia",
-      "description": "Google Cloud genmedia MCP servers (vertical slice: Nanobanana image generation) bundled for one-command install with a download-on-launch binary launcher, plus workflow skills that call the genmedia tools.",
+      "description": "Google Cloud genmedia MCP servers (currently Nanobanana image generation) bundled for one-command install with a download-on-launch binary launcher, plus workflow skills that call the genmedia tools.",
       "skills": [
         "./plugins/genmedia/skills/genmedia-image"
       ]

--- a/experiments/agent_tools/plugins/genmedia/README.md
+++ b/experiments/agent_tools/plugins/genmedia/README.md
@@ -1,14 +1,13 @@
-# genmedia — Agent Plugin (vertical slice)
+# genmedia — Agent Plugin
 
 Packages the Google Cloud **genmedia** MCP servers as an installable
 [Agent Plugin](https://agent-plugins.org) so an Agent-Plugins-aware client can
 install one plugin and get the servers **launchable** — no manual binary build
 and no hand-edited MCP client config.
 
-This directory is **Track A phase A1**: a proven vertical slice wiring **only the
-`nanobanana` image-generation server**. The remaining six genmedia servers
-(veo, chirp3, gemini, lyria, avtool, omni) are added in later phases using the
-same launcher and manifest.
+This plugin currently wires **only the `nanobanana` image-generation server**.
+The remaining six genmedia servers (veo, chirp3, gemini, lyria, avtool, omni)
+are not yet wired; they will be added using the same launcher and manifest.
 
 ## What's here
 
@@ -32,8 +31,7 @@ plugin's `mcp.json` / `.mcp.json`, or a manual MCP config).
 |---|---|---|
 | `genmedia-image` | `nanobanana_image_generation` | Generate a still image from a text prompt (optionally guided by reference images), with control over aspect ratio, resolution, and local vs GCS output; verifies the artifact by existence. |
 
-More genmedia skills (video, speech, and goal-driven orchestrators) are added in
-later phases.
+More genmedia skills (video, speech, and goal-driven orchestrators) are planned.
 
 ## How it works — download on launch
 
@@ -112,7 +110,7 @@ image to your requested `output_directory` / `gcs_bucket_uri`.
 
 Any Agent-Plugins-aware client reads `mcp.json`; the launcher is client-agnostic.
 Native repackaging for Gemini CLI / Antigravity, and manual-config fallback docs
-for other clients, are later phases (design §5.4 / A5).
+for other clients, are planned.
 
 ## Client compatibility
 
@@ -140,8 +138,8 @@ binaries are written only to the client-designated writable cache
 (`${PLUGIN_DATA}` for spec clients, or `~/.cache/genmedia/bin` as a standalone
 fallback) — never via a `../` escape, and the launcher creates no symlinks.
 
-## Scope (A1)
+## Current scope
 
 Only `nanobanana` is wired. `lyria` is deliberately deferred (a client-side
 audio-parsing fix rides in a later pinned release); `avtool` needs `ffmpeg` at
-runtime; Windows launcher parity is phase A4.
+runtime; a Windows launcher is not yet available.

--- a/experiments/agent_tools/plugins/genmedia/bin/genmedia-launch
+++ b/experiments/agent_tools/plugins/genmedia/bin/genmedia-launch
@@ -93,7 +93,7 @@ arch_raw="$(uname -m)"
 case "$os_raw" in
   Linux)  os="linux" ;;
   Darwin) os="darwin" ;;
-  *) die "unsupported OS '$os_raw' (linux/darwin only in this phase; Windows is tracked as phase A4)" ;;
+  *) die "unsupported OS '$os_raw' (linux/darwin only; Windows is not yet supported)" ;;
 esac
 
 case "$arch_raw" in

--- a/experiments/agent_tools/plugins/genmedia/plugin.json
+++ b/experiments/agent_tools/plugins/genmedia/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "genmedia",
   "version": "3.18.0",
-  "description": "Google Cloud genmedia MCP servers bundled as launchable MCP servers. This vertical slice wires the Nanobanana image-generation server; the remaining genmedia servers are added in later phases.",
+  "description": "Google Cloud genmedia MCP servers bundled as launchable MCP servers. Currently wires the Nanobanana image-generation server; the remaining genmedia servers will be added over time.",
   "author": {
     "name": "ghchinoy",
     "url": "https://github.com/ghchinoy"

--- a/experiments/agent_tools/plugins/genmedia/plugin.json
+++ b/experiments/agent_tools/plugins/genmedia/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "genmedia",
   "version": "3.18.0",
-  "description": "Google Cloud genmedia MCP servers bundled as launchable MCP servers. Currently wires the Nanobanana image-generation server; the remaining genmedia servers will be added over time.",
+  "description": "Google Cloud genmedia MCP servers bundled as launchable MCP servers. Currently wires the Nanobanana image-generation server; the remaining genmedia servers will be added.",
   "author": {
     "name": "ghchinoy",
     "url": "https://github.com/ghchinoy"

--- a/experiments/agent_tools/plugins/genmedia/skills/genmedia-image/SKILL.md
+++ b/experiments/agent_tools/plugins/genmedia/skills/genmedia-image/SKILL.md
@@ -7,8 +7,8 @@ license: Apache-2.0
 # genmedia Image
 
 This skill generates images by calling the `nanobanana_image_generation` tool
-exposed by the genmedia **Nanobanana** MCP server. It is a Tier-1 primitive: one
-tool, one job. It supports both local workspace execution and remote / managed
+exposed by the genmedia **Nanobanana** MCP server. It is a single-purpose skill:
+one tool, one job. It supports both local workspace execution and remote / managed
 agent execution via GCS staging, and it always verifies that a real artifact was
 produced — never that the call merely returned without error.
 


### PR DESCRIPTION
## What

First editorial pass by the standing docs archivist over the **user-facing** genmedia agent-tools surfaces. Removes internal project/phase vocabulary that is planning and coordination language, not end-user documentation.

Applies the [`technical-post-editorial`](https://github.com/ghchinoy/agent-skills/tree/main/plugins/repo-authoring/skills/technical-post-editorial) skill as a post-hoc acceptance gate, focused on its **audience-fit (Axis A)** and *trust-the-reader / no-vague-declaratives* criteria: docs should say **what the thing is and how to use it**, not the internal roadmap that built it.

## Jargon removed

| Term | Where | Replaced with |
|---|---|---|
| "vertical slice" | README title, plugin.json, marketplace.json | dropped / "currently wires" |
| "Track A phase A1" | plugin README intro | "This plugin currently wires…" |
| "later phases" | plugin README (skills, client-compat) | "planned" / "will be added" |
| "design §5.4 / A5" | plugin README client-compat | "planned" |
| "Scope (A1)" / "phase A4" | plugin README heading + Windows note | "Current scope" / "not yet available" |
| "Tier-1 primitive" | genmedia-image/SKILL.md | "single-purpose skill" |
| "phase A4" | genmedia-launch unsupported-OS error | "Windows is not yet supported" |

## Preserved (not jargon)

Real technical detail is untouched: tool names, model IDs, arg names, GCS/local mode semantics, and legitimate spec references (Agent Plugins §4.1, "no install/fetch phase" — a real protocol fact). "later pinned release" is a version reference, not roadmap language.

## Scope checked, clean already

`experiments/agent_tools/README.md` and the docs-site page `docs-site/src/content/docs/experiments/agent-tools/index.md` (PR #1766) contained no phase-jargon leakage, so they are unchanged. Because the docs-site page was not touched, no site rebuild was required.

## Verification

- Re-grepped all user-facing surfaces for `Track A/B`, `A1..A9`, `B1..B9`, `Tier-1/2`, "vertical slice", "later phases", design-section refs — none survive in user-facing copy.
- Validated `marketplace.json` and `plugin.json` parse as JSON; `genmedia-launch` passes `bash -n`.