### PR TITLE
docs(arena): deprecation notice — archiving in 1 week

### DIFF
--- a/docs-site/src/content/docs/experiments/arena/index.md
+++ b/docs-site/src/content/docs/experiments/arena/index.md
@@ -2,6 +2,17 @@
 title: "Image Generation Arena & Leaderboard"
 ---
 
+:::caution[Deprecation notice]
+This experiment is deprecated and scheduled for archiving.
+
+It relies on unmaintained dependencies and its core image-battle feature is currently broken: the default battle pool depends on Imagen models that were [shut down across Vertex AI on 2026-08-17](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev), so every default battle now fails. The experiment is not actively maintained (recent commits are almost entirely automated dependency bumps) and is not actively used.
+
+- **On or after 2026-09-13**, this experiment will be moved to an archived state.
+- **Approximately 2 months after archiving (around 2026-11-13)**, it will be considered for full removal from the repository.
+
+If you depend on this experiment, please raise an issue before the archiving date.
+:::
+
 This is an example of an arena & leaderboard to compare different image generation tools.
 
 It supports comparing images from a range of image generation models, including Flux1, Stable Diffusion, and Gemini image models (Nano Banana). Note that Imagen models were [deprecated across Google, including Vertex AI, around August 17, 2026](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev); use Gemini Image Generation (Nano Banana) as the replacement.

--- a/docs-site/src/content/docs/experiments/overview.md
+++ b/docs-site/src/content/docs/experiments/overview.md
@@ -23,7 +23,7 @@ The experimental folder contains stand-alone applications, demos, and features n
 * [Imagen Product Recontextualization at Scale](/vertex-ai-creative-studio/experiments/imagen_product_recontext) - A set of notebooks for the Imagen Product Recontext model to run at scale.
 * [Virtual Try-On](/vertex-ai-creative-studio/experiments/vto) - A notebook example for virtually trying on outfits at scale.
 * [Brand Consistency](/vertex-ai-creative-studio/experiments/brand_consistency) - Maintain brand identity in generated media.
-* [Arena](/vertex-ai-creative-studio/experiments/arena) - Rate your images within a visual arena.
+* [Arena](/vertex-ai-creative-studio/experiments/arena) - Rate your images within a visual arena. **(Deprecated — scheduled for archiving on or after 2026-09-13.)**
 
 ## Audio & Voice
 

--- a/experiments/arena/README.md
+++ b/experiments/arena/README.md
@@ -1,5 +1,20 @@
 # Image Generation Arena & Leaderboard
 
+> [!WARNING]
+> **Deprecation notice.** This experiment is deprecated and scheduled for archiving.
+>
+> It relies on unmaintained dependencies and its core image-battle feature is currently
+> broken: the default battle pool depends on Imagen models that were
+> [shut down across Vertex AI on 2026-08-17](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev),
+> so every default battle now fails. The experiment is not actively maintained (recent
+> commits are almost entirely automated dependency bumps) and is not actively used.
+>
+> - **On or after 2026-09-13**, this experiment will be moved to an archived state.
+> - **Approximately 2 months after archiving (around 2026-11-13)**, it will be considered
+>   for full removal from the repository.
+>
+> If you depend on this experiment, please raise an issue before the archiving date.
+
 This is an example of an arena & leaderboard to compare different image generation tools.
 
 Currently, it uses Flux1, Stable Diffusion, Imagen 2, Imagen 3, image generation models with Gemini 2.0 experimental's image output model forthcoming.


### PR DESCRIPTION
## Summary

Phase 1 of an owner-approved 3-phase deprecation of `experiments/arena` (**notice only** — nothing is archived or removed in this PR).

Adds a clear, factual deprecation notice stating that the arena experiment:
- relies on unmaintained dependencies and has a broken core feature (its default image-battle pool depends on Imagen models that were [shut down across Vertex AI on 2026-08-17](https://firebase.google.com/docs/ai-logic/imagen-models-migration?api=dev), so every default battle now fails);
- is not actively maintained (recent commits are almost entirely automated dependency bumps) and is not actively used;
- will be **moved to an archived state on or after 2026-09-13**;
- will be **considered for full removal approximately 2 months after archiving (around 2026-11-13)**.

## Changes
- `experiments/arena/README.md` — prominent deprecation notice at the top.
- `docs-site/src/content/docs/experiments/arena/index.md` — same notice as a Starlight `:::caution` aside at the top of the page.
- `docs-site/src/content/docs/experiments/overview.md` — deprecation marker on the Arena list entry.

## Scope / non-goals
- **No code, files, CI, or dependency-bot scope changed.** This is a documentation notice only.
- Archiving and eventual removal are separate, already-scheduled follow-up tasks.

## Verification
- `docs-site`: `npm ci && npm run build` completes successfully (55 pages built); notice confirmed present in generated HTML.