### PR TITLE
fix(adk-sample): rewire imagen->nanobanana and correct README

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk/.gitignore
+++ b/experiments/mcp-genmedia/sample-agents/adk/.gitignore
@@ -8,3 +8,6 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Keep the example env committed (repo-root .gitignore excludes .env*)
+!genmedia_agent/.env.example

--- a/experiments/mcp-genmedia/sample-agents/adk/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk/README.md
@@ -1,51 +1,80 @@
 # ADK sample
 
-This directory contains a Google Cloud Vertex AI Agent Development Kit sample agent that uses the MCP genmedia tools.
+This directory contains a Google Cloud Vertex AI Agent Development Kit (ADK) sample
+agent that uses the MCP genmedia tools. It is a single `LlmAgent` that wires four
+genmedia MCP servers and lets the model pick and sequence the tools it needs.
 
 ## Backend
 
 This sample is pinned to the **Vertex AI / Google Cloud backend**. The dependency is
-declared as `google-adk[gcp]` in `pyproject.toml`, which pulls in the Vertex/GCP client
-stack (`google-cloud-aiplatform[agent-engines]`, currently `1.165.1` — capped `<2` by
-`google-adk` 2.x). The sample is set up this way on purpose so it stays consistent with
-the rest of the genmedia MCP servers, which all assume a Google Cloud configuration. The
-Vertex backend is selected at runtime by setting `GOOGLE_GENAI_USE_VERTEXAI="True"` (see
-[Setup](#setup) below); no other backend is configured.
+declared as `google-adk[gcp,mcp]` in `pyproject.toml`, which pulls in the Vertex/GCP
+client stack. The sample is set up this way on purpose so it stays consistent with the
+rest of the genmedia MCP servers, which all assume a Google Cloud configuration. The
+Vertex backend is selected at runtime by setting `GOOGLE_GENAI_USE_VERTEXAI="True"`
+(see [Setup](#setup) below); no other backend is configured.
+
+## What this agent wires
+
+The agent (`genmedia_agent/agent.py`) is one `LlmAgent` with four **stdio** MCP
+toolsets — all invoked as binaries on your `PATH`, no separate server processes to
+start:
+
+| Toolset | Binary (`command`) | What it does |
+|---|---|---|
+| `nanobanana` | `mcp-nanobanana-go` | image generation (`nanobanana_image_generation`) |
+| `chirp3` | `mcp-chirp3-go` | text-to-speech (Chirp 3) |
+| `veo` | `mcp-veo-go` | text/image-to-video (Veo) |
+| `avtool` | `mcp-avtool-go` | audio/video compositing (needs `ffmpeg`/`ffprobe`) |
 
 ## Prerequisites
 
-Install the MCP Servers for Genmedia tools. This example uses the Go versions and assumes you've installed them locally.
+1. **Install the MCP genmedia server suite (>= v3.18.1) on your `PATH`.** Use the
+   suite's `install.sh` (from `experiments/mcp-genmedia/mcp-genmedia-go/`), which
+   installs the Go binaries (`mcp-nanobanana-go`, `mcp-chirp3-go`, `mcp-veo-go`,
+   `mcp-avtool-go`, ...) locally. Confirm they are on your path:
+
+   ```bash
+   which mcp-nanobanana-go mcp-chirp3-go mcp-veo-go mcp-avtool-go
+   ```
+
+2. **Install `ffmpeg` / `ffprobe`** (required by `avtool` for compositing):
+
+   ```bash
+   which ffmpeg ffprobe
+   ```
+
+3. **`uv`** for dependency management and running the ADK web UI.
 
 ## Setup
 
-Add an .env file to the `genmedia_agent` agent directory:
+Add a `.env` file to the `genmedia_agent/` directory (see `genmedia_agent/.env.example`).
+The agent model (`gemini-3.8-flash`) runs in the **`global`** region:
 
 ```bash
 GOOGLE_CLOUD_PROJECT="your-project-id"
-GOOGLE_CLOUD_LOCATION="your-location" #e.g. us-central1
+GOOGLE_CLOUD_LOCATION="global"
 GOOGLE_GENAI_USE_VERTEXAI="True"
+GENMEDIA_BUCKET="your-gcs-bucket-name"
 ```
 
-## Start the Imagen MCP Server
-
-The agent example contains two MCP servers using STDIO (Veo, Chirp 3) and one using the SSE protocol (Imagen).
-
-Start the Imagen MCP Server in a separate terminal:
-
-```bash
-export PROJECT_ID=$(gcloud config get project)
-mcp-imagen-go --transport sse
-```
-
+`GENMEDIA_BUCKET` is the GCS bucket the media servers (veo, nanobanana) write their
+output to. Veo always writes to GCS; nanobanana can write locally or to GCS. The media
+servers take their own region/bucket configuration via environment, independent of the
+agent's `global` model region.
 
 ## Run the ADK Developer UI
 
-In this dir, start the adk web debug UX:
+In this dir, start the `adk web` debug UX:
 
 ```bash
 uv sync
 source .venv/bin/activate
 adk web
 ```
+
+Then open the web UI and try a prompt such as *"Generate an image of a red bicycle
+leaning against a blue wall."* — the agent will call `nanobanana_image_generation` and
+report the output. Verify generated media by checking the output file / GCS destination
+(do not rely on reading a returned resource link).
 
 ![adk web screenshot](./assets/adk-genmedia-mcp.png)

--- a/experiments/mcp-genmedia/sample-agents/adk/genmedia_agent/.env.example
+++ b/experiments/mcp-genmedia/sample-agents/adk/genmedia_agent/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to `.env` in the genmedia_agent/ directory and fill in your values.
+
+# Your Google Cloud project id.
+GOOGLE_CLOUD_PROJECT="your-project-id"
+
+# The agent model (gemini-3.8-flash) runs in the GLOBAL region.
+GOOGLE_CLOUD_LOCATION="global"
+
+# Use the Vertex AI / Google Cloud backend.
+GOOGLE_GENAI_USE_VERTEXAI="True"
+
+# GCS bucket the media MCP servers (veo, nanobanana) write output to.
+# Veo always writes to GCS; nanobanana can write locally or to GCS.
+GENMEDIA_BUCKET="your-gcs-bucket-name"

--- a/experiments/mcp-genmedia/sample-agents/adk/genmedia_agent/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk/genmedia_agent/agent.py
@@ -15,7 +15,6 @@
 
 import os
 
-# as of google-adk==1.3.0, StdioConnectionParams
 from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
 from google.adk.tools.mcp_tool.mcp_toolset import (
@@ -27,6 +26,10 @@ from google.adk.tools.mcp_tool.mcp_toolset import (
 load_dotenv()
 
 project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+# Model for the agent. gemini-3.8-flash runs in the GLOBAL region, so set
+# GOOGLE_CLOUD_LOCATION="global" in your .env (see README).
+MODEL = "gemini-3.8-flash"
 
 # MCP Client (STDIO)
 # assumes you've installed the MCP server on your path
@@ -50,23 +53,16 @@ chirp3 = MCPToolset(
     ),
 )
 
-imagen = MCPToolset(
+nanobanana = MCPToolset(
     connection_params=StdioConnectionParams(
         server_params=StdioServerParameters(
-            command="mcp-imagen-go",
+            command="mcp-nanobanana-go",
             env=dict(os.environ, PROJECT_ID=project_id),
         ),
         timeout=60,
     ),
+    tool_filter=["nanobanana_image_generation"],
 )
-
-# MCP Client (SSE)
-# assumes you've started the MCP server separately
-# e.g. mcp-imagen-go --transport sse
-# from google.adk.tools.mcp_tool.mcp_toolset import SseServerParams
-# remote_imagen, _ = MCPToolset(
-#     connection_params=SseServerParams(url="http://localhost:8080/sse"),
-# )
 
 avtool = MCPToolset(
     connection_params=StdioConnectionParams(
@@ -80,13 +76,13 @@ avtool = MCPToolset(
 
 
 root_agent = LlmAgent(
-    model='gemini-2.0-flash',
+    model=MODEL,
     name='genmedia_agent',
         instruction="""You're a creative assistant that can help users with creating audio, images, and video via your generative media tools. You also have the ability to composit these using your available tools.
         Feel free to be helpful in your suggestions, based on the information you know or can retrieve from your tools.
         If you're asked to translate into other languages, please do.
         """,
     tools=[
-       imagen, chirp3, veo, avtool,
+       nanobanana, chirp3, veo, avtool,
     ],
 )


### PR DESCRIPTION
The adk/ genmedia sample wired a dead imagen MCPToolset (mcp-imagen-go) and a dead SSE comment block, ran on the stale gemini-2.0-flash model, and its README described an imagen-over-SSE setup that never matched agent.py.

- agent.py: drop the dead imagen toolset and the dead SSE comment block; add a nanobanana toolset (mcp-nanobanana-go, tool_filter [nanobanana_image_generation]); keep it one LlmAgent (Tier-0 baseline); update tools to nanobanana, chirp3, veo, avtool; introduce a module-level MODEL constant (gemini-3.8-flash, GLOBAL region) used via model=MODEL; remove the stale '# as of google-adk==1.3.0' comment (installed ADK 2.8.0).
- README.md: remove the imagen-over-SSE section and the 'two STDIO + one SSE' description; document the real setup (install MCP genmedia suite >= v3.18.1 on PATH, env vars incl. GOOGLE_CLOUD_LOCATION=global and GENMEDIA_BUCKET, uv sync + adk web) and the correct wired servers (nanobanana, chirp3, veo, avtool, all stdio).
- add genmedia_agent/.env.example (with a scoped .gitignore negation so it is committed despite the repo-root .env* ignore).


## Checklist

- [x] **Contribution Guidelines:** I have read the [Contribution Guidelines](../CONTRIBUTING).
- [x] **CLA:** I have signed the [CLA](https://cla.developers.google.com).
- [x] **Authorship:** I am listed as the author (if applicable).
- [ ] **Conventional Commits:** My PR title and commit messages follow the [Conventional Commits](https://www.conventialcommits.org) spec.
- [ ] **Code Format:** I have run `nox -s format` to format the code.
- [ ] **Spelling:** I have fixed any spelling errors, and added false positives to .github/actions/spelling/allow.txt if necessary.
- [x] **Sync:** My Fork is synced with the upstream.
- [ ] **Documentation:** I have updated relevant documentation (if applicable) in the [docs folder](../docs).
- [ ] **Template:** I have followed the `aaie_notebook_template.ipynb` if submitting a new jupyter notebook.
- [x] **Experiments:** My code is in the [experiments folder](../experiments) and is tested and working.
