### PR TITLE
feat(adk-series): Director/Videographer veo crawl agent (PR-2)

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
@@ -35,7 +35,7 @@ or demo that does the same job on another surface.
 |---|------|--------------|--------|
 | 0 | **Meet ADK** — [the refreshed genmedia sample](../adk/) | an ADK agent is an `LlmAgent` + `MCPToolset`s; the LLM drives across many tools | baseline |
 | 1 | **Your first genmedia agent** — [Photoshoot](./photoshoot/) | one `LlmAgent` + one `MCPToolset` (`tool_filter`); output modes + verify-by-existence | **ready** |
-| 2 | **Now with video** — Director / Videographer | one tool again, but the Veo gotchas (verify by *listing*; explicit Veo-3 model) | coming next |
+| 2 | **Now with video** — [Director / Videographer](./director-videographer/) | one tool again, but the Veo gotchas (verify by *listing*; explicit Veo-3 model) | **ready** |
 | 3 | **Two servers, one agent** — Music Producer | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | coming next |
 | 4 | **Your first pipeline** — Scriptwriter / Storyboarder | `SequentialAgent` + `output_key` state passing between agents | coming next |
 | 5 | **A real multi-agent app** — Ad creative-director's assistant | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | coming next |

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/.env.example
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/.env.example
@@ -1,0 +1,18 @@
+# Copy this file to .env and fill in your values, then `uv sync` and `adk web`.
+
+# Your Google Cloud project id.
+GOOGLE_CLOUD_PROJECT="your-project-id"
+
+# gemini-3.8-flash (the default MODEL in director_videographer/agent.py) is served
+# in the GLOBAL region, so keep this set to "global".
+GOOGLE_CLOUD_LOCATION="global"
+
+# Use the Vertex AI backend (not the public Gemini API).
+GOOGLE_GENAI_USE_VERTEXAI="True"
+
+# Bucket name (NO gs:// prefix). Veo ALWAYS writes the video to GCS, so a
+# destination is effectively required: either the agent passes an explicit
+# `bucket`, or the server falls back to this env var, writing under
+# <bucket>/veo_outputs/. Set this so a "just make me a video" prompt has
+# somewhere to land.
+GENMEDIA_BUCKET="your-bucket-name"

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/.gitignore
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/.gitignore
@@ -1,0 +1,14 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv
+
+# Local secrets and generated media
+.env
+output/

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/README.md
@@ -1,0 +1,171 @@
+# Director / Videographer — now with video
+
+## What you'll build
+
+A director agent. You give it a scene — *"a red kite tangling free of a
+power line at golden hour"* — and it composes a cinematic prompt, generates a
+short video clip with [Veo](../../../mcp-genmedia-go/mcp-veo-go/), and tells you
+exactly where the file landed so you can confirm it's really there. Same shape as
+[Photoshoot](../photoshoot/) — one ADK agent, one tool class — but this time the
+output is video, and the "verify by existence" habit becomes **verify by
+*listing*.**
+
+## What you'll learn
+
+**The new thing: the same `LlmAgent` + one `MCPToolset` shape carries a much
+sharper gotcha, and Gemini's reasoning is what defuses it.** Video generation has
+a model-gating footgun — the *default* model can't do audio, so a naive call
+fails — and Gemini has to reason about the shot (does it need sound? is it
+vertical? how long?) to pick the correct Veo-3 model. You'll also learn why a tool
+returning a link is *not* proof of a result: you verify by listing the
+destination.
+
+## Prerequisites
+
+- **Python ≥ 3.13** and [`uv`](https://docs.astral.sh/uv/).
+- **The genmedia MCP suite ≥ v3.18.1, installed on your `PATH`.** This agent
+  calls `mcp-veo-go`. Install it from the suite's
+  [`install.sh`](../../../mcp-genmedia-go/install.sh); confirm it's reachable:
+  ```bash
+  which mcp-veo-go
+  ```
+- **A Google Cloud project with Vertex AI enabled**, and application-default
+  credentials (`gcloud auth application-default login`).
+- **A GCS bucket.** Veo always writes the video to Cloud Storage, so you need a
+  bucket — set `GENMEDIA_BUCKET` (below) or name one in your prompt.
+- **Environment variables** — copy `.env.example` to `.env` and fill in:
+  - `GOOGLE_CLOUD_PROJECT` — your project id.
+  - `GOOGLE_CLOUD_LOCATION="global"` — `gemini-3.8-flash` is served globally.
+  - `GOOGLE_GENAI_USE_VERTEXAI="True"` — use the Vertex backend.
+  - `GENMEDIA_BUCKET` — a bucket name (no `gs://`) for the GCS destination.
+- **ffmpeg:** not needed for this agent. (The later audio/AV agents need it.)
+
+## Run it
+
+```bash
+cp .env.example .env      # then edit .env with your values
+uv sync                   # create the venv and install google-adk[gcp,mcp]
+source .venv/bin/activate
+adk web                   # open the printed URL, pick "director_videographer"
+```
+
+Try this sample prompt:
+
+> Direct a 6-second cinematic clip: a lone red umbrella tumbling down a
+> rain-slicked Tokyo street at night, neon reflections, with ambient rain sound.
+> Save it to my GCS bucket.
+
+The agent will compose a shot, pick an explicit **Veo-3** model (so the ambient
+sound works), generate the clip to GCS, and report the `gs://` URI. Then verify it
+yourself:
+
+```bash
+gcloud storage ls gs://<your-bucket>/veo_outputs/
+```
+
+To try image-to-video, give it a starting frame that already lives in GCS:
+
+> Animate gs://my-bucket/stills/umbrella.png — slow push-in, gentle rain. 9:16.
+
+(9:16 forces the agent to a Veo-3.1 model; see the gotcha below.)
+
+## How it works
+
+The entire agent is `director_videographer/agent.py`. Annotated:
+
+```python
+MODEL = "gemini-3.8-flash"            # one constant; change it to a model you have
+
+server_env = dict(os.environ)         # forward the environment to the server...
+if project_id:
+    server_env["PROJECT_ID"] = project_id   # ...adding PROJECT_ID only when set
+
+veo = MCPToolset(                     # one MCP server, wired over stdio
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-veo-go",                     # the PATH-installed binary
+            env=server_env,
+        ),
+        timeout=300,                                  # video gen + polling is slow
+    ),
+    tool_filter=["veo_t2v", "veo_i2v"],               # expose exactly two tools
+)
+
+root_agent = LlmAgent(                # the agent ADK's `adk web` discovers
+    model=MODEL,
+    name="director_videographer",
+    instruction=INSTRUCTION,          # the shot-direction + model-gating + verify recipe
+    tools=[veo],
+)
+```
+
+It's the identical shape you learned in Photoshoot — `LlmAgent` + one
+`MCPToolset`, narrowed with `tool_filter`. All the new weight is in the
+`INSTRUCTION`: it tells Gemini to (1) direct a real cinematic prompt, (2) **pick
+the correct Veo-3 model** for the shot's audio/aspect/duration needs, (3) choose a
+GCS destination, and (4) **verify by listing** — never by reading the returned
+link.
+
+## The gotcha this teaches
+
+Video is where two footguns become mandatory. Both are baked into the
+instruction, and every rule below is **source-verified against the live
+`mcp-veo-go` Go server** (paths relative to
+[`../../../mcp-genmedia-go/mcp-veo-go/`](../../../mcp-genmedia-go/mcp-veo-go/)):
+
+**1. Pick an explicit Veo-3 model, or the "minimal" call fails.**
+`generate_audio` defaults to **true** (`utils.go:127`), but if you leave `model`
+unset the handler falls back to **`veo-2.0-generate-001`** (`utils.go:44-47`) —
+and that Veo-2 model has `SupportsGenerateAudio: false` (`models.go:257-264`), so
+the server returns *"generate_audio is set to true, but is not supported by
+model"* (`utils.go:132-134`). A bare "make me a video" therefore errors out. The
+agent always passes an explicit Veo-3 model (default
+`veo-3.1-fast-generate-001`, which matches the tool's own schema default at
+`veo.go:115-118`). This is the reasoning showcase: Gemini reads the shot and
+chooses a model that clears the gate.
+
+**2. Model-gated aspect ratio & duration.** The server validates these against the
+chosen model and errors on a bad combo:
+- Aspect ratio (`utils.go:106-124`): Veo-3.1 supports `16:9` **and** `9:16`
+  (`models.go:312-330`); Veo-3.0 supports **`16:9` only** (`models.go:290-308`).
+  So a vertical `9:16` clip *requires* a Veo-3.1 model — the agent knows this.
+- Duration (`utils.go:81-104`): Veo-3 models support **4, 6, 8** seconds
+  (`models.go:290-363`); other values error.
+- Count is `num_videos` (`veo.go:119-122`), **not** `sample_count`.
+
+**3. GCS is required — and it's `bucket`, not `gcs_bucket_uri`.** Veo writes to
+Cloud Storage; the destination param is spelled **`bucket`** (`veo.go:106-108`).
+With no `bucket`, the server falls back to `GENMEDIA_BUCKET`, writing under
+`gs://<bucket>/veo_outputs/` (`utils.go:56-62`). With neither, it has nowhere to
+write. `output_directory` (`veo.go:109-111`) is only an *additional* local copy.
+
+**4. Verify by LISTING — never trust the `resource_link`.** Veo appends a
+`resource_link` per video to its result (`video_logic.go:475-506`) — but a
+returned link is **not** proof the object persisted, and many clients can't render
+it. What is trustworthy is the text result, *"Videos saved to GCS: gs://..."*
+(`video_logic.go:426-427`), emitted only after the API wrote the objects. The
+agent relays that `gs://` URI and tells you to confirm with
+`gcloud storage ls`. This is exactly the case the Photoshoot README warned about:
+persisted-path report is fine, but the real check is **listing the destination.**
+
+> **Naming note.** Veo diverges from the image servers: it uses `bucket` (not
+> `gcs_bucket_uri`) for GCS and `num_videos` (not `num_images`/`sample_count`) for
+> the count. When you build a multi-server agent later, [`../NAMING.md`](../NAMING.md)
+> is the full crosswalk — this agent's spellings are the veo row there.
+
+## See also
+
+- **The `genmedia-video-editor` skill** —
+  [`experiments/mcp-genmedia/skills/genmedia-video-editor/SKILL.md`](../../../skills/genmedia-video-editor/SKILL.md).
+  Same Veo craft (the five-part cinematic prompt formula, soundstage direction,
+  first/last-frame and reference-image workflows, plus FFmpeg compositing over
+  `mcp-avtool-go`), expressed as an agent **skill** instead of an ADK agent. Read
+  it for deeper prompting and editing technique; this Director agent is the
+  ADK-runnable surface of the same idea.
+
+## Next in the series
+
+Head back to the [series overview](../README.md), or jump to **Music Producer**
+(coming next) — the first agent that wires **more than one** MCP server (lyria +
+TTS + avtool), where you meet `tool_name_prefix` and the full naming crosswalk you
+just got a taste of.

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/README.md
@@ -110,13 +110,17 @@ link.
 
 Video is where two footguns become mandatory. Both are baked into the
 instruction, and every rule below is **source-verified against the live
-`mcp-veo-go` Go server** (paths relative to
-[`../../../mcp-genmedia-go/mcp-veo-go/`](../../../mcp-genmedia-go/mcp-veo-go/)):
+genmedia Go sources** — the veo server files (`veo.go`, `handlers.go`, `utils.go`,
+`video_logic.go`) live in
+[`../../../mcp-genmedia-go/mcp-veo-go/`](../../../mcp-genmedia-go/mcp-veo-go/), and
+the shared model registry (`models.go`) lives in
+[`../../../mcp-genmedia-go/mcp-common/`](../../../mcp-genmedia-go/mcp-common/):
 
 **1. Pick an explicit Veo-3 model, or the "minimal" call fails.**
 `generate_audio` defaults to **true** (`utils.go:127`), but if you leave `model`
 unset the handler falls back to **`veo-2.0-generate-001`** (`utils.go:44-47`) —
-and that Veo-2 model has `SupportsGenerateAudio: false` (`models.go:257-264`), so
+and that Veo-2 model has `SupportsGenerateAudio: false`
+(`mcp-common/models.go:257-264`), so
 the server returns *"generate_audio is set to true, but is not supported by
 model"* (`utils.go:132-134`). A bare "make me a video" therefore errors out. The
 agent always passes an explicit Veo-3 model (default
@@ -127,10 +131,11 @@ chooses a model that clears the gate.
 **2. Model-gated aspect ratio & duration.** The server validates these against the
 chosen model and errors on a bad combo:
 - Aspect ratio (`utils.go:106-124`): Veo-3.1 supports `16:9` **and** `9:16`
-  (`models.go:312-330`); Veo-3.0 supports **`16:9` only** (`models.go:290-308`).
-  So a vertical `9:16` clip *requires* a Veo-3.1 model — the agent knows this.
+  (`mcp-common/models.go:312-330`); Veo-3.0 supports **`16:9` only**
+  (`mcp-common/models.go:290-308`). So a vertical `9:16` clip *requires* a Veo-3.1
+  model — the agent knows this.
 - Duration (`utils.go:81-104`): Veo-3 models support **4, 6, 8** seconds
-  (`models.go:290-363`); other values error.
+  (`mcp-common/models.go:290-363`); other values error.
 - Count is `num_videos` (`veo.go:119-122`), **not** `sample_count`.
 
 **3. GCS is required — and it's `bucket`, not `gcs_bucket_uri`.** Veo writes to

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/director_videographer/__init__.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/director_videographer/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/director_videographer/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/director_videographer/agent.py
@@ -1,0 +1,171 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Director / Videographer — your first video agent (crawl tier).
+
+One LlmAgent, one MCPToolset wiring the veo video server over stdio (the two
+generation tools veo_t2v and veo_i2v). Like Photoshoot it is a single-tool-class
+agent, but video is where two footguns become mandatory to teach:
+
+  1. Veo returns a `resource_link` that is NOT proof the video persisted — you
+     verify by *listing the destination*, never by reading the link.
+  2. The tool's model fallback is a Veo-2 model that REJECTS the default
+     generate_audio=true, so a "minimal" call fails. Gemini must reason about the
+     shot (audio? vertical? duration?) and pick the correct, model-gated Veo-3
+     model. That reasoning is the value of this agent.
+
+Every parameter name and model rule below is source-verified against the live Go
+server (mcp-veo-go); see README.md "The gotcha this teaches" for the citations.
+"""
+
+import os
+
+# Imports mirror the Photoshoot agent so the series stays on one ADK 2.8.0
+# surface. `tool_filter` is a supported MCPToolset kwarg in 2.8.0.
+from dotenv import load_dotenv
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import (
+    MCPToolset,
+    StdioConnectionParams,
+    StdioServerParameters,
+)
+
+load_dotenv()
+
+# Set this to a Gemini model you have access to on your Vertex backend.
+# gemini-3.8-flash is served in the GLOBAL region, so keep
+# GOOGLE_CLOUD_LOCATION="global" in your .env (see .env.example).
+MODEL = "gemini-3.8-flash"
+
+project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+# Forward the whole environment to the stdio server, and add PROJECT_ID only when
+# it is set. Env values must be strings — passing PROJECT_ID=None (which happens
+# when GOOGLE_CLOUD_PROJECT is unset) raises TypeError when the subprocess
+# actually launches, so we guard rather than pass None. (GOOGLE_CLOUD_PROJECT
+# itself still passes through via os.environ when present.)
+server_env = dict(os.environ)
+if project_id:
+    server_env["PROJECT_ID"] = project_id
+
+# MCP Client (STDIO): assumes the genmedia suite (>= v3.18.1) is installed on
+# your PATH via the suite's install.sh, so `mcp-veo-go` is runnable. The veo
+# server exposes several tools (t2v, i2v, first/last frame, reference, extend);
+# `tool_filter` keeps this crawl agent's surface to exactly the two generation
+# tools it teaches. Video generation + GCS polling is slow, so the timeout is
+# generous (the server itself polls the operation for up to ~5 min).
+veo = MCPToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-veo-go",
+            env=server_env,
+        ),
+        timeout=300,
+    ),
+    tool_filter=["veo_t2v", "veo_i2v"],
+)
+
+
+INSTRUCTION = """\
+You are a film director and videographer. A user gives you a scene idea — a line
+or two, sometimes a starting image — and you turn it into a short cinematic video
+clip, then confirm the video really persisted by pointing them at the destination
+to list.
+
+# 1. Direct the shot (Gemini's reasoning is the value here)
+Never pass the user's raw words straight through. Compose a cinematic prompt using
+the five-part shape: cinematography (shot size + camera move, e.g. "slow dolly-in,
+low-angle wide"), subject, action, context/setting, and style (film stock, era,
+mood). For Veo-3 models you can direct sound in the prompt: put spoken lines in
+quotes and bracket ambient/SFX cues, e.g. a fox says "good evening" [soft wind,
+distant owl]. Briefly tell the user the choices you made, then generate.
+
+# 2. Choose the tool
+- `veo_t2v` (text-to-video): the default. REQUIRED param `prompt`.
+- `veo_i2v` (image-to-video): use when the user gives a STARTING IMAGE. REQUIRED
+  param `image_uri` — it must be a `gs://...` GCS URI (a local path will be
+  rejected), with an optional `prompt` to guide motion. Optional `mime_type`
+  (`image/jpeg` or `image/png`; inferred from the extension otherwise).
+
+# 3. Pick the model DELIBERATELY — this is the footgun this agent exists to teach
+There is NO safe "leave model unset" option. If you omit `model`, the server
+falls back to a Veo-2 model (`veo-2.0-generate-001`) that does NOT support audio —
+and audio generation is ON by default — so the call ERRORS out. Always pass an
+explicit Veo-3 model, chosen from the shot's requirements:
+
+- Default choice: `model="veo-3.1-fast-generate-001"` — fast, supports audio, and
+  supports both `16:9` and `9:16`. Use this unless the user needs otherwise.
+- Higher fidelity: `veo-3.1-generate-001` (same aspect-ratio support, slower).
+- If the user wants a **9:16 vertical** clip, you MUST use a **Veo-3.1** model
+  (`veo-3.1-fast-generate-001` / `veo-3.1-generate-001`). The Veo-3.0 models
+  (`veo-3.0-generate-001`, `veo-3.0-fast-generate-001`) support **`16:9` only** and
+  will reject `9:16`.
+
+Model-gated parameters — honor these so you never emit an invalid call (the tool
+schema does NOT show you these limits, so they live here):
+- `generate_audio` (boolean, default **true**): audio is supported ONLY by Veo-3
+  models. This is exactly why an explicit Veo-3 `model` is mandatory. Set it to
+  false only if the user wants a silent clip.
+- `aspect_ratio` (string): Veo-3.1 supports `16:9` and `9:16`; Veo-3.0 supports
+  `16:9` only. If unset, the server picks the model's first supported ratio.
+- `duration` (number, seconds): Veo-3 models support **4, 6, or 8** seconds
+  (default 8). Requesting an unsupported duration ERRORS; keep to {4, 6, 8}.
+- `num_videos` (number, default 1): the count parameter is spelled **`num_videos`**
+  for veo — NOT `sample_count`. Veo-3.1 allows up to 4; Veo-3.0 up to 2.
+- `seed` (number, optional): non-negative int for best-effort reproducibility.
+
+# 4. Choose the output destination (veo ALWAYS writes to GCS)
+Unlike the image agent, veo does not keep bytes locally by default — it writes the
+video to Cloud Storage, so a GCS destination is effectively REQUIRED:
+- `bucket` (string): the GCS destination — veo spells this **`bucket`**, NOT
+  `gcs_bucket_uri`. Pass it ONLY when the user names a real bucket, as
+  `gs://<their-bucket>/<prefix>/` or `<their-bucket>/<prefix>`. Never invent or use
+  a placeholder bucket — a made-up URI will 403.
+- No bucket named: pass NEITHER `bucket` NOR `output_directory` for GCS, and the
+  server uses the configured `GENMEDIA_BUCKET` fallback, writing under
+  `gs://<GENMEDIA_BUCKET>/veo_outputs/`. Prefer this over guessing a URI.
+- `output_directory` (string, optional): an ADDITIONAL local directory to download
+  the finished video into (e.g. `./output`). This does not replace GCS — it is a
+  copy alongside it.
+- The trap: if you pass no `bucket` AND no `GENMEDIA_BUCKET` is configured, veo has
+  nowhere to write and the generation fails. If a run reports no destination, tell
+  the user to set `GENMEDIA_BUCKET` or name a bucket.
+
+# 5. Verify by LISTING the destination — never trust the resource_link
+Veo's tool result includes a `resource_link` for each video, but a returned link
+is NOT proof the file exists — many clients cannot even render it, and it must
+never be treated as verification. What IS trustworthy is the tool's TEXT result,
+which reports the persisted GCS path(s): "Videos saved to GCS: gs://...". So:
+- Relay the exact `gs://...` URI from that text (and the local path, if you passed
+  `output_directory`).
+- Tell the user to verify by LISTING the destination, e.g.
+  `gcloud storage ls gs://<bucket>/<prefix>/` for GCS, or `ls <dir>` for a local
+  download. Listing the destination is the real check.
+- If the tool result does not name a saved `gs://` path, treat the generation as
+  NOT verified and say so plainly — do not fabricate a URI and do not claim
+  success from a bare resource_link.
+"""
+
+
+root_agent = LlmAgent(
+    model=MODEL,
+    name="director_videographer",
+    description=(
+        "A film-director agent that turns a scene idea (or a starting image) into "
+        "a cinematic Veo video, reasoning about the shot to pick a correct Veo-3 "
+        "model, then verifies the result by pointing at the GCS destination to list."
+    ),
+    instruction=INSTRUCTION,
+    tools=[veo],
+)

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "director-videographer"
+version = "0.1.0"
+description = "ADK crawl-tier agent: turn a scene idea into a cinematic video via veo, with the Veo-3 model-gating and verify-by-listing gotchas baked in"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "python-dotenv>=1.0",
+    "google-adk[gcp,mcp]>=1.28.1",
+]

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/photoshoot/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/photoshoot/README.md
@@ -139,7 +139,8 @@ learn it here where there's only one tool to reason about.
 
 ## Next in the series
 
-Head back to the [series overview](../README.md), or jump to **Director /
-Videographer** (coming next) — one agent, one tool, but this time video, where
-the "verify by existence" habit you just learned becomes mandatory (Veo always
-returns a resource link you must verify by *listing* the destination).
+Head back to the [series overview](../README.md), or jump to **[Director /
+Videographer](../director-videographer/)** — one agent, one tool, but this time
+video, where the "verify by existence" habit you just learned becomes mandatory
+(Veo always returns a resource link you must verify by *listing* the
+destination).


### PR DESCRIPTION
## What & why
PR-2 of the ADK genmedia example series: the **Director/Videographer** crawl agent — a runnable ADK video-gen example that teaches the Veo footguns. Copies the reusable contract established by PR-1 (#1812).

## Scope (new dir only)
`experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/`, mirroring `photoshoot/` exactly (pyproject.toml, .env.example, .gitignore, README.md [8-section template], director_videographer/{__init__.py,agent.py}). Through-line README + photoshoot 'next' flipped to the now-live Director step (no dead links).

## Agent
One `LlmAgent` (`root_agent`) + one veo `MCPToolset` (`tool_filter=["veo_t2v","veo_i2v"]`), `MODEL=gemini-3.8-flash` (global), env guarded photoshoot-style.

## Veo gotchas baked in (source-verified against mcp-common/models.go + mcp-veo-go)
- **Explicit Veo-3 model required.** Handler fallback when model unset is veo-2.0 (`SupportsGenerateAudio:false`) which errors on the default `generate_audio=true`. Agent always passes an explicit Veo-3 model (default `veo-3.1-fast-generate-001`).
- **Model-gated aspect ratio:** Veo-3.0 = 16:9 only; Veo-3.1 = 16:9 + 9:16.
- **Count param is `num_videos`** (not sample_count); **GCS dest is `bucket`** (not gcs_bucket_uri); GENMEDIA_BUCKET fallback -> `gs://<bucket>/veo_outputs/`.
- **Verify by destination-listing (`gcloud storage ls`), never by reading `resource_link`.**

## Validation
Credentialed `adk web`/Runner run is the acceptance gate (executed by a credentialed runner via a deterministic recipe): a veo call with an explicit Veo-3 model succeeding, video verified by destination-listing (never resource_link), plus a negative check documenting the default-model failure. Offline gates green: py_compile, import-mirror vs photoshoot, dead-link check, NAMING.md consistency.