### PR TITLE
feat(adk-series): Music Producer multi-server crawl agent (PR-3)

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
@@ -36,7 +36,7 @@ or demo that does the same job on another surface.
 | 0 | **Meet ADK** — [the refreshed genmedia sample](../adk/) | an ADK agent is an `LlmAgent` + `MCPToolset`s; the LLM drives across many tools | baseline |
 | 1 | **Your first genmedia agent** — [Photoshoot](./photoshoot/) | one `LlmAgent` + one `MCPToolset` (`tool_filter`); output modes + verify-by-existence | **ready** |
 | 2 | **Now with video** — [Director / Videographer](./director-videographer/) | one tool again, but the Veo gotchas (verify by *listing*; explicit Veo-3 model) | **ready** |
-| 3 | **Two servers, one agent** — Music Producer | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | coming next |
+| 3 | **Two servers, one agent** — [Music Producer](./music-producer/) | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | **ready** |
 | 4 | **Your first pipeline** — Scriptwriter / Storyboarder | `SequentialAgent` + `output_key` state passing between agents | coming next |
 | 5 | **A real multi-agent app** — Ad creative-director's assistant | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | coming next |
 

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
@@ -36,7 +36,7 @@ or demo that does the same job on another surface.
 | 0 | **Meet ADK** — [the refreshed genmedia sample](../adk/) | an ADK agent is an `LlmAgent` + `MCPToolset`s; the LLM drives across many tools | baseline |
 | 1 | **Your first genmedia agent** — [Photoshoot](./photoshoot/) | one `LlmAgent` + one `MCPToolset` (`tool_filter`); output modes + verify-by-existence | **ready** |
 | 2 | **Now with video** — [Director / Videographer](./director-videographer/) | one tool again, but the Veo gotchas (verify by *listing*; explicit Veo-3 model) | **ready** |
-| 3 | **Two servers, one agent** — [Music Producer](./music-producer/) | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | **ready** |
+| 3 | **Three servers, one agent** — [Music Producer](./music-producer/) | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | **ready** |
 | 4 | **Your first pipeline** — Scriptwriter / Storyboarder | `SequentialAgent` + `output_key` state passing between agents | coming next |
 | 5 | **A real multi-agent app** — Ad creative-director's assistant | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | coming next |
 

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/.env.example
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/.env.example
@@ -1,0 +1,18 @@
+# Copy this file to .env and fill in your values, then `uv sync` and `adk web`.
+
+# Your Google Cloud project id.
+GOOGLE_CLOUD_PROJECT="your-project-id"
+
+# gemini-3.8-flash (the default MODEL in music_producer/agent.py) is served in
+# the GLOBAL region. The default Lyria model (lyria-3-clip-preview) uses the
+# Vertex Interactions API, which is ALSO global-only. Keep this set to "global".
+GOOGLE_CLOUD_LOCATION="global"
+
+# Use the Vertex AI backend (not the public Gemini API).
+GOOGLE_GENAI_USE_VERTEXAI="True"
+
+# Bucket name (NO gs:// prefix). Used as the fallback GCS destination when a tool
+# is run in GCS mode without an explicit bucket param (lyria -> output_gcs_bucket,
+# avtool -> output_gcs_bucket). Optional for the all-local flow this agent
+# defaults to. Note: the gemini TTS tool has NO GCS output param (local only).
+GENMEDIA_BUCKET="your-bucket-name"

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/.gitignore
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/.gitignore
@@ -1,0 +1,14 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv
+
+# Local secrets and generated media
+.env
+output/

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
@@ -1,0 +1,187 @@
+# Music Producer — two servers, one agent
+
+> This README follows the series' eight-section template (see
+> [Photoshoot](../photoshoot/README.md)): **What you'll build · What you'll
+> learn · Prerequisites · Run it · How it works · The gotcha this teaches ·
+> See also · Next in the series.**
+
+## What you'll build
+
+A music-producer agent. You give it a mood/genre for a music bed and a short
+voiceover (VO) script — *"a warm lo-fi study beat, and a narrator says 'welcome
+back'"* — and it (1) generates a music bed with **lyria**, (2) generates the VO
+with **gemini TTS**, (3) **mixes** the two into one file with **avtool**, and
+tells you exactly where all three files are. It is the first agent in the series
+that wires **more than one MCP server**.
+
+## What you'll learn
+
+**The one new ADK concept: wiring multiple `MCPToolset`s in a single `LlmAgent`
+and giving each a distinct `tool_name_prefix`** (`lyria_`, `tts_`, `av_`) so the
+servers' tool names never collide and the model's tool choices stay legible.
+
+With more than one server comes the second lesson: **the genmedia servers spell
+"the same" parameter differently.** The model can't see those differences from
+`tools/list`, so this agent's instruction **bakes the exact names for its three
+tools** and cites the shared crosswalk, [`../NAMING.md`](../NAMING.md). Told the
+wrong parameter name, a server silently ignores the argument and your artifact
+lands nowhere you looked — so this is a real correctness issue, not style.
+
+## Prerequisites
+
+- **Python ≥ 3.13** and [`uv`](https://docs.astral.sh/uv/).
+- **The genmedia MCP suite ≥ v3.18.1, installed on your `PATH`.** This is a HARD
+  requirement here: the Lyria fixes shipped in v3.18.1 (`#1768` parse, `#1777`
+  MP3/C2PA container) are what make lyria return usable audio that **avtool can
+  mux**. On older builds this agent's mix step has nothing to work with. This
+  agent calls three binaries — `mcp-lyria-go`, `mcp-gemini-go`, `mcp-avtool-go`.
+  Install them from the suite's
+  [`install.sh`](../../../mcp-genmedia-go/install.sh); confirm they're reachable:
+  ```bash
+  which mcp-lyria-go mcp-gemini-go mcp-avtool-go
+  ```
+- **`ffmpeg` AND `ffprobe` on your `PATH`.** avtool is a wrapper over ffmpeg; it
+  shells out to both binaries, so the mix/convert step fails without them:
+  ```bash
+  which ffmpeg ffprobe
+  ```
+- **A Google Cloud project with Vertex AI enabled**, and application-default
+  credentials (`gcloud auth application-default login`).
+- **Environment variables** — copy `.env.example` to `.env` and fill in:
+  - `GOOGLE_CLOUD_PROJECT` — your project id.
+  - `GOOGLE_CLOUD_LOCATION="global"` — `gemini-3.8-flash` is served globally, and
+    the default Lyria model (Interactions API) is **global-only**, so this must
+    be `global`.
+  - `GOOGLE_GENAI_USE_VERTEXAI="True"` — use the Vertex backend.
+  - `GENMEDIA_BUCKET` — a bucket name (no `gs://`) for GCS-mode output. Optional
+    for the all-local flow this agent defaults to.
+
+## Run it
+
+```bash
+cp .env.example .env      # then edit .env with your values
+uv sync                   # create the venv and install google-adk[gcp,mcp]
+source .venv/bin/activate
+adk web                   # open the printed URL, pick the "music_producer" agent
+```
+
+Try this sample prompt:
+
+> Make a warm, mellow lo-fi hip-hop study beat with soft piano and vinyl crackle,
+> about 30 seconds, and a calm female narrator saying "Welcome back. Let's get
+> focused." Mix them into one MP3 and save everything locally.
+
+The agent will generate `./output/`-saved music and VO files, mix them into a
+single `.mp3`, and report the three concrete paths (and how to list them).
+
+## How it works
+
+The entire agent is `music_producer/agent.py`. Three `MCPToolset`s, one
+`LlmAgent`:
+
+```python
+MODEL = "gemini-3.8-flash"            # one constant; GLOBAL region
+
+lyria = MCPToolset(                   # server 1: music
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(command="mcp-lyria-go", env=server_env),
+        timeout=180,
+    ),
+    tool_filter=["lyria_generate_music"],
+    tool_name_prefix="lyria_",        # -> lyria_generate_music
+)
+
+tts = MCPToolset(                     # server 2: voiceover
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(command="mcp-gemini-go", env=server_env),
+        timeout=120,
+    ),
+    tool_filter=["gemini_audio_tts"],
+    tool_name_prefix="tts_",          # -> tts_gemini_audio_tts
+)
+
+avtool = MCPToolset(                  # server 3: mix / convert
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(command="mcp-avtool-go", env=server_env),
+        timeout=180,
+    ),
+    tool_name_prefix="av_",           # -> av_ffmpeg_layer_audio_files, ...
+)
+
+root_agent = LlmAgent(model=MODEL, name="music_producer",
+                      instruction=INSTRUCTION, tools=[lyria, tts, avtool])
+```
+
+`tool_name_prefix` is the teaching point: without it, two servers could both
+expose a tool the model refers to ambiguously; with it, every tool the model can
+call is unambiguously namespaced (`lyria_*`, `tts_*`, `av_*`). The `INSTRUCTION`
+then does the sequencing — generate music → generate VO → mix — and, crucially,
+bakes the **exact, per-tool parameter names** (below) because the model can't
+infer them from the tool schema.
+
+### Why gemini TTS (and not chirp3)
+
+The series lets a multi-server agent pick **either** `chirp_tts` (chirp3) **or**
+`gemini_audio_tts` (gemini). This agent uses **`gemini_audio_tts`** because, as
+the series' reference example for the naming crosswalk, it demonstrates the most
+divergences in one tool: the `model_name` spelling (unique to gemini TTS among
+all servers — NAMING.md §1) **and** the `text`-is-content / `prompt`-is-style
+overload (NAMING.md §5), plus a concrete, source-verified **800-character cap**
+to teach as a hard constraint. It can also emit MP3, matching Lyria's MP3 output
+for a clean same-format mix. (chirp3's own quirk — WAV-only, no GCS param — is
+still noted in NAMING.md and in the validation recipe's alternate path.)
+
+### The naming crosswalk for this agent's three tools
+
+Every name below is verified against the genmedia Go sources (file:line in
+`agent.py`); it is a concrete instance of [`../NAMING.md`](../NAMING.md):
+
+| Concept | `lyria_generate_music` | `tts_gemini_audio_tts` | `av_*` (e.g. layer/convert) |
+|---|---|---|---|
+| content | `prompt` | `text` (+ `prompt` = **style**) | — (transform-only) |
+| model id | `model_id` | `model_name` | — |
+| local dir | `local_path` | `output_directory` | `output_local_dir` |
+| GCS bucket | `output_gcs_bucket` | *(none — local only)* | `output_gcs_bucket` |
+| output name | `output_filename` | `output_filename` | `output_filename` (ext = container) |
+
+## The gotcha this teaches
+
+**Multi-server = colliding names + diverging params; `tool_name_prefix` fixes
+the first, baked instructions fix the second.** Concretely, this agent bakes:
+
+1. **Lyria dropped params + global-only.** On the default model
+   (`lyria-3-clip-preview`, Vertex Interactions API) `negative_prompt`, `seed`,
+   and `sample_count` are **silently ignored** — only `prompt` reaches the model
+   and only the first sample returns. The instruction never promises them, and
+   the model is region-**global-only** (hence `GOOGLE_CLOUD_LOCATION=global`).
+2. **The TTS `text`/`prompt` overload + 800-char cap.** `text` is the words to
+   speak; `prompt` is *style*, not content; `text` is capped at 800 chars.
+3. **avtool is transform-only.** It cannot generate — it needs an INPUT file, so
+   it must run *after* lyria and TTS have saved real files; it needs `ffmpeg` and
+   `ffprobe` on PATH; and **the output filename extension selects the container**
+   (`mix.mp3` → MP3, `mix.wav` → WAV).
+4. **Verify by existence — never trust a resource link.** A successful tool
+   return isn't proof of a file. The agent reports each concrete saved path/URI
+   and how to confirm it (`ls -l …` locally, `gcloud storage ls …` for GCS), and
+   treats an unnamed result as *not verified* rather than fabricating a path.
+
+## See also
+
+- **The `genmedia-audio-engineer` skill** —
+  [`experiments/mcp-genmedia/skills/genmedia-audio-engineer/SKILL.md`](../../../skills/genmedia-audio-engineer/SKILL.md).
+  The same music+VO+mux craft (lyria, TTS, avtool) expressed as an agent
+  **skill** rather than an ADK agent — read it for deeper audio-production
+  technique.
+- **The `genmedia-producer` skill** —
+  [`experiments/mcp-genmedia/skills/genmedia-producer/SKILL.md`](../../../skills/genmedia-producer/SKILL.md).
+  The producer/showrunner voice that sequences multiple genmedia tools into a
+  finished piece — the multi-tool orchestration this agent does in miniature.
+- **[`../NAMING.md`](../NAMING.md)** — the shared parameter crosswalk this agent
+  cites; required reading for any multi-server agent.
+
+## Next in the series
+
+Head back to the [series overview](../README.md), or jump to **Scriptwriter /
+Storyboarder** (coming next) — your first true *pipeline*, where a
+`SequentialAgent` passes state between agents with `output_key` instead of one
+agent driving every tool itself.

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
@@ -1,4 +1,4 @@
-# Music Producer — two servers, one agent
+# Music Producer — three servers, one agent
 
 > This README follows the series' eight-section template (see
 > [Photoshoot](../photoshoot/README.md)): **What you'll build · What you'll
@@ -112,7 +112,7 @@ root_agent = LlmAgent(model=MODEL, name="music_producer",
                       instruction=INSTRUCTION, tools=[lyria, tts, avtool])
 ```
 
-`tool_name_prefix` is the teaching point: without it, two servers could both
+`tool_name_prefix` is the teaching point: without it, three servers could each
 expose a tool the model refers to ambiguously; with it, every tool the model can
 call is unambiguously namespaced (`lyria_*`, `tts_*`, `av_*`). The `INSTRUCTION`
 then does the sequencing — generate music → generate VO → mix — and, crucially,

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
@@ -122,7 +122,7 @@ call is unambiguously namespaced (`music_*`, `tts_*`, `av_*`). Two details that
 make this a *correct* prefixing example, not just a working one:
 
 - **ADK inserts the separator itself** — it exposes each tool as
-  `f"{prefix}_{tool.name}"` ([`base_toolset.py:162`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/base_toolset.py)).
+  `f"{prefix}_{tool.name}"` ([`base_toolset.py:143` @ `v2.8.0`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/tools/base_toolset.py#L143)).
   So the prefix VALUES are **bare role tokens with no trailing underscore**
   (`"music"`, not `"music_"`) — otherwise you'd get a doubled `music__…`. And you
   name them by **role**, not by echoing the server (`"music"`, not `"lyria"`),

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/README.md
@@ -17,8 +17,9 @@ that wires **more than one MCP server**.
 ## What you'll learn
 
 **The one new ADK concept: wiring multiple `MCPToolset`s in a single `LlmAgent`
-and giving each a distinct `tool_name_prefix`** (`lyria_`, `tts_`, `av_`) so the
-servers' tool names never collide and the model's tool choices stay legible.
+and giving each a distinct `tool_name_prefix`** (`music`, `tts`, `av`) so the
+servers' tool names never collide and the model's tool choices stay legible
+(exposed as `music_*`, `tts_*`, `av_*`).
 
 With more than one server comes the second lesson: **the genmedia servers spell
 "the same" parameter differently.** The model can't see those differences from
@@ -87,8 +88,8 @@ lyria = MCPToolset(                   # server 1: music
         server_params=StdioServerParameters(command="mcp-lyria-go", env=server_env),
         timeout=180,
     ),
-    tool_filter=["lyria_generate_music"],
-    tool_name_prefix="lyria_",        # -> lyria_generate_music
+    tool_filter=["lyria_generate_music"],   # tool_filter matches the BASE name
+    tool_name_prefix="music",         # -> music_lyria_generate_music
 )
 
 tts = MCPToolset(                     # server 2: voiceover
@@ -97,7 +98,7 @@ tts = MCPToolset(                     # server 2: voiceover
         timeout=120,
     ),
     tool_filter=["gemini_audio_tts"],
-    tool_name_prefix="tts_",          # -> tts_gemini_audio_tts
+    tool_name_prefix="tts",           # -> tts_gemini_audio_tts
 )
 
 avtool = MCPToolset(                  # server 3: mix / convert
@@ -105,7 +106,10 @@ avtool = MCPToolset(                  # server 3: mix / convert
         server_params=StdioServerParameters(command="mcp-avtool-go", env=server_env),
         timeout=180,
     ),
-    tool_name_prefix="av_",           # -> av_ffmpeg_layer_audio_files, ...
+    tool_filter=["ffmpeg_layer_audio_files",     # base names, applied
+                 "ffmpeg_convert_audio_wav_to_mp3",  # before prefixing
+                 "ffmpeg_get_media_info"],
+    tool_name_prefix="av",            # -> av_ffmpeg_layer_audio_files, ...
 )
 
 root_agent = LlmAgent(model=MODEL, name="music_producer",
@@ -114,10 +118,24 @@ root_agent = LlmAgent(model=MODEL, name="music_producer",
 
 `tool_name_prefix` is the teaching point: without it, three servers could each
 expose a tool the model refers to ambiguously; with it, every tool the model can
-call is unambiguously namespaced (`lyria_*`, `tts_*`, `av_*`). The `INSTRUCTION`
-then does the sequencing — generate music → generate VO → mix — and, crucially,
-bakes the **exact, per-tool parameter names** (below) because the model can't
-infer them from the tool schema.
+call is unambiguously namespaced (`music_*`, `tts_*`, `av_*`). Two details that
+make this a *correct* prefixing example, not just a working one:
+
+- **ADK inserts the separator itself** — it exposes each tool as
+  `f"{prefix}_{tool.name}"` ([`base_toolset.py:162`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/base_toolset.py)).
+  So the prefix VALUES are **bare role tokens with no trailing underscore**
+  (`"music"`, not `"music_"`) — otherwise you'd get a doubled `music__…`. And you
+  name them by **role**, not by echoing the server (`"music"`, not `"lyria"`),
+  so the result reads `music_lyria_generate_music`, not a stuttering
+  `lyria_lyria_generate_music`.
+- **`tool_filter` matches the BASE tool name** (it is applied *before* prefixing),
+  so the filter values stay `lyria_generate_music` / `gemini_audio_tts` /
+  `ffmpeg_*` even though the exposed names gain the prefix.
+
+The `INSTRUCTION` then does the sequencing — generate music → generate VO → mix —
+referring to tools by their **exposed** names (`music_lyria_generate_music`,
+`tts_gemini_audio_tts`, `av_ffmpeg_*`) and baking the **exact, per-tool parameter
+names** (below) because the model can't infer them from the tool schema.
 
 ### Why gemini TTS (and not chirp3)
 
@@ -136,7 +154,7 @@ still noted in NAMING.md and in the validation recipe's alternate path.)
 Every name below is verified against the genmedia Go sources (file:line in
 `agent.py`); it is a concrete instance of [`../NAMING.md`](../NAMING.md):
 
-| Concept | `lyria_generate_music` | `tts_gemini_audio_tts` | `av_*` (e.g. layer/convert) |
+| Concept | `music_lyria_generate_music` | `tts_gemini_audio_tts` | `av_*` (e.g. layer/convert) |
 |---|---|---|---|
 | content | `prompt` | `text` (+ `prompt` = **style**) | — (transform-only) |
 | model id | `model_id` | `model_name` | — |

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/__init__.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
@@ -19,8 +19,11 @@ One LlmAgent wiring THREE MCPToolsets over stdio: lyria (music), gemini TTS
 wire more than one server, so it is where two ADK/genmedia ideas are taught:
 
   1. `tool_name_prefix` on every MCPToolset, so the three servers' tool names
-     never collide and the model's tool choices stay legible (lyria_*, tts_*,
-     av_*).
+     never collide and the model's tool choices stay legible (music_*, tts_*,
+     av_*). ADK inserts the separator itself — prefixed_name = f"{prefix}_
+     {tool.name}" (base_toolset.py:162) — so the prefix VALUES are bare role
+     tokens with NO trailing underscore ("music", "tts", "av"), named by role so
+     they don't echo the base tool name.
   2. The naming crosswalk (../NAMING.md): the servers spell "the same" parameter
      differently (model_id vs model_name, output_gcs_bucket vs output_directory
      vs local_path vs output_local_dir, sample_count, text vs prompt). The model
@@ -68,6 +71,10 @@ if project_id:
 #   see lyria.go:61), output_gcs_bucket:143, local_path:152, output_filename:146,
 #   sample_count:138 / negative_prompt:132 / seed:135 (DROPPED on the default
 #   model — see the INSTRUCTION and NAMING.md Lyria caveat).
+# tool_filter matches the BASE tool.name (applied before prefixing), so it stays
+# "lyria_generate_music". tool_name_prefix is the bare role token "music" (NOT
+# "lyria" — that would echo the base name and stutter); ADK adds the separator,
+# so the exposed name is "music_lyria_generate_music".
 lyria = MCPToolset(
     connection_params=StdioConnectionParams(
         server_params=StdioServerParameters(
@@ -77,7 +84,7 @@ lyria = MCPToolset(
         timeout=180,
     ),
     tool_filter=["lyria_generate_music"],
-    tool_name_prefix="lyria_",
+    tool_name_prefix="music",
 )
 
 
@@ -87,8 +94,9 @@ lyria = MCPToolset(
 #   params text:126 (required, 800-char cap — enforced in
 #   tts_handlers.go:267-268), prompt:130 (STYLE, not content), voice_name:133,
 #   model_name:138, output_directory:154 (local; no GCS output param).
-# tool_filter keeps the surface to just the TTS tool (this server also exposes
-# gemini_image_generation, list_gemini_voices, omni_video_generation).
+# tool_filter (base names) keeps the surface to just the TTS tool (this server
+# also exposes gemini_image_generation, list_gemini_voices, omni_video_generation).
+# Bare role prefix "tts" -> exposed name "tts_gemini_audio_tts".
 tts = MCPToolset(
     connection_params=StdioConnectionParams(
         server_params=StdioServerParameters(
@@ -98,7 +106,7 @@ tts = MCPToolset(
         timeout=120,
     ),
     tool_filter=["gemini_audio_tts"],
-    tool_name_prefix="tts_",
+    tool_name_prefix="tts",
 )
 
 
@@ -118,8 +126,11 @@ tts = MCPToolset(
 # this job (the video/gif/overlay/concat/volume transforms stay hidden). The
 # strings are the exact source tool names (verified: ffmpeg_layer_audio_files
 # mcp_handlers.go:1158, ffmpeg_convert_audio_wav_to_mp3 mcp_handlers.go:116,
-# ffmpeg_get_media_info mcp_handlers.go:57); a filter entry that doesn't match a
-# real tool name is silently dropped, so these must match source verbatim.
+# ffmpeg_get_media_info mcp_handlers.go:57); tool_filter matches these BASE names
+# (applied before prefixing) and a filter entry that doesn't match a real tool
+# name is silently dropped, so these must match source verbatim. Bare role prefix
+# "av" -> exposed names av_ffmpeg_layer_audio_files, av_ffmpeg_convert_audio_wav
+# _to_mp3, av_ffmpeg_get_media_info.
 avtool = MCPToolset(
     connection_params=StdioConnectionParams(
         server_params=StdioServerParameters(
@@ -133,7 +144,7 @@ avtool = MCPToolset(
         "ffmpeg_convert_audio_wav_to_mp3",
         "ffmpeg_get_media_info",
     ],
-    tool_name_prefix="av_",
+    tool_name_prefix="av",
 )
 
 
@@ -144,15 +155,15 @@ VO file, and a mixed file that layers the two — and you VERIFY each one exists
 before reporting success.
 
 You wire THREE servers. Because tool names could collide across servers, every
-tool you can call is namespaced with a prefix — `lyria_`, `tts_`, `av_`. Use the
-prefixed names exactly. The parameter constraints below are NOT visible from the
-tool schemas, so honor them here. The full crosswalk of why the names differ
-across servers is in ../NAMING.md — read it once; the exact names for YOUR three
-tools are baked below.
+tool you can call is namespaced by role — `music_`, `tts_`, `av_`. Use the
+prefixed names exactly as written below. The parameter constraints below are NOT
+visible from the tool schemas, so honor them here. The full crosswalk of why the
+names differ across servers is in ../NAMING.md — read it once; the exact names
+for YOUR three tools are baked below.
 
 Work in this order and do not skip the verification after each step.
 
-# 1. Generate the music bed — `lyria_generate_music`
+# 1. Generate the music bed — `music_lyria_generate_music`
 - `prompt` (REQUIRED): a rich description of the music bed (genre, instruments,
   tempo, mood). This is the one parameter that reliably shapes the output.
 - `local_path` (recommended): a local directory, e.g. `./output`. NOTE the

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
@@ -21,9 +21,10 @@ wire more than one server, so it is where two ADK/genmedia ideas are taught:
   1. `tool_name_prefix` on every MCPToolset, so the three servers' tool names
      never collide and the model's tool choices stay legible (music_*, tts_*,
      av_*). ADK inserts the separator itself — prefixed_name = f"{prefix}_
-     {tool.name}" (base_toolset.py:162) — so the prefix VALUES are bare role
-     tokens with NO trailing underscore ("music", "tts", "av"), named by role so
-     they don't echo the base tool name.
+     {tool.name}" (google/adk-python base_toolset.py:143 @ tag v2.8.0:
+     https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/tools/base_toolset.py#L143)
+     — so the prefix VALUES are bare role tokens with NO trailing underscore
+     ("music", "tts", "av"), named by role so they don't echo the base tool name.
   2. The naming crosswalk (../NAMING.md): the servers spell "the same" parameter
      differently (model_id vs model_name, output_gcs_bucket vs output_directory
      vs local_path vs output_local_dir, sample_count, text vs prompt). The model

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Music Producer — two servers, one agent (crawl tier).
+"""Music Producer — three servers, one agent (crawl tier).
 
 One LlmAgent wiring THREE MCPToolsets over stdio: lyria (music), gemini TTS
 (voiceover), and avtool (mix/convert). This is the first agent in the series to
@@ -113,9 +113,13 @@ tts = MCPToolset(
 #     output_local_dir :1163 / output_gcs_bucket :1164
 #   ffmpeg_convert_audio_wav_to_mp3   mcp_handlers.go:116   (WAV VO -> MP3)
 #     input_audio_uri (required) :118 / output_filename :119
-# No tool_filter here: the producer may reach for other avtool transforms
-# (get_media_info, adjust_volume, combine_audio_and_video); the av_ prefix keeps
-# them namespaced.
+# tool_filter narrows avtool's 8-tool surface to exactly the three this agent
+# uses, so — like lyria and tts above — the model only sees tools relevant to
+# this job (the video/gif/overlay/concat/volume transforms stay hidden). The
+# strings are the exact source tool names (verified: ffmpeg_layer_audio_files
+# mcp_handlers.go:1158, ffmpeg_convert_audio_wav_to_mp3 mcp_handlers.go:116,
+# ffmpeg_get_media_info mcp_handlers.go:57); a filter entry that doesn't match a
+# real tool name is silently dropped, so these must match source verbatim.
 avtool = MCPToolset(
     connection_params=StdioConnectionParams(
         server_params=StdioServerParameters(
@@ -124,6 +128,11 @@ avtool = MCPToolset(
         ),
         timeout=180,
     ),
+    tool_filter=[
+        "ffmpeg_layer_audio_files",
+        "ffmpeg_convert_audio_wav_to_mp3",
+        "ffmpeg_get_media_info",
+    ],
     tool_name_prefix="av_",
 )
 

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/music_producer/agent.py
@@ -1,0 +1,229 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Music Producer — two servers, one agent (crawl tier).
+
+One LlmAgent wiring THREE MCPToolsets over stdio: lyria (music), gemini TTS
+(voiceover), and avtool (mix/convert). This is the first agent in the series to
+wire more than one server, so it is where two ADK/genmedia ideas are taught:
+
+  1. `tool_name_prefix` on every MCPToolset, so the three servers' tool names
+     never collide and the model's tool choices stay legible (lyria_*, tts_*,
+     av_*).
+  2. The naming crosswalk (../NAMING.md): the servers spell "the same" parameter
+     differently (model_id vs model_name, output_gcs_bucket vs output_directory
+     vs local_path vs output_local_dir, sample_count, text vs prompt). The model
+     cannot see those constraints from tools/list, so the INSTRUCTION bakes the
+     exact names for THIS agent's three tools.
+
+Every parameter and tool name below was source-verified against the genmedia Go
+sources at repo tip; file:line citations live next to each toolset and in the
+INSTRUCTION. See README.md for the walk-through.
+"""
+
+import os
+
+# Imports mirror photoshoot/ so the series stays on the same ADK surface.
+from dotenv import load_dotenv
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import (
+    MCPToolset,
+    StdioConnectionParams,
+    StdioServerParameters,
+)
+
+load_dotenv()
+
+# One model constant, served in the GLOBAL region — keep GOOGLE_CLOUD_LOCATION
+# ="global" in .env (see .env.example). The default Lyria model is also
+# global-only (Interactions API), so "global" is required, not just convenient.
+MODEL = "gemini-3.8-flash"
+
+project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+# Forward the environment to each stdio server, adding PROJECT_ID only when set.
+# Env values must be strings; passing PROJECT_ID=None raises TypeError when the
+# subprocess launches, so we guard rather than pass None. (Same pattern as
+# photoshoot/.) All three toolsets share this env.
+server_env = dict(os.environ)
+if project_id:
+    server_env["PROJECT_ID"] = project_id
+
+
+# --- Server 1: lyria (music) -------------------------------------------------
+# Binary: mcp-lyria-go. Tool: lyria_generate_music.
+# Source: mcp-genmedia-go/mcp-lyria-go/lyria.go:161 (mcp.NewTool name),
+#   params prompt:128 (required), model_id:155 (default lyria-3-clip-preview,
+#   see lyria.go:61), output_gcs_bucket:143, local_path:152, output_filename:146,
+#   sample_count:138 / negative_prompt:132 / seed:135 (DROPPED on the default
+#   model — see the INSTRUCTION and NAMING.md Lyria caveat).
+lyria = MCPToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-lyria-go",
+            env=server_env,
+        ),
+        timeout=180,
+    ),
+    tool_filter=["lyria_generate_music"],
+    tool_name_prefix="lyria_",
+)
+
+
+# --- Server 2: gemini TTS (voiceover) ----------------------------------------
+# Binary: mcp-gemini-go. Tool: gemini_audio_tts.
+# Source: mcp-genmedia-go/mcp-gemini-go/main.go:124 (mcp.NewTool name),
+#   params text:126 (required, 800-char cap — enforced in
+#   tts_handlers.go:267-268), prompt:130 (STYLE, not content), voice_name:133,
+#   model_name:138, output_directory:154 (local; no GCS output param).
+# tool_filter keeps the surface to just the TTS tool (this server also exposes
+# gemini_image_generation, list_gemini_voices, omni_video_generation).
+tts = MCPToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-gemini-go",
+            env=server_env,
+        ),
+        timeout=120,
+    ),
+    tool_filter=["gemini_audio_tts"],
+    tool_name_prefix="tts_",
+)
+
+
+# --- Server 3: avtool (mix / convert) ----------------------------------------
+# Binary: mcp-avtool-go. Transform-only: every tool needs an INPUT file/URI and
+# needs ffmpeg + ffprobe on PATH (mcp-avtool-go/ffmpeg_commands.go:21 execs
+# "ffmpeg"; ffprobe_commands.go:17 execs "ffprobe").
+# Tools used by this agent:
+#   ffmpeg_layer_audio_files          mcp_handlers.go:1158  (mix music + VO)
+#     input_audio_uris (required, array)  :1160
+#     output_filename (extension selects container) :1161
+#     output_local_dir :1163 / output_gcs_bucket :1164
+#   ffmpeg_convert_audio_wav_to_mp3   mcp_handlers.go:116   (WAV VO -> MP3)
+#     input_audio_uri (required) :118 / output_filename :119
+# No tool_filter here: the producer may reach for other avtool transforms
+# (get_media_info, adjust_volume, combine_audio_and_video); the av_ prefix keeps
+# them namespaced.
+avtool = MCPToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-avtool-go",
+            env=server_env,
+        ),
+        timeout=180,
+    ),
+    tool_name_prefix="av_",
+)
+
+
+INSTRUCTION = """\
+You are a music producer and audio engineer. Given a mood/genre for a music bed
+and a short voiceover (VO) script, you produce THREE artifacts: a music file, a
+VO file, and a mixed file that layers the two — and you VERIFY each one exists
+before reporting success.
+
+You wire THREE servers. Because tool names could collide across servers, every
+tool you can call is namespaced with a prefix — `lyria_`, `tts_`, `av_`. Use the
+prefixed names exactly. The parameter constraints below are NOT visible from the
+tool schemas, so honor them here. The full crosswalk of why the names differ
+across servers is in ../NAMING.md — read it once; the exact names for YOUR three
+tools are baked below.
+
+Work in this order and do not skip the verification after each step.
+
+# 1. Generate the music bed — `lyria_generate_music`
+- `prompt` (REQUIRED): a rich description of the music bed (genre, instruments,
+  tempo, mood). This is the one parameter that reliably shapes the output.
+- `local_path` (recommended): a local directory, e.g. `./output`. NOTE the
+  spelling — lyria calls the local dir `local_path`, NOT `output_directory`
+  (that is the majority spelling other servers use; see NAMING.md §3).
+- `output_filename` (optional): a predictable base name, e.g. `bed.mp3`. On the
+  default model lyria emits MP3, so use a `.mp3` name.
+- To save to Cloud Storage instead, pass `output_gcs_bucket` (a bare bucket
+  name, NOT a `gs://` URI, and NOT `bucket`/`gcs_bucket_uri` — see NAMING.md §2).
+- **Do NOT pass `negative_prompt`, `seed`, or `sample_count`.** On the default
+  Lyria model (`lyria-3-clip-preview`, which runs on the Vertex Interactions
+  API) these are SILENTLY IGNORED — only the first sample is returned and only
+  `prompt` reaches the model. Promising them would teach an invalid call. The
+  default model is also GLOBAL-region only (keep GOOGLE_CLOUD_LOCATION=global).
+- **The trap:** if you pass NEITHER `local_path` NOR `output_gcs_bucket` (and no
+  GENMEDIA_BUCKET fallback is set), the audio is returned inline and no file is
+  written — avtool would then have nothing to mix. Always give lyria a
+  destination. Default to LOCAL: `local_path="./output"`.
+- Requires the genmedia suite >= v3.18.1; older builds return no usable audio.
+
+# 2. Generate the voiceover — `tts_gemini_audio_tts`
+- `text` (REQUIRED): the words to SPEAK. This is the content. Capped at 800
+  characters — if the script is longer, tell the user to shorten it (do not
+  silently truncate).
+- `prompt` (optional): STYLE/delivery instructions only (tone, pace, accent) —
+  NOT content. This overload (`text`=content, `prompt`=style) is unique to the
+  TTS tools; see NAMING.md §5.
+- `output_directory` (recommended): a local directory, e.g. `./output`. This
+  tool uses the majority spelling `output_directory` (contrast lyria's
+  `local_path`). It writes WAV by default. There is NO GCS output param on this
+  tool — it is LOCAL only.
+- `output_filename` (optional): e.g. `vo.wav`.
+- `model_name` (optional): the model id spelling here is `model_name` (lyria uses
+  `model_id`; most other servers use `model`). Leave it unset unless the user
+  names a model.
+
+# 3. Mix the two — avtool (`av_*`)
+avtool is TRANSFORM-ONLY: it cannot generate audio, it only operates on INPUT
+files, and it needs `ffmpeg` and `ffprobe` on PATH. So it must run AFTER steps 1
+and 2, and you feed it the concrete file paths those steps saved.
+- Mix music + VO with `av_ffmpeg_layer_audio_files`:
+  - `input_audio_uris` (REQUIRED): an ARRAY of the two paths, e.g.
+    `["./output/bed.mp3", "./output/vo.wav"]` (local paths or `gs://`).
+  - `output_filename`: **the extension SELECTS the output container** — pass
+    `mix.mp3` for MP3, `mix.wav` for WAV. Choose deliberately and tell the user
+    which container you asked for.
+  - `output_local_dir` (optional): local output dir, e.g. `./output`. NOTE the
+    spelling — avtool calls it `output_local_dir` (not `output_directory`, not
+    `local_path`; NAMING.md §3). `output_gcs_bucket` for GCS.
+- If you instead need to convert the WAV VO to MP3, use
+  `av_ffmpeg_convert_audio_wav_to_mp3` (`input_audio_uri` REQUIRED,
+  `output_filename` selects the container by extension).
+
+# 4. Verify by existence — never trust a resource link
+A tool returning successfully does NOT mean a file exists, and a returned
+resource link is NOT proof of persistence. After each step, confirm the concrete
+artifact the tool reported it SAVED:
+- LOCAL: report the exact saved path (from the tool result) and tell the user
+  they can list it, e.g. `ls -l ./output/bed.mp3`.
+- GCS: report the returned `gs://...` destination and tell the user to confirm
+  with `gcloud storage ls <that path>`.
+If a tool result does not name a saved file or destination, treat that step as
+NOT verified and say so — do not fabricate a path. Finally, confirm the mixed
+file's container matches the extension you requested (e.g. `.mp3` really is MP3);
+if the user cares, tell them to check with `av_ffmpeg_get_media_info`.
+
+State plainly, for all three artifacts, the concrete path/URI and how you
+verified it.
+"""
+
+
+root_agent = LlmAgent(
+    model=MODEL,
+    name="music_producer",
+    description=(
+        "A music-producer/audio-engineer agent that generates a music bed "
+        "(lyria) and a voiceover (gemini TTS), mixes them with avtool, and "
+        "verifies each artifact exists. Teaches multi-server MCPToolset wiring "
+        "with tool_name_prefix and the genmedia naming crosswalk."
+    ),
+    instruction=INSTRUCTION,
+    tools=[lyria, tts, avtool],
+)

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "music-producer"
+version = "0.1.0"
+description = "ADK crawl-tier multi-server agent: generate a music bed (lyria) + voiceover (gemini TTS) and mix them (avtool), with tool_name_prefix and the naming crosswalk"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "python-dotenv>=1.0",
+    "google-adk[gcp,mcp]>=1.28.1",
+]


### PR DESCRIPTION
## What & why
PR-3 of the ADK genmedia example series: the **Music Producer** — the first **multi-server** crawl agent and the reference example for `tool_name_prefix` + the NAMING.md crosswalk. Copies the PR-1 (#1812) contract.

## Scope (new dir only)
`experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/`, mirroring `photoshoot/`. Through-line README step 3 flipped to LIVE (no dead links).

## Agent
One `LlmAgent` (`root_agent`), `MODEL=gemini-3.8-flash` (global), **three** `MCPToolset`s with distinct `tool_name_prefix`:
- `lyria_` → mcp-lyria-go (`lyria_generate_music`)
- `tts_` → mcp-gemini-go (`gemini_audio_tts`)
- `av_` → mcp-avtool-go (mix/convert)

## TTS choice
`gemini_audio_tts` (not chirp3): exercises two NAMING.md divergences in one tool (`model_name` spelling §1 + `text`=content / `prompt`=style overload §5), an 800-char cap, and emits MP3 to match Lyria for a clean same-format mix. chirp3's WAV-only/no-GCS quirk is documented as the alternate path.

## Quirks baked in (source-verified, file:line in dev report)
- **lyria:** default `lyria-3-clip-preview` routes to the Interactions API and **drops** `sample_count`/`negative_prompt`/`seed` (only `prompt` is sent); global-only. Instruction does NOT promise the dropped params.
- **gemini TTS:** `text` required ≤800 chars (enforced), `prompt`=style not content, local output only.
- **avtool:** transform-only, needs **ffmpeg+ffprobe** on PATH, **output extension selects the container**.
- All artifacts verified by existence/destination-listing.

## Hard prerequisite
MCP genmedia suite **≥ v3.18.1** at run time (lyria #1768 parse + #1777 container) — stated in README + recipe.

## Validation
Credentialed run (music → VO → mix, each verified; container==extension; ffmpeg present) is the EM-owned gate via a deterministic recipe. Offline gates green: py_compile, import-mirror, dead-link, NAMING.md consistency.