### PR TITLE
feat(adk-series): Scriptwriter/Storyboarder walk-tier pipeline (SequentialAgent + output_key)

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
@@ -37,7 +37,7 @@ or demo that does the same job on another surface.
 | 1 | **Your first genmedia agent** — [Photoshoot](./photoshoot/) | one `LlmAgent` + one `MCPToolset` (`tool_filter`); output modes + verify-by-existence | **ready** |
 | 2 | **Now with video** — [Director / Videographer](./director-videographer/) | one tool again, but the Veo gotchas (verify by *listing*; explicit Veo-3 model) | **ready** |
 | 3 | **Three servers, one agent** — [Music Producer](./music-producer/) | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | **ready** |
-| 4 | **Your first pipeline** — Scriptwriter / Storyboarder | `SequentialAgent` + `output_key` state passing between agents | coming next |
+| 4 | **Your first pipeline** — [Scriptwriter / Storyboarder](./scriptwriter-storyboarder/) | `SequentialAgent` + `output_key` state passing between agents | **ready** |
 | 5 | **A real multi-agent app** — Ad creative-director's assistant | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | coming next |
 
 > Steps 2–5 are being added as the series rolls out; they're listed here so you

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/.env.example
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to .env and fill in your values, then `uv sync` and `adk web`.
+
+# Your Google Cloud project id.
+GOOGLE_CLOUD_PROJECT="your-project-id"
+
+# gemini-3.8-flash (the default MODEL in scriptwriter_storyboarder/agent.py) is
+# served in the GLOBAL region, so keep this set to "global".
+GOOGLE_CLOUD_LOCATION="global"
+
+# Use the Vertex AI backend (not the public Gemini API).
+GOOGLE_GENAI_USE_VERTEXAI="True"
+
+# Bucket name (NO gs:// prefix) used as the fallback GCS destination when you run
+# the storyboarder in GCS mode without passing an explicit gcs_bucket_uri. Stills
+# then land under <bucket>/nanobanana_outputs/. Optional for local
+# (output_directory) mode.
+GENMEDIA_BUCKET="your-bucket-name"

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/.gitignore
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/.gitignore
@@ -1,0 +1,14 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv
+
+# Local secrets and generated media
+.env
+output/

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/README.md
@@ -1,0 +1,151 @@
+# Scriptwriter / Storyboarder — your first pipeline
+
+## What you'll build
+
+A two-stage pipeline. You give it a one-line brief — *"a lonely lighthouse
+keeper's last night on the job"* — and a **scriptwriter** agent turns it into a
+numbered shot list, then a **storyboarder** agent reads that shot list and
+generates one storyboard still per shot, verifies each file, and hands you a
+shot→image map. It's the first agent in the series that is more than a single
+`LlmAgent`: it's two agents wired into an ordered pipeline that pass work between
+each other.
+
+## What you'll learn
+
+**The one new ADK concept: `SequentialAgent` + `output_key` state passing.** One
+agent writes a value into session state under an `output_key`; the next agent
+reads it back by name in its instruction with the `{key}` template. That is ADK's
+native, no-glue way to hand a result from one stage of a pipeline to the next:
+
+- the `scriptwriter` sets `output_key="shot_list"`, so ADK stores its final text
+  in `state["shot_list"]`;
+- the `storyboarder`'s instruction contains `{shot_list}`, so ADK substitutes
+  that stored text into the prompt before the storyboarder runs;
+- a `SequentialAgent` runs the two in order, so the write always happens before
+  the read.
+
+You'll also carry forward the crawl-tier habits: nanobanana output modes and
+**verify-by-existence** — now applied once per shot.
+
+## Prerequisites
+
+- **Python ≥ 3.13** and [`uv`](https://docs.astral.sh/uv/).
+- **The genmedia MCP suite ≥ v3.18.1, installed on your `PATH`.** The
+  storyboarder calls `mcp-nanobanana-go`. Install it from the suite's
+  [`install.sh`](../../../mcp-genmedia-go/install.sh); confirm it's reachable:
+  ```bash
+  which mcp-nanobanana-go
+  ```
+- **A Google Cloud project with Vertex AI enabled**, and application-default
+  credentials (`gcloud auth application-default login`).
+- **Environment variables** — copy `.env.example` to `.env` and fill in:
+  - `GOOGLE_CLOUD_PROJECT` — your project id.
+  - `GOOGLE_CLOUD_LOCATION="global"` — `gemini-3.8-flash` is served globally.
+  - `GOOGLE_GENAI_USE_VERTEXAI="True"` — use the Vertex backend.
+  - `GENMEDIA_BUCKET` — a bucket name (no `gs://`) for GCS-mode output. Optional
+    if you only use local output.
+- **ffmpeg:** not needed here. (Later audio/video agents need it.)
+
+## Run it
+
+```bash
+cp .env.example .env      # then edit .env with your values
+uv sync                   # create the venv and install google-adk[gcp,mcp]
+source .venv/bin/activate
+adk web                   # open the printed URL, pick "scriptwriter_storyboarder"
+```
+
+Try this sample prompt:
+
+> A lonely lighthouse keeper's last night on the job. Save the stills locally.
+
+The scriptwriter will write a numbered shot list (≤ 6 shots); then the
+storyboarder will generate one still per shot into `./output/` and report a
+shot→image map. To try GCS instead:
+
+> Same brief, but 16:9 and save the stills to my GCS bucket.
+
+## How it works
+
+The whole pipeline is `scriptwriter_storyboarder/agent.py`. Annotated:
+
+```python
+MODEL = "gemini-3.8-flash"            # one constant; change it to a model you have
+
+scriptwriter = LlmAgent(              # stage 1: text only, no tools
+    model=MODEL,
+    name="scriptwriter",
+    instruction=SCRIPTWRITER_INSTRUCTION,   # "turn the brief into a numbered shot list, <= 6"
+    output_key="shot_list",          # <-- ADK writes its final text to state["shot_list"]
+)
+
+storyboarder = LlmAgent(             # stage 2: wires the nanobanana image tool
+    model=MODEL,
+    name="storyboarder",
+    instruction=STORYBOARDER_INSTRUCTION,   # contains {shot_list}  <-- ADK reads state here
+    tools=[nanobanana],
+)
+
+root_agent = SequentialAgent(        # run scriptwriter, THEN storyboarder
+    name="scriptwriter_storyboarder",
+    sub_agents=[scriptwriter, storyboarder],
+)
+```
+
+The hand-off is the lesson, and it's two lines:
+
+1. **The write.** `output_key="shot_list"` tells ADK to copy the scriptwriter's
+   final text response into session state under `shot_list`. (In ADK 2.8.0 this
+   happens in `LlmAgent`'s `output_key` handling —
+   `google/adk/agents/llm_agent.py`, the field at line 419 and the write
+   `event.actions.state_delta[self.output_key] = result` at line 1045.)
+2. **The read.** The storyboarder's instruction string contains the literal
+   `{shot_list}`. Before each LLM call, ADK runs *instruction templating* over
+   the instruction and substitutes `{key}` with `state[key]`
+   (`google/adk/utils/instructions_utils.py` → `inject_session_state` →
+   `_render_with_regex` / `_replace_match`). So the storyboarder literally sees
+   the scriptwriter's shot list inside its prompt.
+
+`SequentialAgent` guarantees the order — scriptwriter first (write), storyboarder
+second (read) — so the value is always in state by the time it's needed.
+
+## The gotcha this teaches
+
+**The state-passing contract: the reader must use the exact key the writer
+wrote.** `output_key="shot_list"` and `{shot_list}` are two halves of one
+contract — spell the key the same in both places or the hand-off silently breaks.
+Two things worth knowing about the `{...}` template:
+
+1. **A plain `{shot_list}` is required, not optional.** If the key is missing
+   from state, ADK raises `KeyError` rather than passing an empty prompt. In a
+   `SequentialAgent` the scriptwriter always runs first, so the key is always
+   present — and if it somehow isn't, you *want* the loud failure, because it
+   means the pipeline's hand-off is broken. (ADK also supports an optional form,
+   `{shot_list?}`, which substitutes an empty string when the key is absent; we
+   deliberately do **not** use it here — an empty shot list is not a valid input
+   to the storyboarder.)
+2. **Verify by existence, still — now per shot.** Exactly as in Photoshoot, a
+   returned tool call is not proof of a file. The storyboarder reports the
+   concrete saved path (local) or `gs://` URI (GCS) for *each* shot, and for GCS
+   you confirm with `gcloud storage ls`. The number of rows in the shot→image map
+   must equal the number of shots — that 1:1 correspondence is the visible proof
+   that the storyboarder actually read the scriptwriter's `{shot_list}`.
+
+## See also
+
+- **The `story-generator` skill** —
+  [`experiments/mcp-genmedia/skills/story-generator/SKILL.md`](../../../skills/story-generator/SKILL.md).
+  Same "writers room → per-scene generation" shape (a script stage that feeds a
+  per-scene media stage), expressed as an agent **skill** instead of an ADK
+  pipeline. This Scriptwriter / Storyboarder agent ports that *shape* into ADK's
+  `SequentialAgent` + `output_key` form; read the skill for the deeper
+  storytelling craft, and use this agent as the ADK-runnable surface of the same
+  idea. (Cross-linked, not forked.)
+
+## Next in the series
+
+Head back to the [series overview](../README.md), or continue to **Ad
+creative-director's assistant** (coming next) — where this pipeline grows into a
+real multi-agent app: a `SequentialAgent` wrapping a `ParallelAgent` fan-out that
+composes the crawl personas (Photoshoot / Director / Music Producer) as tools to
+turn a brand brief into an assembled ad.

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "scriptwriter-storyboarder"
+version = "0.1.0"
+description = "ADK walk-tier pipeline: a SequentialAgent turns a brief into a shot list, then a still per shot via nanobanana"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "python-dotenv>=1.0",
+    "google-adk[gcp,mcp]>=1.28.1",
+]

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/scriptwriter_storyboarder/__init__.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/scriptwriter_storyboarder/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/scriptwriter_storyboarder/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/scriptwriter_storyboarder/agent.py
@@ -1,0 +1,217 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scriptwriter / Storyboarder — your first ADK pipeline (walk tier).
+
+A two-stage `SequentialAgent`. The `scriptwriter` (text only, no tools) turns a
+one-line brief into a numbered shot list and writes it to session state under
+`output_key="shot_list"`. The `storyboarder` then reads that value back by name
+via the `{shot_list}` template in its instruction and generates one nanobanana
+still per shot. This is the series' reference example for ADK's native
+state-passing between agents: `output_key` writes, `{key}` reads.
+See README.md for the walk-through.
+"""
+
+import os
+
+# Imports mirror the crawl-tier photoshoot agent so the series stays on the same
+# ADK 2.8.0 surface, and add `SequentialAgent` — the one new construct this tier
+# teaches. `tool_filter` is a supported MCPToolset kwarg in 2.8.0.
+from dotenv import load_dotenv
+from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.tools.mcp_tool.mcp_toolset import (
+    MCPToolset,
+    StdioConnectionParams,
+    StdioServerParameters,
+)
+
+load_dotenv()
+
+# Set this to a Gemini model you have access to on your Vertex backend.
+# gemini-3.8-flash is served in the GLOBAL region, so keep
+# GOOGLE_CLOUD_LOCATION="global" in your .env (see .env.example).
+MODEL = "gemini-3.8-flash"
+
+project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+# Forward the whole environment to the stdio server, and add PROJECT_ID only when
+# it is set. Env values must be strings — passing PROJECT_ID=None (which happens
+# when GOOGLE_CLOUD_PROJECT is unset) raises TypeError when the subprocess
+# actually launches, so we guard rather than pass None. (GOOGLE_CLOUD_PROJECT
+# itself still passes through via os.environ when present.)
+server_env = dict(os.environ)
+if project_id:
+    server_env["PROJECT_ID"] = project_id
+
+# MCP Client (STDIO): assumes the genmedia suite (>= v3.18.1) is installed on
+# your PATH via the suite's install.sh, so `mcp-nanobanana-go` is runnable.
+# `tool_filter` keeps the storyboarder's tool surface to exactly the one image
+# tool — the same nanobanana wiring the crawl-tier photoshoot agent uses.
+nanobanana = MCPToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-nanobanana-go",
+            env=server_env,
+        ),
+        timeout=120,
+    ),
+    tool_filter=["nanobanana_image_generation"],
+)
+
+
+# --- Stage 1: the scriptwriter (text only, no tools) -------------------------
+# It writes its final response into session state under `output_key`. In ADK
+# 2.8.0 the LlmAgent copies the agent's final text response into
+# state["shot_list"] (google/adk/agents/llm_agent.py: the `output_key` field is
+# declared at line 419; the write happens in __maybe_save_output_to_state at
+# line 1045: `event.actions.state_delta[self.output_key] = result`).
+SCRIPTWRITER_INSTRUCTION = """\
+You are a scriptwriter. The user gives you a single one-line creative brief; your
+job is to turn it into a short, shootable shot list.
+
+Produce a NUMBERED shot list. Use AT MOST 6 shots (fewer is fine — only add a
+shot if it earns its place). Keeping it to six or fewer keeps the storyboard
+generation that follows fast and cheap.
+
+For each shot, on its own numbered line, give three things clearly labelled:
+- Scene: where we are / the setting.
+- Action: what is happening in the frame.
+- Look: composition, lens, light, and mood (the visual style).
+
+Write ONLY the numbered shot list as plain text — no preamble, no closing
+remarks, no markdown headings. This text is handed verbatim to the storyboard
+artist as the next stage of the pipeline, so keep every shot self-contained and
+visually concrete.
+"""
+
+
+# --- Stage 2: the storyboarder (reads {shot_list} from state) ----------------
+# `{shot_list}` is ADK 2.8.0 instruction templating: before each LLM call the
+# flow runs inject_session_state over the instruction string and substitutes
+# {key} with state[key] (google/adk/utils/instructions_utils.py: _render_with_regex
+# / _replace_match). A plain (non-optional) {shot_list} raises KeyError if the key
+# is absent — which is what we want here: in this SequentialAgent the scriptwriter
+# always runs first and populates it, so a missing value means the state hand-off
+# is broken and should fail loudly rather than silently. (The `{shot_list?}`
+# suffix would substitute "" instead; we deliberately do not use it.)
+STORYBOARDER_INSTRUCTION = """\
+You are a storyboard artist. The scriptwriter has just written a shot list; here
+it is, injected from session state:
+
+<shot_list>
+{shot_list}
+</shot_list>
+
+Your job is to generate ONE storyboard still for EACH numbered shot above, in
+order, and then report a shot->image map.
+
+# 1. Work shot by shot
+Read the shot list above and generate exactly one image per numbered shot — no
+more, no fewer. For each shot, art-direct a rich image prompt FROM THAT SHOT's
+Scene / Action / Look (composition, lens, light, mood); do not invent shots that
+are not in the list and do not merge shots.
+
+# 2. Call nanobanana_image_generation (once per shot)
+Parameters (these constraints are NOT visible to you from the tool schema alone,
+so honor them here):
+- `prompt` (REQUIRED): your art-directed prompt string for that one shot.
+- `model` (optional): defaults to `gemini-3.1-flash-image`. Leave unset unless
+  the user asks for a specific image model.
+- `aspect_ratio` (optional): defaults to `1:1`. Match it to the medium the brief
+  implies — e.g. `16:9` for cinematic/wide, `9:16` for phone/stories, `1:1` for
+  social. Supported ratios are model-dependent.
+- `image_size` (optional): one of `1K`, `2K`, `4K`; defaults to `1K` when unset.
+  Supported sizes are model-dependent.
+- `output_filename` (optional): a client-predictable base name, e.g.
+  `shot-01.png`. The extension is forced to the true media type. Use the shot
+  number so the stills are easy to match back to the list.
+
+## Output mode — choose deliberately, and be explicit about it
+The tool writes each still to whichever destination you specify. Use the SAME
+mode for every shot in a run:
+- LOCAL mode: pass `output_directory` (e.g. `./output`) to save a local file.
+- GCS mode, specific bucket: ONLY when the user gives you a real bucket, pass
+  `gcs_bucket_uri` as an actual GCS URI prefix of the form
+  `gs://<your-bucket>/<prefix>/`. Never invent a bucket name, and never pass a
+  placeholder — a made-up or example URI will 403. Use exactly the bucket the
+  user named.
+- GCS mode, no bucket named: when the user asks to save to GCS/Cloud Storage but
+  does NOT name a specific bucket, pass NEITHER `output_directory` nor
+  `gcs_bucket_uri`. The server then uses the configured `GENMEDIA_BUCKET`
+  fallback (writing under `<bucket>/nanobanana_outputs/`). Prefer this over
+  guessing a URI.
+- The trap: if you pass NEITHER output param AND no `GENMEDIA_BUCKET` fallback is
+  configured, the image bytes are DISCARDED. So for local requests always pass
+  `output_directory`; for GCS-without-a-named-bucket rely on the fallback (and if
+  the tool reports nothing was saved, tell the user to set `GENMEDIA_BUCKET`).
+Default to LOCAL (`output_directory="./output"`) unless the user asks for GCS.
+
+# 3. Verify by existence — never trust the response blindly
+The tool response may contain a resource link or references, but you must NOT
+assume a still exists just because the call returned. For each shot, confirm the
+artifact:
+- LOCAL mode: read the exact local file path the tool saved (from the tool's
+  result). Do not claim inline image data.
+- GCS mode: read the returned `gs://...` URI as the destination to list; tell the
+  user to confirm with `gcloud storage ls <that path>`.
+If the tool result for a shot does not name a saved file or a destination, treat
+that still as NOT verified and say so for that shot — do not fabricate a path.
+
+# 4. Emit the shot->image map
+When every shot is done, end with a plain mapping, one line per shot, e.g.:
+  Shot 1 -> ./output/shot-01.png (verified)
+  Shot 2 -> ./output/shot-02.png (verified)
+State plainly which output mode you used. The number of rows in the map MUST
+equal the number of shots in the shot list — that 1:1 correspondence is the
+proof that you read and honored the scriptwriter's shot list.
+"""
+
+
+scriptwriter = LlmAgent(
+    model=MODEL,
+    name="scriptwriter",
+    description=(
+        "Turns a one-line creative brief into a numbered shot list (<= 6 shots), "
+        "written to session state under output_key='shot_list'."
+    ),
+    instruction=SCRIPTWRITER_INSTRUCTION,
+    # ADK writes this agent's final text response into state["shot_list"], where
+    # the next agent reads it via the {shot_list} template.
+    output_key="shot_list",
+)
+
+
+storyboarder = LlmAgent(
+    model=MODEL,
+    name="storyboarder",
+    description=(
+        "Reads the scriptwriter's shot list from state ({shot_list}) and "
+        "generates one verified nanobanana still per shot, then a shot->image map."
+    ),
+    instruction=STORYBOARDER_INSTRUCTION,
+    tools=[nanobanana],
+)
+
+
+# The pipeline: scriptwriter runs first (writes shot_list), then storyboarder
+# runs (reads shot_list). This ordered hand-off through session state IS the
+# lesson of the walk tier.
+root_agent = SequentialAgent(
+    name="scriptwriter_storyboarder",
+    description=(
+        "A two-stage pipeline that turns a one-line brief into a shot list and "
+        "then a storyboard still per shot, passing state via output_key."
+    ),
+    sub_agents=[scriptwriter, storyboarder],
+)


### PR DESCRIPTION
PR-4 of the ADK genmedia example series. The first true ADK pipeline: root_agent = SequentialAgent(sub_agents=[scriptwriter, storyboarder]). The scriptwriter is a text-only LlmAgent(output_key='shot_list', <=6 shots, no tools); the storyboarder reads {shot_list} from session state via ADK 2.8.0 instruction templating and generates one nanobanana still per shot, verify-by-existence, emitting a shot->image map (1:1 with the shot list = state-passing proof). Reuses the merged Photoshoot nanobanana contract verbatim. MODEL gemini-3.8-flash (global). Teaches SequentialAgent + output_key state passing. Gate: fresh review + credentialed adk web run (stills 1:1 with the shot list, verified by existence) pending.