### PR TITLE
fix(genkit sample): wire Nano Banana MCP server, drop dead imagen, refresh deps

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/genkit/README.md
+++ b/experiments/mcp-genmedia/sample-agents/genkit/README.md
@@ -2,10 +2,23 @@
 
 Example [Genkit](https://firebase.google.com/docs/genkit) AI application using Genmedia MCP servers.
 
+This sample wires three genmedia MCP servers over stdio: **Nano Banana**
+(`mcp-nanobanana-go`, text/image→image — the current image server that replaces
+the retired `imagen` server), **Veo** (`mcp-veo-go`), and **Chirp 3**
+(`mcp-chirp3-go`).
 
 ## Prerequisites
 
 * NodeJs (You can use the [nvm](https://github.com/nvm-sh/nvm) node manager to install this)
+* The genmedia MCP server binaries (`mcp-nanobanana-go`, `mcp-veo-go`,
+  `mcp-chirp3-go`) built and available on your `PATH`. See
+  `experiments/mcp-genmedia` for build/install instructions.
+* A Google Cloud project with the required APIs enabled. Export it before
+  running:
+
+  ```bash
+  export GOOGLE_CLOUD_PROJECT="$(gcloud config get project)"
+  ```
 
 Install Genkit client
 

--- a/experiments/mcp-genmedia/sample-agents/genkit/genkit-agent-js/package.json
+++ b/experiments/mcp-genmedia/sample-agents/genkit/genkit-agent-js/package.json
@@ -12,12 +12,11 @@
   "author": "Google Cloud Applied AI Engineering",
   "license": "ISC",
   "dependencies": {
-    "@genkit-ai/googleai": "^1.7.0",
-    "@genkit-ai/vertexai": "^1.7.0",
-    "genkit": "^1.7.0",
-    "genkitx-mcp": "^1.7.0"
+    "@genkit-ai/vertexai": "^1.42.0",
+    "genkit": "^1.42.0",
+    "genkitx-mcp": "^1.14.1"
   },
   "devDependencies": {
-    "genkit-cli": "^1.7.0"
+    "genkit-cli": "^1.42.0"
   }
 }

--- a/experiments/mcp-genmedia/sample-agents/genkit/genkit-agent-js/src/index.js
+++ b/experiments/mcp-genmedia/sample-agents/genkit/genkit-agent-js/src/index.js
@@ -21,13 +21,20 @@ import { mcpClient } from "genkitx-mcp";
 
 logger.setLogLevel("debug");
 
-const imagenClient = mcpClient({
-  name: "imagen",
-  version: "1.0.0",
-  //serverUrl: "http://localhost:8080/sse",
+// The genmedia MCP servers read their Google Cloud project from
+// GOOGLE_CLOUD_PROJECT (LOCATION is optional; the servers default to
+// us-central1). Set it before running, e.g. via `gcloud config get project`.
+const projectId = process.env.GOOGLE_CLOUD_PROJECT;
+const serverEnv = projectId ? { GOOGLE_CLOUD_PROJECT: projectId } : {};
+
+// Nano Banana (Gemini image) is the current text/image->image server.
+// It replaces the retired `imagen` server, which was shut down and removed.
+const nanobananaClient = mcpClient({
+  name: 'nanobanana',
+  version: '1.0.0',
   serverProcess: {
-    command: './mcp-imagen-go',
-    env: {"PROJECT_ID": "ghchinoy-genai-sa"},
+    command: 'mcp-nanobanana-go',
+    env: serverEnv,
   },
 });
 
@@ -36,7 +43,7 @@ const veoClient = mcpClient({
   version: '1.0.0',
   serverProcess: {
     command: 'mcp-veo-go',
-    env: {"PROJECT_ID": "veo-testing"},
+    env: serverEnv,
   },
 });
 
@@ -45,14 +52,14 @@ const chirp3Client = mcpClient({
   version: '1.0.0',
   serverProcess: {
     command: 'mcp-chirp3-go',
-    env: {"PROJECT_ID": "ghchinoy-genai-sa"},
+    env: serverEnv,
   },
 });
 
 const ai = genkit({
-  plugins: [vertexAI({ location: "us-central1" }), 
-    imagenClient, 
-    veoClient, 
+  plugins: [vertexAI({ location: "us-central1" }),
+    nanobananaClient,
+    veoClient,
     chirp3Client
   ],
   model: gemini20Flash,

--- a/experiments/mcp-genmedia/sample-agents/genkit/package.json
+++ b/experiments/mcp-genmedia/sample-agents/genkit/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "genkit-cli": "^1.7.0"
+    "genkit-cli": "^1.42.0"
   }
 }


### PR DESCRIPTION
## What changed

Staleness fix for the JS Genkit sample under `experiments/mcp-genmedia/sample-agents/genkit/` (4 files):

- Rewires the sample from the retired `imagen` MCP server to the current **Nano Banana** MCP server (`mcp-nanobanana-go`, tool `nanobanana_image_generation`).
- Removes hardcoded personal project IDs (`ghchinoy-genai-sa`, `veo-testing`); all servers now route through `GOOGLE_CLOUD_PROJECT`.
- Refreshes dependency pins (`genkit ^1.42.0`, `@genkit-ai/vertexai ^1.42.0`, `genkit-cli ^1.42.0`, `genkitx-mcp ^1.14.1`); drops unused `@genkit-ai/googleai`.
- Minimal, factual README edits.

Scope is JS/Node only — the Go series is untouched.

## Review

Passed independent review (reviewer ≠ author): verdict **APPROVE**, no Critical or Required findings. See review note `jsfix-review-r1.md`. Facts (server command, tool name, env precedence) were cross-checked against the repo's own genmedia source, not asserted.

## Build-verified status

Build/static gates ran green: `node --check src/index.js` (PARSE OK), ESM import + `mcpClient` smoke test, `npm install`, `npm ls --depth=0` (clean tree, versions match pins, googleai absent), and residual-staleness grep (clean).

**Not run (environment limit, not a defect):** end-to-end runtime against live Vertex AI / genmedia MCP servers — no GCP credentials, MCP server binaries, or ffmpeg in the build container. This is a wiring sample; the change matches the "build-verified vs runtime-unverified" disclosure.

Ready for review — please do not squash away the co-authorship; leaving merge to the owner.
