### PR TITLE
chore(adk-genmedia-series): bump google-adk floor to verified >=2.8.0

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/director-videographer/pyproject.toml
@@ -6,5 +6,5 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "python-dotenv>=1.0",
-    "google-adk[gcp,mcp]>=1.28.1",
+    "google-adk[gcp,mcp]>=2.8.0",
 ]

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/music-producer/pyproject.toml
@@ -6,5 +6,5 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "python-dotenv>=1.0",
-    "google-adk[gcp,mcp]>=1.28.1",
+    "google-adk[gcp,mcp]>=2.8.0",
 ]

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/photoshoot/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/photoshoot/pyproject.toml
@@ -6,5 +6,5 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "python-dotenv>=1.0",
-    "google-adk[gcp,mcp]>=1.28.1",
+    "google-adk[gcp,mcp]>=2.8.0",
 ]

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/scriptwriter-storyboarder/pyproject.toml
@@ -6,5 +6,5 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "python-dotenv>=1.0",
-    "google-adk[gcp,mcp]>=1.28.1",
+    "google-adk[gcp,mcp]>=2.8.0",
 ]


### PR DESCRIPTION
Bumps the `google-adk[gcp,mcp]` dependency floor from `>=1.28.1` to `>=2.8.0` across all four ADK genmedia series agents (photoshoot, director-videographer, music-producer, scriptwriter-storyboarder).

## Why
The series' idioms, ADK line-references, and every credentialed run were verified on **ADK 2.8.0**, but the declared floor was `>=1.28.1` — an untested surface where the verified idioms/line-refs may not hold (a reproducibility hazard). This aligns the declared floor with the verified surface.

## Change
- Four `pyproject.toml` files: specifier `>=1.28.1` → `>=2.8.0`; `[gcp,mcp]` extras unchanged. No other changes (mechanical, 4 insertions / 4 deletions).

## Verification
- `uv lock` (photoshoot) resolves `google-adk==2.8.0` from PyPI with the `[gcp,mcp]` extras (108 pkgs); `uv sync` OK; `py_compile` OK; `import google.adk` OK (`__version__==2.8.0`). PyPI confirms 2.8.0 publishes both extras.
- No behavior change; flips no through-line row and adds no new directory.

Off the critical path; no conflict with the in-flight PR-5 (disjoint files).