### PR TITLE
chore(adk sample): harmonize google-adk floor to >=2.8.0

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk/pyproject.toml
@@ -6,5 +6,5 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "dotenv>=0.9.9",
-    "google-adk[gcp,mcp]>=1.28.1",
+    "google-adk[gcp,mcp]>=2.8.0",
 ]

--- a/experiments/mcp-genmedia/sample-agents/adk/uv.lock
+++ b/experiments/mcp-genmedia/sample-agents/adk/uv.lock
@@ -18,7 +18,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "google-adk", extras = ["gcp", "mcp"], specifier = ">=1.28.1" },
+    { name = "google-adk", extras = ["gcp", "mcp"], specifier = ">=2.8.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Harmonizes the Tier-0 single-agent sample `experiments/mcp-genmedia/sample-agents/adk/` so its declared `google-adk[gcp,mcp]` floor matches its already-pinned install.

## Why
The sample had an internal mismatch: `pyproject.toml` declared `>=1.28.1` while `requirements.txt` pins `==2.8.0` (and `uv.lock` already resolved 2.8.0). Same reproducibility-hygiene rationale as the series floor bump (#1819); zero behavior risk since the effective install is already 2.8.0.

## Change (2 files, 1 line each)
- `pyproject.toml`: `google-adk[gcp,mcp]>=1.28.1` → `>=2.8.0` (extras preserved).
- `uv.lock`: sync the tracked lock's `requires-dist` specifier to `>=2.8.0` (the lock is tracked in this sample, unlike the series agents; syncing it prevents reintroducing the mismatch). **No resolved-version churn** — google-adk stays 2.8.0, no package add/remove/upgrade.

## Verification
- `uv lock` → 109 pkgs resolved, google-adk 2.8.0 (PyPI, extras gcp,mcp); `uv sync` OK; `py_compile` OK; `import google.adk` OK (version 2.8.0). Metadata-only, no credentialed run.

Off the critical path; disjoint from the in-flight PR-5.