### PR TITLE
feat(adk-genmedia-series): Ad creative-director's assistant (RUN-tier capstone)

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
@@ -38,7 +38,7 @@ or demo that does the same job on another surface.
 | 2 | **Now with video** — [Director / Videographer](./director-videographer/) | one tool again, but the Veo gotchas (verify by *listing*; explicit Veo-3 model) | **ready** |
 | 3 | **Three servers, one agent** — [Music Producer](./music-producer/) | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | **ready** |
 | 4 | **Your first pipeline** — [Scriptwriter / Storyboarder](./scriptwriter-storyboarder/) | `SequentialAgent` + `output_key` state passing between agents | **ready** |
-| 5 | **A real multi-agent app** — Ad creative-director's assistant | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | coming next |
+| 5 | **A real multi-agent app** — [Ad creative-director's assistant](./ad-creative-director/) | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | **ready** |
 
 > Steps 2–5 are being added as the series rolls out; they're listed here so you
 > can see the whole arc. Only linked steps are live today.

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.env.example
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.env.example
@@ -1,0 +1,19 @@
+# Copy this file to .env and fill in your values, then `uv sync` and `adk web`.
+
+# Your Google Cloud project id.
+GOOGLE_CLOUD_PROJECT="your-project-id"
+
+# gemini-3.8-flash (the default MODEL in ad_creative_director/agent.py) is served
+# in the GLOBAL region, and the default Lyria model reused via the Music Producer
+# persona is global-only too, so keep this set to "global".
+GOOGLE_CLOUD_LOCATION="global"
+
+# Use the Vertex AI backend (not the public Gemini API).
+GOOGLE_GENAI_USE_VERTEXAI="True"
+
+# Bucket name (NO gs:// prefix) used as the fallback GCS destination when a tool
+# runs in GCS mode without an explicit bucket. Veo (clips) always writes to GCS,
+# so this fallback matters for the capstone: clips land under
+# <bucket>/veo_outputs/ when no bucket is named. Stills/audio default to local
+# ./output. Set this to a REAL bucket you own — a placeholder URI will 403.
+GENMEDIA_BUCKET="your-bucket-name"

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.gitignore
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.gitignore
@@ -1,0 +1,14 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv
+
+# Local secrets and generated media
+.env
+output/

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
@@ -1,0 +1,250 @@
+# Ad creative-director's assistant — a real multi-agent app
+
+> **The capstone.** This is the last and largest agent in the series. It reuses
+> the same eight-section template as the rest (**What you'll build · What you'll
+> learn · Prerequisites · Run it · How it works · The gotcha this teaches · See
+> also · Next in the series**), but where the earlier agents each wired one or a
+> few tools, this one **composes the agents you already built**.
+
+## What you'll build
+
+An ad creative-director's assistant. You give it a **brand brief** and a
+**target duration** (anywhere from 15 seconds to 2 minutes) — *"a 20-second ad
+for Aurora, a cold-brew coffee brand; bright, optimistic, ends on the can"* — and
+it produces **one assembled short video ad**: a duration-budgeted shot plan, a
+still and a motion clip for each hero shot, a music bed, a voiceover, and a final
+`.mp4` that concatenates the clips with the audio mixed over them — every
+intermediate artifact verified to exist.
+
+It does this by **orchestrating the crawl-tier personas you already shipped** —
+[Photoshoot](../photoshoot/) (stills), [Director /
+Videographer](../director-videographer/) (clips), and [Music
+Producer](../music-producer/) (music + voice) — as callable tools. It composes
+them; it does not re-implement them.
+
+## What you'll learn
+
+**The new ADK concepts: a `SequentialAgent` spine that contains a `ParallelAgent`
+fan-out, agents reused as tools via `AgentTool`, and a planner whose reply is a
+schema-validated JSON plan via `output_schema`.** Concretely:
+
+- **`SequentialAgent` ⊃ `ParallelAgent`.** The top-level pipeline runs its four
+  stages in order; stage two is itself a parallel agent that generates several
+  shots at once, sharing session state.
+- **`AgentTool` — reuse, don't re-author.** Each crawl persona is wrapped with
+  `AgentTool` and handed to the stage that needs it. The photoshoot/director/
+  music-producer *instructions and tool wiring live in their own projects*; this
+  capstone imports their `root_agent` objects and calls them.
+- **`output_schema` — a plan that is data, not prose.** The planner emits an
+  `AdPlan` (a Pydantic model), so the downstream stages read a guaranteed shape
+  from `state["ad_plan"]` instead of parsing free text.
+- **The static-fan-out constraint.** `ParallelAgent`'s sub-agent list is fixed at
+  build time — you'll see how to reconcile that with a runtime-variable shot
+  count.
+
+## Prerequisites
+
+- **Python ≥ 3.13** and [`uv`](https://docs.astral.sh/uv/).
+- **The genmedia MCP suite ≥ v3.18.1, installed on your `PATH`.** This is the one
+  agent that exercises **every** server: it calls (directly or through the reused
+  personas) `mcp-nanobanana-go`, `mcp-veo-go`, `mcp-lyria-go`, `mcp-gemini-go`,
+  and `mcp-avtool-go`. Install them from the suite's
+  [`install.sh`](../../../mcp-genmedia-go/install.sh); confirm they're reachable:
+  ```bash
+  for b in mcp-nanobanana-go mcp-veo-go mcp-lyria-go mcp-gemini-go mcp-avtool-go; do which $b; done
+  ```
+  The suite **must be ≥ v3.18.1** — older builds don't return usable Lyria audio
+  and don't give avtool a muxable container.
+- **`ffmpeg` and `ffprobe` on your `PATH`** — avtool is transform-only and shells
+  out to them for the final assembly.
+- **A Google Cloud project with Vertex AI enabled**, and application-default
+  credentials (`gcloud auth application-default login`).
+- **The sibling example dirs must be present.** This capstone composes them, so
+  [`photoshoot/`](../photoshoot/), [`director-videographer/`](../director-videographer/),
+  and [`music-producer/`](../music-producer/) must sit next to this project in the
+  `adk-genmedia-series/` tree (they do in a normal checkout). See **How it works**
+  for why. If one is missing, the agent fails at import with an actionable message.
+- **Environment variables** — copy `.env.example` to `.env` and fill in:
+  - `GOOGLE_CLOUD_PROJECT` — your project id.
+  - `GOOGLE_CLOUD_LOCATION="global"` — `gemini-3.8-flash` and the default Lyria
+    model are served globally.
+  - `GOOGLE_GENAI_USE_VERTEXAI="True"` — use the Vertex backend.
+  - `GENMEDIA_BUCKET` — a **real** bucket name (no `gs://`). Veo (the clips)
+    always writes to GCS, so this fallback matters here. A placeholder URI 403s.
+
+## Run it
+
+```bash
+cp .env.example .env      # then edit .env with your values
+uv sync                   # create the venv and install google-adk[gcp,mcp]
+source .venv/bin/activate
+adk web                   # open the printed URL, pick "ad_creative_director_ad"
+```
+
+Try this sample brief (name your duration explicitly):
+
+> Make a 20-second ad for **Aurora**, a canned cold-brew coffee. Bright and
+> optimistic, morning-city energy, and end on a clean shot of the can with the
+> tagline "Mornings, brightened." Save artifacts locally.
+
+The assistant will: plan a duration-budgeted 3-shot spine, generate a still then
+a clip for each shot (in parallel), generate a music bed and a voiceover, and
+assemble the final `./output/final_ad.mp4` — reporting the verified path and the
+measured duration.
+
+## How it works
+
+The whole engine is `ad_creative_director/agent.py`, built behind a one-line
+factory in `ad_creative_director/profiles.py`. The graph:
+
+```python
+SequentialAgent(name="ad_creative_director_ad", sub_agents=[
+    planner,                       # LlmAgent(output_schema=AdPlan, output_key="ad_plan")
+    ParallelAgent(name="shots", sub_agents=[shot_1, shot_2, shot_3]),
+    audio,                         # LlmAgent(tools=[music_producer_tool])
+    assembler,                     # LlmAgent(tools=[avtool])
+])
+root_agent = build_root_agent(AD_PROFILE)   # adk web loads the ad capstone
+```
+
+**Stage 1 — the planner** is an `LlmAgent` with an `output_schema` (`AdPlan`) and
+`output_key="ad_plan"`, and **no tools and no sub-agents**. From the brief +
+duration it emits a schema-validated JSON plan — per-shot `look` / `motion` /
+`vo_line` / `duration_seconds`, plus `music_mood` — that ADK writes into
+`state["ad_plan"]`. Keeping the planner tool-free keeps the schema enforcement
+unambiguous: its only job is to produce the plan.
+
+**Stage 2 — the shot stage** is a `ParallelAgent` of three shot slots that run
+concurrently and share session state. Each slot reads *its* shot from the plan
+(`shots[i]`), then delegates: it calls the **`photoshoot`** tool for the still,
+then the **`director_videographer`** tool for the clip. `ParallelAgent`'s
+sub-agent list is **static** (fixed at build time), so we build a fixed number of
+slots and each slot no-ops if the plan has fewer shots — see *The gotcha this
+teaches*.
+
+**Stage 3 — the audio stage** is an `LlmAgent` that reuses the **`music_producer`**
+persona (one `AgentTool`) to generate a music bed from the plan's `music_mood`
+and a voiceover from the plan's `vo_line`s.
+
+**Stage 4 — the assembler** is an `LlmAgent` that wires the **avtool** server
+directly (final video assembly is a new role no crawl persona covers). It
+concatenates the clips, mixes the music bed with the VO, lays that audio over the
+video, and **verifies the final file by existence** (media-info + destination
+listing), never by a returned resource link.
+
+### Reuse, not re-implement (and the co-location dependency)
+
+The heart of the capstone is that it **composes the personas you already
+taught**. Each crawl persona is its own self-contained `uv` project, so it is
+reused like this (`agent.py`, abridged):
+
+```python
+# each sibling PROJECT dir is put on sys.path (computed from __file__, not cwd,
+# idempotent, and it fails LOUD if a sibling dir is missing)
+_SERIES_ROOT = Path(__file__).resolve().parents[2]
+for _sibling in ("photoshoot", "director-videographer", "music-producer"):
+    ...  # sys.path.insert(0, series_root / sibling)
+
+from photoshoot.agent import root_agent as photoshoot_agent
+from director_videographer.agent import root_agent as director_agent
+from music_producer.agent import root_agent as music_producer_agent
+
+photoshoot_tool = AgentTool(agent=photoshoot_agent)          # tools/agent_tool.py:109
+director_tool   = AgentTool(agent=director_agent)
+music_producer_tool = AgentTool(agent=music_producer_agent)
+```
+
+`AgentTool` ([`tools/agent_tool.py:109`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/tools/agent_tool.py#L109)
+@ v2.8.0) wraps an agent so another agent can call it as a tool. When a slot
+calls one, `AgentTool` runs the wrapped persona in its **own** runner and session
+(seeded with a copy of the caller's state), so the three shot slots can call the
+*same* photoshoot/director objects concurrently without stepping on each other.
+
+Because the imports are `photoshoot`, `director_videographer`, `music_producer`,
+**this capstone requires those sibling example directories to be present at their
+series paths.** That co-location dependency is inherent to a capstone that
+composes its siblings — it is not a published library depending on packages, it
+is one example directory reusing the example directories next to it. Why `sys.path`
+rather than declaring them as dependencies? Each sibling is a runnable example
+project, not a buildable/publishable library, so wiring them as package
+dependencies would mean restructuring the merged siblings; putting their project
+dirs on `sys.path` reuses them verbatim and keeps every example copy-pasteable.
+Their only runtime needs — `google-adk` and `python-dotenv` — are already in this
+project's own dependencies, so a single `uv sync` here runs the whole thing.
+
+### The profile seam (one internal line)
+
+The engine is built by `build_root_agent(profile=AD_PROFILE)`. A `Profile` (a
+frozen dataclass in `profiles.py`) selects the planner's persona, the plan schema
+(`AdPlan`), what each shot slot produces, and the assembler recipe. **This project
+ships the `ad` profile only** — the seam is a thin internal factory so the same
+engine can grow a second audience later without reshaping the graph. It is
+deliberately a plain-Python dataclass + factory, **not** ADK's `from_config` /
+`AgentConfig` YAML, which is `@deprecated` *and* `@experimental` in ADK 2.8.0.
+
+## The gotcha this teaches
+
+**`ParallelAgent` fans out to a *fixed* list of sub-agents, not to a
+runtime-determined count — so budget the shots and reconcile the two.**
+
+`ParallelAgent._run_async_impl` iterates `self.sub_agents`
+([`agents/parallel_agent.py:266`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/agents/parallel_agent.py#L266)
+@ v2.8.0); there is no mechanism to spawn one branch per plan shot at runtime.
+The plan, however, has a variable number of shots. We reconcile them with a
+**fixed shot cap, `MAX_SHOTS = 3`**:
+
+- We build exactly 3 shot slots. Each reads `shots[i]` from the plan if present
+  and **no-ops** if the plan has fewer shots. `AdPlan.shots` is bounded to
+  `max_length=3`, and the planner instruction states the cap, so the plan never
+  asks for a fourth shot that would be silently dropped.
+- **Why 3?** Each shot becomes a Veo-3 clip, and Veo-3 supports clip durations of
+  **only 4, 6, or 8 seconds**. So 3 shots × {4,6,8}s = **12–24 seconds** of
+  distinct hero footage — squarely a short-form / bumper ad, and comfortably
+  inside the 15s–2m budget ceiling. The planner allocates the per-shot durations
+  to sum near the requested target, up to the 3×8 = 24s hero-footage ceiling; if
+  you ask for longer, it plans to the ceiling and tells you rather than inventing
+  filler shots. Keeping N small also keeps a demo run fast and cheap (three
+  parallel Veo generations is already the heavy part).
+
+This is the honest shape of a static-graph framework meeting a dynamic plan: pick
+a cap you can justify against the real constraints (here, the Veo clip-length
+grid and the duration budget), enforce it in the schema *and* the instruction,
+and make the extra slots degrade gracefully.
+
+**And, as everywhere in this series: verify by existence.** The assembler confirms
+the final `.mp4` with `ffmpeg_get_media_info` and a destination listing — never a
+returned `resource_link`. This matters most here because Veo returns exactly such
+a link that is *not* proof of persistence.
+
+Every server this agent touches carries its own quirks — the explicit Veo-3 model
+(the default falls back to a Veo-2 model that rejects audio), Lyria's dropped
+params and global-only default, avtool needing real inputs + ffmpeg with the
+output extension selecting the container, and the gemini TTS 800-char cap. Those
+quirks live *inside the reused personas' instructions* (that's the point of
+reuse), and the naming crosswalk that spans all of them is
+[`../NAMING.md`](../NAMING.md) — this is the agent that exercises the whole
+crosswalk.
+
+## See also
+
+- **[`countdown-workflow`](../../../../countdown-workflow/)** — a Python pipeline
+  that does the same end-to-end job on another surface: script → Nano Banana
+  first-frames → continuous Veo clips → validate/select → compose with music
+  (with Pydantic-validated data structures). This capstone re-expresses that
+  *shape* in ADK primitives (`SequentialAgent` ⊃ `ParallelAgent`, `AgentTool`,
+  `output_schema`); read the workflow for the deeper composition craft. Cited,
+  not forked.
+- **The `story-generator` skill** —
+  [`experiments/mcp-genmedia/skills/story-generator/SKILL.md`](../../../skills/story-generator/SKILL.md).
+  Its "writers room → per-scene generation" shape — and its "Editor's QC Room"
+  self-critique loop — is the storytelling craft behind the planner and the
+  (future, optional) QC stage. Read it for the technique; this agent is an
+  ADK-runnable surface of the same idea. Cited, not forked.
+
+## Next in the series
+
+You've reached the capstone — head back to the [series overview](../README.md)
+to see the whole arc, from a nine-line single-tool agent to this multi-agent ad
+pipeline. From here, the natural extensions (an optional `LoopAgent` QC stage, or
+a second planner profile) build directly on the profile seam and the reuse
+pattern you just saw.

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
@@ -102,7 +102,7 @@ SequentialAgent(name="ad_creative_director_ad", sub_agents=[
     planner,                       # LlmAgent(output_schema=AdPlan, output_key="ad_plan")
     ParallelAgent(name="shots", sub_agents=[shot_1, shot_2, shot_3]),
     audio,                         # LlmAgent(tools=[music_producer_tool])
-    assembler,                     # LlmAgent(tools=[avtool])
+    assembler,                     # LlmAgent(tools=[avtool, trim_audio_to_video_length])
 ])
 root_agent = build_root_agent(AD_PROFILE)   # adk web loads the ad capstone
 ```
@@ -128,9 +128,29 @@ and a voiceover from the plan's `vo_line`s.
 
 **Stage 4 — the assembler** is an `LlmAgent` that wires the **avtool** server
 directly (final video assembly is a new role no crawl persona covers). It
-concatenates the clips, mixes the music bed with the VO, lays that audio over the
-video, and **verifies the final file by existence** (media-info + destination
-listing), never by a returned resource link.
+concatenates the clips, mixes the music bed with the VO, **trims that audio to
+the video's length**, lays it over the video, and **verifies the final file by
+existence** (media-info + destination listing), never by a returned resource
+link. That trim step is the one place this capstone drops below MCP — see
+*Keeping the audio in sync* below for why.
+
+### Keeping the audio in sync (the one local helper)
+
+There is exactly one spot where the assembler does *not* call an MCP tool. The
+reused Music Producer's Lyria bed is a **fixed ~30-second clip** —
+`lyria_generate_music` has no duration parameter — and avtool always mixes with
+`amix=duration=longest` and exposes no `-shortest`/trim option
+([`mcp_handlers.go:485`](../../../mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go)
+in combine, `:1310` in layer). So mixing a 30s bed onto a 20s video and combining
+directly yields a **~30s file** whose last ~10s is audio over a frozen/black
+tail. Since modifying the shared avtool server is out of scope for this example,
+the assembler fills the gap with a tiny local helper,
+`trim_audio_to_video_length` — a plain Python function ADK auto-wraps as a
+`FunctionTool` — that shells the already-required `ffprobe`/`ffmpeg` to cut the
+mixed audio to the concatenated-video duration (`-t`) before the final combine.
+It keeps both streams and never touches the video. Real pipelines are full of
+these seams where a managed tool doesn't expose the one flag you need; the honest
+move is a small, well-labelled local step, not pretending the gap isn't there.
 
 ### Reuse, not re-implement (and the co-location dependency)
 
@@ -210,6 +230,16 @@ This is the honest shape of a static-graph framework meeting a dynamic plan: pic
 a cap you can justify against the real constraints (here, the Veo clip-length
 grid and the duration budget), enforce it in the schema *and* the instruction,
 and make the extra slots degrade gracefully.
+
+> **A benign log quirk you may see.** When the shot slots run in parallel, each
+> calls `AgentTool`-wrapped personas that hold stdio `MCPToolset`s, and as those
+> concurrent branches finish you may see teardown noise in the logs —
+> `ConnectionError: MCP session connection lost` or `BrokenResourceError` — as
+> the per-call stdio subprocesses close. It is **harmless**: it is retried and
+> blocks no artifact. `AgentTool` already closes its child runner and MCP
+> sessions correctly ([`tools/agent_tool.py:340`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/tools/agent_tool.py#L340)),
+> so this is not a leak in the wiring — it's a concurrency/teardown artifact of
+> reusing stdio-MCP agents as tools under a `ParallelAgent`. Nothing to fix.
 
 **And, as everywhere in this series: verify by existence.** The assembler confirms
 the final `.mp4` with `ffmpeg_get_media_info` and a destination listing — never a

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/__init__.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
@@ -26,7 +26,7 @@ NOT re-author them.
             shot_1, shot_2, shot_3,    #   each: photoshoot still -> director clip (AgentTool)
         ),
         audio_stage,                   # LlmAgent -> music_producer persona (AgentTool): bed + VO
-        assembler,                     # LlmAgent -> avtool: concat clips + mix + combine, verify
+        assembler,                     # LlmAgent -> avtool: concat + mix + trim-to-video + combine, verify
     )
 
 The engine is built behind `build_root_agent(profile=AD_PROFILE)` (see
@@ -74,10 +74,35 @@ ADK 2.8.0 constructs used here are source-verified against the installed 2.8.0
     reads `session.state["ad_plan"]` (:162) and substitutes `str(value)`; a
     plain (non-`?`) placeholder raises KeyError if absent (:174), which is what
     we want: the planner always runs first, so a missing plan is a real failure.
+
+  * FunctionTool     — tools/function_tool.py:99 (class), :106 (__init__ takes a
+    `func` and reads its docstring as the tool description). A bare callable in
+    an LlmAgent's `tools` list is auto-wrapped in one: llm_agent.py:206-207
+    (`if callable(tool_union): return [FunctionTool(func=tool_union)]`). The
+    assembler uses this for its one local helper (see AUDIO/VIDEO DURATION below).
+
+--------------------------------------------------------------------------------
+AUDIO/VIDEO DURATION — why the assembler has a small local ffmpeg helper.
+The final ad's audio must not run past the visuals. The reused Music Producer's
+Lyria produces a FIXED-length (~30s) music bed — `lyria_generate_music` exposes
+no duration/length parameter (mcp-lyria-go/lyria.go:128-161: only `prompt` +
+model/output params). And avtool's mixing tools always mix with
+`amix=...:duration=longest` and expose NO `-shortest`/`-t`/trim option
+(mcp-avtool-go/mcp_handlers.go:485 in ffmpeg_combine_audio_and_video, :1310 in
+ffmpeg_layer_audio_files), so a 30s bed over a 20s video yields a ~30s file with
+a silent/last-frame tail. Modifying the shared avtool server is out of scope, so
+the assembler fills that gap itself with `trim_audio_to_video_length` below (a
+FunctionTool that shells the already-required ffmpeg/ffprobe — no new dependency)
+and runs it on the mixed audio BEFORE the final combine, so the container tracks
+the VIDEO length. This is the one spot the capstone drops below MCP, and it is a
+deliberate, documented teaching point (README "How it works").
 --------------------------------------------------------------------------------
 """
 
+import json
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -286,6 +311,18 @@ def _build_shot_stage(profile: Profile) -> ParallelAgent:
         )
         for i in range(MAX_SHOTS)
     ]
+    # KNOWN QUIRK (benign, no fix needed): running several shot slots
+    # concurrently, each calling AgentTool-wrapped personas that hold stdio
+    # MCPToolsets, can emit teardown noise in the logs as the parallel branches
+    # finish — e.g. "ConnectionError: MCP session connection lost" /
+    # "BrokenResourceError" as the per-call stdio subprocesses close. It is
+    # harmless: it is retried and blocks no artifact. AgentTool already closes
+    # its child runner and MCP sessions correctly (tools/agent_tool.py:340,
+    # "Clean up runner resources (especially MCP sessions)"), so this is NOT a
+    # leak in our wiring — it is a concurrency/teardown artifact of the
+    # AgentTool-over-stdio-MCP reuse pattern. Because AgentTool always builds its
+    # own child runner regardless of the outer runner, it is not specific to the
+    # headless InMemoryRunner. Documented in the README so learners aren't alarmed.
     return ParallelAgent(
         name="shots",
         description=(
@@ -348,8 +385,97 @@ def _build_audio_stage(profile: Profile) -> LlmAgent:
 
 
 # ============================================================================
-# Stage 4 — the assembler (LlmAgent wiring avtool directly)
+# Stage 4 — the assembler (LlmAgent wiring avtool + one local ffmpeg helper)
 # ============================================================================
+def _ffprobe_duration_seconds(media_path: str) -> float:
+    """Return a media file's duration in seconds via ffprobe (float)."""
+    out = subprocess.run(
+        [
+            "ffprobe", "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1",
+            media_path,
+        ],
+        capture_output=True, text=True, check=True,
+    )
+    return float(out.stdout.strip())
+
+
+def trim_audio_to_video_length(
+    audio_path: str, video_path: str, output_path: str
+) -> str:
+    """Trim an audio file so it is no longer than a video, writing a new audio file.
+
+    Use this on the MIXED music+VO track BEFORE combining it with the video, so
+    the finished ad's audio does not run past the visuals. It is needed because
+    the reused Lyria music bed is a fixed ~30s clip (no duration parameter) and
+    avtool mixes with `amix=duration=longest` and offers no `-shortest`/trim, so
+    without this step a 20s ad becomes a ~30s file with a silent/last-frame tail.
+
+    The video is never modified. If the audio is already shorter than the video,
+    it is left as-is (nothing to trim).
+
+    Args:
+      audio_path: local path to the mixed audio (music bed + VO) to trim.
+      video_path: local path to the concatenated video whose duration is the target.
+      output_path: local path to write the trimmed audio to (e.g.
+        ./output/ad_mix_fit.m4a). The extension selects the container.
+
+    Returns:
+      A human-readable status string with the video duration, the original and
+      the resulting audio durations, and the output path (verify by existence).
+    """
+    for tool in ("ffprobe", "ffmpeg"):
+        if shutil.which(tool) is None:
+            return (
+                f"ERROR: '{tool}' is not on PATH. ffmpeg and ffprobe are required "
+                "for assembly (see the project prerequisites)."
+            )
+    for label, p in (("audio", audio_path), ("video", video_path)):
+        if not os.path.isfile(p):
+            return f"ERROR: {label} file not found at '{p}'. Pass the verified path from the earlier step."
+
+    try:
+        video_dur = _ffprobe_duration_seconds(video_path)
+        audio_dur = _ffprobe_duration_seconds(audio_path)
+    except (subprocess.CalledProcessError, ValueError) as exc:
+        return f"ERROR: could not read media duration with ffprobe: {exc}"
+
+    if audio_dur <= video_dur + 0.05:
+        return (
+            f"No trim needed: audio {audio_dur:.2f}s <= video {video_dur:.2f}s. "
+            f"Use '{audio_path}' as the audio input to the final combine."
+        )
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    # -t caps the OUTPUT to the video duration: the video is untouched and the
+    # audio is cut at video length, so the combined container tracks the video.
+    try:
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", audio_path, "-t", f"{video_dur:.3f}",
+             "-c:a", "aac", output_path],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        return f"ERROR: ffmpeg trim failed: {exc.stderr or exc}"
+
+    if not os.path.isfile(output_path):
+        return f"ERROR: expected trimmed audio at '{output_path}' but it was not written."
+    try:
+        new_dur = _ffprobe_duration_seconds(output_path)
+    except (subprocess.CalledProcessError, ValueError):
+        new_dur = video_dur
+    return (
+        f"Trimmed audio to the video length. video={video_dur:.2f}s, "
+        f"audio was {audio_dur:.2f}s, now {new_dur:.2f}s. "
+        f"Use '{output_path}' as the audio input to the final combine (verified: file exists)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The assembler wires the avtool server (LlmAgent tool orchestration) plus the
+# one local helper above.
+# ---------------------------------------------------------------------------
 # The assembler is the capstone's OWN new role (no crawl persona covers final
 # video assembly), so it wires the avtool server directly with the video tools
 # the Music Producer's audio-only avtool filter deliberately hides. avtool is
@@ -405,12 +531,23 @@ Call `ffmpeg_layer_audio_files` with `input_audio_uris` = [music bed, VO],
 sit above the bed, you may lower the bed with a volume step, but a straight mix
 is fine for the reference.
 
-# 3. Lay the mixed audio over the video -> the final ad
+# 3. Trim the mixed audio to the VIDEO length (so the audio doesn't run long)
+The Lyria music bed is a fixed ~30s clip and avtool mixes with
+`amix=duration=longest`, so the mixed audio from step 2 is usually LONGER than
+the video from step 1 — combining them directly would leave the ad's audio
+playing over a frozen/black tail. Before combining, call the
+`trim_audio_to_video_length` tool with `audio_path` = the mixed audio (step 2),
+`video_path` = the concatenated video (step 1), and
+`output_path="./output/ad_mix_fit.m4a"`. Use its returned audio path as the
+audio input to the next step (it tells you whether it trimmed or no trim was
+needed). This keeps BOTH streams and never modifies the video.
+
+# 4. Lay the (fitted) audio over the video -> the final ad
 Call `ffmpeg_combine_audio_and_video` with `input_video_uri` = the concatenated
-video from step 1, `input_audio_uri` = the mixed audio from step 2,
+video from step 1, `input_audio_uri` = the fitted audio from step 3,
 `output_filename="final_ad.mp4"`, `output_local_dir="./output"`.
 
-# 4. VERIFY the final ad by existence — never a resource_link
+# 5. VERIFY the final ad by existence — never a resource_link
 Confirm final_ad.mp4 really exists and is within the duration budget: call
 `ffmpeg_get_media_info` on it and report its duration, and tell the user to list
 the destination (e.g. `ls -l ./output/final_ad.mp4`, or
@@ -429,11 +566,16 @@ def _build_assembler(profile: Profile) -> LlmAgent:
         model=MODEL,
         name="assembler",
         description=(
-            "Concatenates the per-shot clips, mixes music + VO, lays the audio "
-            "over the video via avtool, and verifies the final ad by existence."
+            "Concatenates the per-shot clips, mixes music + VO, trims the audio "
+            "to the video length, lays it over the video via avtool, and verifies "
+            "the final ad by existence."
         ),
         instruction=ASSEMBLER_INSTRUCTION,
-        tools=[assembler_avtool],
+        # avtool MCPToolset for the transform steps, plus one local ffmpeg helper
+        # (a bare callable ADK auto-wraps in a FunctionTool: llm_agent.py:206-207)
+        # that fills avtool's missing audio-trim; see the AUDIO/VIDEO DURATION note
+        # in the module docstring.
+        tools=[assembler_avtool, trim_audio_to_video_length],
     )
 
 

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
@@ -417,8 +417,9 @@ def trim_audio_to_video_length(
     Args:
       audio_path: local path to the mixed audio (music bed + VO) to trim.
       video_path: local path to the concatenated video whose duration is the target.
-      output_path: local path to write the trimmed audio to (e.g.
-        ./output/ad_mix_fit.m4a). The extension selects the container.
+      output_path: local path to write the trimmed AAC audio to — use an
+        .m4a/.mp4 container (the audio is re-encoded with -c:a aac); e.g.
+        ./output/ad_mix_fit.m4a.
 
     Returns:
       A human-readable status string with the video duration, the original and

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
@@ -99,7 +99,6 @@ deliberate, documented teaching point (README "How it works").
 --------------------------------------------------------------------------------
 """
 
-import json
 import os
 import shutil
 import subprocess

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
@@ -1,0 +1,467 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ad creative-director's assistant — the capstone (run tier).
+
+A brand brief + a target duration (15s-2m) in; one assembled short video ad out.
+This is the series' "real multi-agent app": a top-level `SequentialAgent` spine
+wrapping a `ParallelAgent` per-shot fan-out, that REUSES the crawl personas you
+already shipped (Photoshoot, Director, Music Producer) via `AgentTool` — it does
+NOT re-author them.
+
+    SequentialAgent(
+        planner,                       # LlmAgent + output_schema=AdPlan -> state["ad_plan"]
+        shot_stage = ParallelAgent(    # MAX_SHOTS fixed slots, run concurrently
+            shot_1, shot_2, shot_3,    #   each: photoshoot still -> director clip (AgentTool)
+        ),
+        audio_stage,                   # LlmAgent -> music_producer persona (AgentTool): bed + VO
+        assembler,                     # LlmAgent -> avtool: concat clips + mix + combine, verify
+    )
+
+The engine is built behind `build_root_agent(profile=AD_PROFILE)` (see
+profiles.py) so a future audience is purely additive; THIS PR ships the `ad`
+profile only, and `root_agent = build_root_agent(AD_PROFILE)` so `adk web` shows
+the ad capstone by default.
+
+--------------------------------------------------------------------------------
+ADK 2.8.0 constructs used here are source-verified against the installed 2.8.0
+(== tag v2.8.0 of github.com/google/adk-python). file:line citations:
+
+  * SequentialAgent  — agents/sequential_agent.py:83 (class); runs its
+    sub_agents IN ORDER: `for i in range(start_index, len(self.sub_agents))`
+    at :111, sharing one session (state passes via output_key). NOTE it is
+    @deprecated in 2.8.0 (:79 "in favor of Workflow") but Workflow "cannot yet
+    be used as an LlmAgent sub-agent", so it remains the correct construct and
+    is what the merged walk-tier agent already ships.
+
+  * ParallelAgent    — agents/parallel_agent.py:230 (class; @deprecated at :226,
+    same caveat as above). Its sub_agents list is STATIC — `_run_async_impl`
+    iterates `self.sub_agents` (:266); there is no runtime fan-out to a plan's
+    shot count. Sub-agents run CONCURRENTLY via asyncio.TaskGroup
+    (`_merge_agent_run` :82, :122) and SHARE session state: each branch ctx is a
+    shallow `model_copy()` of the invocation context (:50 in
+    `_create_branch_ctx_for_sub_agent` :44) that only changes `branch`, so the
+    session (and its `state`) is the same object across branches. -> the fixed
+    MAX_SHOTS design below, and each slot reading `shots[i]` if present.
+
+  * AgentTool        — tools/agent_tool.py:109. Wraps an agent so another agent
+    can call it as a tool. `run_async` builds its OWN Runner +
+    InMemorySessionService (:264) and seeds the child session with a copy of the
+    caller's state (:285), so calling the SAME wrapped persona object from
+    several concurrent shot slots is isolated (no state clobber).
+
+  * output_schema    — agents/llm_agent.py:404 (field), :415 (docstring). ADK
+    validates the final reply against it (`validate_schema` at :1044) and writes
+    the result to `state[output_key]` (:1045). For a Pydantic BaseModel the
+    stored value is a dict (utils/_schema_utils.py:141-142). The planner has
+    NO tools and NO sub_agents — it is a leaf — so the schema enforcement is
+    unambiguous; it just emits a validated plan into state.
+
+  * output_key       — agents/llm_agent.py:419 (field); write at :1045.
+
+  * {ad_plan} templating — utils/instructions_utils.py:133 (`_replace_match`)
+    reads `session.state["ad_plan"]` (:162) and substitutes `str(value)`; a
+    plain (non-`?`) placeholder raises KeyError if absent (:174), which is what
+    we want: the planner always runs first, so a missing plan is a real failure.
+--------------------------------------------------------------------------------
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from google.adk.agents import LlmAgent, ParallelAgent, SequentialAgent
+from google.adk.tools.agent_tool import AgentTool
+from google.adk.tools.mcp_tool.mcp_toolset import (
+    MCPToolset,
+    StdioConnectionParams,
+    StdioServerParameters,
+)
+
+from .profiles import AD_PROFILE, Profile
+from .schemas import MAX_SHOTS
+
+load_dotenv()
+
+# Set this to a Gemini model you have access to on your Vertex backend.
+# gemini-3.8-flash is served in the GLOBAL region, so keep
+# GOOGLE_CLOUD_LOCATION="global" in your .env (see .env.example). The default
+# Lyria model reused via the Music Producer persona is also global-only.
+MODEL = "gemini-3.8-flash"
+
+project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+# Forward the whole environment to the stdio server, adding PROJECT_ID only when
+# it is set. Env values must be strings — passing PROJECT_ID=None (which happens
+# when GOOGLE_CLOUD_PROJECT is unset) raises TypeError when the subprocess
+# launches, so we guard rather than pass None. Same guarded pattern as the crawl
+# agents. (Only the assembler below wires its own MCPToolset directly; the shot
+# and audio stages reuse the crawl personas, which each build their own
+# server_env exactly like this.)
+server_env = dict(os.environ)
+if project_id:
+    server_env["PROJECT_ID"] = project_id
+
+
+# --- REUSE, not re-implement: import the merged crawl personas ---------------
+# The capstone COMPOSES the crawl agents; it does not re-author them. Each crawl
+# agent is its own self-contained uv project (a sibling directory), NOT a
+# published library, and the merged sibling projects have no [build-system] in
+# their pyproject.toml — so we cannot add them as uv path dependencies without
+# modifying merged code we don't own. Instead we put each sibling PROJECT dir on
+# sys.path (they all live under the shared series root) and import the persona's
+# `root_agent`. Importing does NOT launch any MCP server — MCPToolset connects
+# lazily on first tool use — so this is cheap and side-effect-free at import.
+#
+# CO-LOCATION DEPENDENCY (by design, documented in README): because this capstone
+# composes its siblings, it REQUIRES the sibling example dirs to be present at
+# their series paths. Paths are computed from __file__ (never cwd), the insert is
+# idempotent, and a missing sibling fails LOUD with an actionable message — a
+# reader who copied only this dir gets help, not an opaque ImportError.
+_SERIES_ROOT = Path(__file__).resolve().parents[2]
+for _sibling in ("photoshoot", "director-videographer", "music-producer"):
+    _project_dir = _SERIES_ROOT / _sibling
+    if not _project_dir.is_dir():
+        raise RuntimeError(
+            "ad-creative-director is the capstone: it COMPOSES the crawl "
+            f"personas and needs the sibling example project '{_sibling}/' at "
+            f"{_project_dir}, but that directory is missing. Check out the whole "
+            "adk-genmedia-series/ (photoshoot/, director-videographer/, "
+            "music-producer/ next to ad-creative-director/), not just this "
+            "folder. See this project's README, section 'How it works'."
+        )
+    if str(_project_dir) not in sys.path:
+        sys.path.insert(0, str(_project_dir))
+
+from photoshoot.agent import root_agent as photoshoot_agent  # noqa: E402
+from director_videographer.agent import root_agent as director_agent  # noqa: E402
+from music_producer.agent import root_agent as music_producer_agent  # noqa: E402
+
+# Wrap each persona as a callable tool. AgentTool(name=agent.name), so the tool
+# names the LLM sees are "photoshoot", "director_videographer", "music_producer".
+# These wrappers are stateless config, safe to share across the parallel shot
+# slots (each call gets its own isolated Runner + session; see the header).
+photoshoot_tool = AgentTool(agent=photoshoot_agent)
+director_tool = AgentTool(agent=director_agent)
+music_producer_tool = AgentTool(agent=music_producer_agent)
+
+
+# ============================================================================
+# Stage 1 — the planner (LlmAgent + output_schema, NO tools, NO sub_agents)
+# ============================================================================
+# The construct-level half of the planner instruction. The tone/audience half is
+# the profile's `planner_persona`, appended below — that is the only per-profile
+# difference in the planner. Note there are NO `{...}` templates here: the
+# planner is the FIRST stage and reads the user's brief directly.
+PLANNER_BASE = f"""\
+You are the creative director for a short video ad. Turn the user's brand brief
+and target duration into a duration-budgeted shot plan. You emit a STRUCTURED
+plan only — you do not call any tools; later stages generate the media from your
+plan.
+
+# The duration budget (respect it precisely)
+- The finished ad must be between 15 and 120 seconds (15s-2m).
+- You have AT MOST {MAX_SHOTS} hero shots. This is a hard cap: the shot stage has
+  exactly {MAX_SHOTS} parallel slots, so a {MAX_SHOTS + 1}th shot would be
+  silently dropped. Use fewer shots for a short bumper; never exceed {MAX_SHOTS}.
+- Each shot becomes a Veo-3 clip, and Veo-3 supports clip durations of ONLY
+  4, 6, or 8 seconds. So every shot's `duration_seconds` MUST be 4, 6, or 8.
+- Allocate the per-shot durations so their SUM is as close as possible to the
+  requested target, up to the hero-footage ceiling of {MAX_SHOTS} x 8 =
+  {MAX_SHOTS * 8}s. If the user asks for longer than {MAX_SHOTS * 8}s, plan to
+  the {MAX_SHOTS * 8}s ceiling and tell the user this reference capstone caps
+  hero footage at {MAX_SHOTS} shots — do NOT invent extra shots to pad the time.
+
+# What each shot needs
+For every shot provide: `look` (still art-direction — subject, composition,
+lens, light, mood), `motion` (camera/subject motion for the clip), `vo_line`
+(one spoken line), and `duration_seconds` (4, 6, or 8). Keep the combined
+voiceover concise: all `vo_line`s together should be well under ~800 characters
+(the TTS cap the audio stage honors). Also give the ad a `brand`,
+`total_duration_seconds`, and a `music_mood` for the score.
+
+Return ONLY the plan as JSON matching the required schema — no preamble.
+"""
+
+
+def _build_planner(profile: Profile) -> LlmAgent:
+    return LlmAgent(
+        model=MODEL,
+        name="creative_director",
+        description=(
+            "Turns a brand brief + target duration into a schema-validated, "
+            "duration-budgeted shot plan (AdPlan) in state['ad_plan']."
+        ),
+        instruction=PLANNER_BASE + profile.planner_persona,
+        # output_schema makes the reply a schema-validated JSON plan; output_key
+        # lands it in state['ad_plan'] for the downstream stages to read.
+        output_schema=profile.plan_schema,
+        output_key="ad_plan",
+    )
+
+
+# ============================================================================
+# Stage 2 — the shot stage (ParallelAgent with MAX_SHOTS fixed slots)
+# ============================================================================
+# ADK's ParallelAgent has a STATIC sub_agents list (see header), so we build
+# exactly MAX_SHOTS shot slots up front. Each slot reads its own shot index from
+# the shared plan and no-ops if the plan has fewer shots. All slots run
+# concurrently and share session state.
+def _shot_slot_instruction(index: int) -> str:
+    # human-friendly 1-based number for prose, 0-based index for array access
+    human = index + 1
+    return f"""\
+You are the unit that produces HERO SHOT {human} of a short video ad. The
+creative director's plan is injected below from session state:
+
+<ad_plan>
+{{ad_plan}}
+</ad_plan>
+
+# 1. Find YOUR shot
+Read the plan's `shots` list (0-indexed) and take element [{index}] — that is
+YOUR shot ({human}). If the list has fewer than {human} shots, then this slot
+has no work: say "shot {human}: no shot in plan" and STOP without calling any
+tool. Do NOT borrow another slot's shot and do NOT invent one.
+
+# 2. Generate the still, then the clip (reuse the crawl personas as tools)
+You do not generate media yourself — you delegate to two persona tools, in order:
+
+a) `photoshoot` tool — hand it YOUR shot's `look` as a shot description and ask
+   it to produce ONE still and save it LOCALLY under ./output with a predictable
+   name like `shot-{human:02d}.png` (pass output_directory="./output"). The
+   photoshoot persona art-directs, calls nanobanana, and verifies the file by
+   existence. Capture the exact local path it reports.
+
+b) `director_videographer` tool — hand it YOUR shot's `motion` plus the still
+   from step (a) and ask for an image-to-video (i2v) clip of exactly YOUR shot's
+   `duration_seconds` seconds. IMPORTANT constraints to pass through so the clip
+   actually renders (the director persona enforces them, but state them):
+     - veo_i2v needs the starting image as a gs:// URI, so if your still is
+       local, ask the director to use it as the visual reference / first frame;
+       if only text motion is available, veo_t2v is acceptable.
+     - An explicit Veo-3 model is REQUIRED (the default falls back to a Veo-2
+       model that rejects audio and errors). The director defaults to
+       veo-3.1-fast-generate-001; keep that unless the plan implies 9:16 (still
+       a Veo-3.1 model).
+     - duration must be YOUR shot's `duration_seconds` (one of 4/6/8).
+   Veo writes to GCS; capture the exact gs:// URI the director verified by
+   LISTING the destination (never a bare resource_link).
+
+# 3. Report
+End with two labelled lines for shot {human}:
+  shot {human} still -> <local path> (verified)
+  shot {human} clip  -> <gs:// URI> (verified)
+If either step could not be verified, say so plainly for shot {human} — do not
+fabricate a path or URI.
+"""
+
+
+def _build_shot_stage(profile: Profile) -> ParallelAgent:
+    # profile.shot_media == "clips" for the ad profile: still (photoshoot) then
+    # clip (director) per slot. Kept on the Profile so a future stills-only
+    # audience is a one-line change, not a graph rewrite.
+    shot_slots = [
+        LlmAgent(
+            model=MODEL,
+            name=f"shot_{i + 1}",
+            description=(
+                f"Produces hero shot {i + 1}: a still (photoshoot) then a clip "
+                f"(director), reading shots[{i}] from the plan; no-ops if absent."
+            ),
+            instruction=_shot_slot_instruction(i),
+            tools=[photoshoot_tool, director_tool],
+        )
+        for i in range(MAX_SHOTS)
+    ]
+    return ParallelAgent(
+        name="shots",
+        description=(
+            f"Runs {MAX_SHOTS} per-shot slots concurrently; each turns its plan "
+            "shot into a verified still + clip by reusing the crawl personas."
+        ),
+        sub_agents=shot_slots,
+    )
+
+
+# ============================================================================
+# Stage 3 — the audio stage (LlmAgent reusing the Music Producer persona)
+# ============================================================================
+AUDIO_INSTRUCTION = """\
+You are the audio department for a short video ad. The creative director's plan
+is injected below:
+
+<ad_plan>
+{ad_plan}
+</ad_plan>
+
+Produce TWO audio artifacts for the ad by delegating to the `music_producer`
+persona tool (it wires lyria for music and gemini TTS for voice, and verifies
+each file by existence):
+
+# 1. The music bed
+Ask `music_producer` to generate a music bed matching the plan's `music_mood`,
+saved LOCALLY under ./output (e.g. bed.mp3). Reuse the persona as-is — it knows
+the lyria quirks (global-only default model; negative_prompt/seed/sample_count
+are silently ignored; give it a local destination so a file is actually written).
+
+# 2. The voiceover (VO)
+Concatenate the plan's per-shot `vo_line`s, in shot order, into ONE continuous
+narration script and ask `music_producer` to generate the VO from it, saved
+LOCALLY under ./output (e.g. vo.wav). The gemini TTS tool caps `text` at 800
+characters — if the combined narration exceeds that, tell the user to shorten
+the VO lines rather than truncating silently. You want the VO as its OWN file;
+you do NOT need the persona's mixed output here (the assembler mixes music and
+VO against the video in the next stage).
+
+# 3. Report
+End with two labelled lines, each with the concrete verified local path:
+  music bed -> <local path> (verified)
+  voiceover -> <local path> (verified)
+If either could not be verified, say so plainly — do not fabricate a path.
+"""
+
+
+def _build_audio_stage(profile: Profile) -> LlmAgent:
+    return LlmAgent(
+        model=MODEL,
+        name="audio",
+        description=(
+            "Reuses the Music Producer persona to produce a music bed (from the "
+            "plan's music_mood) and a VO (from the plan's vo_lines) as files."
+        ),
+        instruction=AUDIO_INSTRUCTION,
+        tools=[music_producer_tool],
+    )
+
+
+# ============================================================================
+# Stage 4 — the assembler (LlmAgent wiring avtool directly)
+# ============================================================================
+# The assembler is the capstone's OWN new role (no crawl persona covers final
+# video assembly), so it wires the avtool server directly with the video tools
+# the Music Producer's audio-only avtool filter deliberately hides. avtool is
+# TRANSFORM-ONLY: every tool needs input files and needs ffmpeg + ffprobe on
+# PATH. tool_filter matches BASE tool names, verified verbatim against the Go
+# source (mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go):
+#   ffmpeg_concatenate_media_files  :652  (concat the per-shot clips)
+#   ffmpeg_layer_audio_files        :1158 (mix music bed + VO)
+#   ffmpeg_combine_audio_and_video  :367  (lay the mixed audio over the video)
+#   ffmpeg_get_media_info           :57   (verify the final container/duration)
+assembler_avtool = MCPToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-avtool-go",
+            env=server_env,
+        ),
+        timeout=300,
+    ),
+    tool_filter=[
+        "ffmpeg_concatenate_media_files",
+        "ffmpeg_layer_audio_files",
+        "ffmpeg_combine_audio_and_video",
+        "ffmpeg_get_media_info",
+    ],
+)
+
+
+ASSEMBLER_INSTRUCTION = """\
+You are the video editor who assembles the final ad. The creative director's
+plan is injected below for reference (shot order, total duration):
+
+<ad_plan>
+{ad_plan}
+</ad_plan>
+
+The shot stage produced one verified clip per shot (in GCS) and the audio stage
+produced a verified music bed and a verified VO (local). The exact paths/URIs
+are in the conversation above — read them from there; do NOT guess names.
+
+avtool is TRANSFORM-ONLY (it needs real input files and ffmpeg/ffprobe on PATH),
+so feed it the concrete paths the earlier stages reported. The output filename
+EXTENSION selects the container, so use .mp4 for the video and .m4a/.mp3 for
+audio. Assemble in this order:
+
+# 1. Concatenate the clips -> one video
+Call `ffmpeg_concatenate_media_files` with `input_media_uris` = the per-shot clip
+URIs IN SHOT ORDER, `output_filename="ad_video.mp4"`, and
+`output_local_dir="./output"` (or `output_gcs_bucket` if the user wants GCS).
+
+# 2. Mix the music bed + VO -> one audio track
+Call `ffmpeg_layer_audio_files` with `input_audio_uris` = [music bed, VO],
+`output_filename="ad_mix.m4a"`, `output_local_dir="./output"`. If the VO should
+sit above the bed, you may lower the bed with a volume step, but a straight mix
+is fine for the reference.
+
+# 3. Lay the mixed audio over the video -> the final ad
+Call `ffmpeg_combine_audio_and_video` with `input_video_uri` = the concatenated
+video from step 1, `input_audio_uri` = the mixed audio from step 2,
+`output_filename="final_ad.mp4"`, `output_local_dir="./output"`.
+
+# 4. VERIFY the final ad by existence — never a resource_link
+Confirm final_ad.mp4 really exists and is within the duration budget: call
+`ffmpeg_get_media_info` on it and report its duration, and tell the user to list
+the destination (e.g. `ls -l ./output/final_ad.mp4`, or
+`gcloud storage ls <gs URI>` for GCS). A tool returning successfully or a bare
+resource_link is NOT proof — the destination listing / media info IS. If the
+final file cannot be verified, say so plainly; do not claim success.
+
+End with the concrete verified path/URI of the final ad and its measured
+duration, and confirm it fits the 15s-2m budget.
+"""
+
+
+def _build_assembler(profile: Profile) -> LlmAgent:
+    # profile.assembler_recipe == "video_ad_concat" for the ad profile.
+    return LlmAgent(
+        model=MODEL,
+        name="assembler",
+        description=(
+            "Concatenates the per-shot clips, mixes music + VO, lays the audio "
+            "over the video via avtool, and verifies the final ad by existence."
+        ),
+        instruction=ASSEMBLER_INSTRUCTION,
+        tools=[assembler_avtool],
+    )
+
+
+# ============================================================================
+# The engine — one factory, the ad profile as default
+# ============================================================================
+def build_root_agent(profile: Profile = AD_PROFILE) -> SequentialAgent:
+    """Build the capstone SequentialAgent for the given profile.
+
+    THIS PR ships the `ad` profile only. The factory seam keeps a future
+    audience (e.g. an editorial storyboard profile) purely additive — no change
+    to this graph shape, just a different Profile passed in.
+    """
+    return SequentialAgent(
+        name=f"ad_creative_director_{profile.name}",
+        description=(
+            "The capstone: a brand brief + target duration -> one assembled "
+            "short video ad, composing the crawl personas via AgentTool."
+        ),
+        sub_agents=[
+            _build_planner(profile),
+            _build_shot_stage(profile),
+            _build_audio_stage(profile),
+            _build_assembler(profile),
+        ],
+    )
+
+
+# `adk web` discovers this module-level `root_agent`. Building with AD_PROFILE
+# means the ad capstone is what loads by default.
+root_agent = build_root_agent(AD_PROFILE)

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The profile seam — a plain-Python dataclass + factory input.
+
+The capstone is built behind `build_root_agent(profile)` (see agent.py) so the
+same engine can later grow a second audience (e.g. an editorial `storyboard`
+profile) without reworking the graph. THIS PR ships the `ad` profile ONLY; the
+README presents "the ad creative-director's assistant" and the seam stays a thin
+internal one-liner, not reader-facing overhead.
+
+DESIGN CONSTRAINT (deliberate): profiles are a **frozen dataclass + factory**,
+using only stable ADK constructor APIs. We do NOT use ADK's `from_config` /
+`AgentConfig` YAML loader: in ADK 2.8.0 `agents/config_agent_utils.py:from_config`
+is decorated BOTH `@deprecated` AND `@experimental(FeatureName.AGENT_CONFIG)`, so
+building the engine on it would schedule a removal into the series.
+"""
+
+from dataclasses import dataclass
+from typing import Type
+
+from pydantic import BaseModel
+
+from .schemas import AdPlan
+
+
+@dataclass(frozen=True)
+class Profile:
+    """Selects what the one engine produces for a given audience.
+
+    Attributes:
+      name: short profile id, used in the root agent's name ("ad").
+      planner_persona: tone/audience prose appended to the shared planner
+        instruction (PLANNER_BASE in agent.py).
+      plan_schema: the planner's `output_schema` (AdPlan for the ad profile).
+      shot_media: what each per-shot slot produces ("clips": still -> Veo clip).
+      assembler_recipe: which avtool assembly the assembler runs
+        ("video_ad_concat": concat clips + mix music/VO + combine).
+    """
+
+    name: str
+    planner_persona: str
+    plan_schema: Type[BaseModel]
+    shot_media: str
+    assembler_recipe: str
+
+
+# The tone/audience half of the planner instruction for the ad profile. The
+# construct-level half (schema fields, duration budget, shot cap) lives in
+# PLANNER_BASE in agent.py so it is shared across any future profile.
+_AD_PLANNER_PERSONA = """\
+
+# Your brief and voice (ad creative director)
+You are an ad creative director. The user gives you a brand brief and a target
+duration; you turn it into a tight, persuasive short video ad. Think like an
+advertiser: a clear through-line, a hero product/benefit, an emotional beat, and
+a crisp call-to-action in the final shot's voiceover. Keep the brand voice
+consistent across shots and make every second earn its place.
+"""
+
+
+AD_PROFILE = Profile(
+    name="ad",
+    planner_persona=_AD_PLANNER_PERSONA,
+    plan_schema=AdPlan,
+    shot_media="clips",
+    assembler_recipe="video_ad_concat",
+)

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
@@ -28,7 +28,6 @@ building the engine on it would schedule a removal into the series.
 """
 
 from dataclasses import dataclass
-from typing import Type
 
 from pydantic import BaseModel
 
@@ -51,7 +50,7 @@ class Profile:
 
     name: str
     planner_persona: str
-    plan_schema: Type[BaseModel]
+    plan_schema: type[BaseModel]
     shot_media: str
     assembler_recipe: str
 

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Schema-validated shot plan for the ad creative-director capstone.
+
+`AdPlan` is the planner's `output_schema`. Giving the planner an `output_schema`
+turns its reply into a schema-validated JSON spine that lands in session state
+(`state["ad_plan"]`) instead of free text — every downstream stage reads a
+guaranteed shape rather than parsing prose.
+
+ADK 2.8.0 write path (source-verified against the installed 2.8.0 —
+tag v2.8.0 of github.com/google/adk-python):
+  - `LlmAgent.output_schema` field: agents/llm_agent.py:404 (docstring :415).
+  - On the final response ADK runs `validate_schema(output_schema, text)` and
+    stores the result under `output_key`:
+    agents/llm_agent.py:1044-1045.
+  - For a Pydantic `type[BaseModel]`, `validate_schema` returns a **dict**
+    (`schema.model_validate_json(json_text).model_dump(exclude_none=True)`):
+    utils/_schema_utils.py:141-142. So `state["ad_plan"]` is a dict, and the
+    `{ad_plan}` instruction template renders it via `str(value)`
+    (utils/instructions_utils.py:162-165).
+
+MAX_SHOTS is intentionally small and FIXED. ADK's `ParallelAgent` has a STATIC
+`sub_agents` list (agents/parallel_agent.py:266 iterates `self.sub_agents`; it
+does not fan out to a runtime shot count), so the shot stage builds exactly
+MAX_SHOTS sub-agents and each reads `shots[i]` if present / no-ops if absent.
+The budget math for MAX_SHOTS is justified in agent.py and the README.
+"""
+
+from pydantic import BaseModel, Field
+
+# Fixed number of per-shot slots the ParallelAgent fans out to. Veo-3 clips are
+# 4, 6, or 8 seconds each (see the Director persona + agent.py budget note), so
+# MAX_SHOTS=3 gives 3 x {4,6,8}s = 12-24s of distinct hero footage — squarely a
+# short-form / bumper ad and comfortably inside the 15s-2m budget ceiling.
+MAX_SHOTS = 3
+
+
+class Shot(BaseModel):
+    """One hero shot: a still (look) that is then animated into a clip (motion)."""
+
+    look: str = Field(
+        description=(
+            "Art-direction for the still: subject, composition, lens, light, "
+            "and mood. This drives the Photoshoot (nanobanana) still."
+        )
+    )
+    motion: str = Field(
+        description=(
+            "Camera and subject motion for the clip: e.g. 'slow dolly-in, "
+            "low-angle'. This drives the Director (Veo) clip from the still."
+        )
+    )
+    vo_line: str = Field(
+        description="The single voiceover line spoken over this shot."
+    )
+    duration_seconds: int = Field(
+        description=(
+            "Length of this shot's clip in seconds. MUST be one of 4, 6, or 8 "
+            "(the durations Veo-3 supports)."
+        )
+    )
+
+
+class AdPlan(BaseModel):
+    """A duration-budgeted plan for one short video ad.
+
+    The sum of `shots[*].duration_seconds` is the assembled ad's hero-footage
+    length; it must respect `total_duration_seconds` and the 15s-2m envelope.
+    """
+
+    brand: str = Field(description="The brand or product the ad is for.")
+    total_duration_seconds: int = Field(
+        description=(
+            "Target length of the finished ad in seconds. Must be within the "
+            "15-120s (15s-2m) budget. The per-shot durations should sum to "
+            "approximately this value, up to the hero-footage ceiling "
+            "(MAX_SHOTS x 8s)."
+        )
+    )
+    music_mood: str = Field(
+        description=(
+            "The mood/genre for the music bed (e.g. 'upbeat indie-pop, warm, "
+            "optimistic'), handed to the Music Producer (lyria) persona."
+        )
+    )
+    shots: list[Shot] = Field(
+        description=(
+            f"The hero shots, in order. AT MOST {MAX_SHOTS} shots — the shot "
+            "stage has a fixed number of parallel slots."
+        ),
+        max_length=MAX_SHOTS,
+    )

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
@@ -38,7 +38,11 @@ MAX_SHOTS sub-agents and each reads `shots[i]` if present / no-ops if absent.
 The budget math for MAX_SHOTS is justified in agent.py and the README.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# The only clip durations Veo-3 supports (see the Director persona + agent.py
+# budget note). Enforced in-schema below so a bad plan fails at validation time.
+VALID_SHOT_DURATIONS = (4, 6, 8)
 
 # Fixed number of per-shot slots the ParallelAgent fans out to. Veo-3 clips are
 # 4, 6, or 8 seconds each (see the Director persona + agent.py budget note), so
@@ -72,6 +76,21 @@ class Shot(BaseModel):
         )
     )
 
+    @field_validator("duration_seconds")
+    @classmethod
+    def _duration_must_be_veo3_supported(cls, v: int) -> int:
+        # Fail-loud at model_validate time: the prose above steers generation,
+        # but this guarantees an out-of-grid duration never reaches Veo. (We
+        # use a validator rather than Literal[4, 6, 8] because integer-enum
+        # response-schema translation is not confirmed honored by the pinned
+        # ADK/genai; the validator is guaranteed to fire.)
+        if v not in VALID_SHOT_DURATIONS:
+            raise ValueError(
+                f"duration_seconds must be one of {VALID_SHOT_DURATIONS} "
+                f"(Veo-3 supported), got {v}"
+            )
+        return v
+
 
 class AdPlan(BaseModel):
     """A duration-budgeted plan for one short video ad.
@@ -82,12 +101,14 @@ class AdPlan(BaseModel):
 
     brand: str = Field(description="The brand or product the ad is for.")
     total_duration_seconds: int = Field(
+        ge=15,
+        le=120,
         description=(
             "Target length of the finished ad in seconds. Must be within the "
             "15-120s (15s-2m) budget. The per-shot durations should sum to "
             "approximately this value, up to the hero-footage ceiling "
             "(MAX_SHOTS x 8s)."
-        )
+        ),
     )
     music_mood: str = Field(
         description=(

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/pyproject.toml
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "ad-creative-director"
+version = "0.1.0"
+description = "ADK run-tier capstone: a brand brief + duration -> one assembled short video ad, composing the crawl personas (Photoshoot/Director/Music Producer) via AgentTool"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "python-dotenv>=1.0",
+    "google-adk[gcp,mcp]>=2.8.0",
+]
+
+# NOTE: the sibling crawl agents (photoshoot/, director-videographer/,
+# music-producer/) are NOT listed as dependencies here. They are self-contained
+# uv example projects, not published/buildable libraries, so they are reused by
+# putting their project dirs on sys.path at import time (see
+# ad_creative_director/agent.py and the README "How it works"). Their only
+# runtime deps — google-adk and python-dotenv — are already provided above, so a
+# single `uv sync` in this project is enough to run the whole capstone, provided
+# the sibling example dirs are present at their series paths.


### PR DESCRIPTION
The series capstone: a brand brief + a target duration (15s–2m) → one assembled short video ad, composing the crawl personas (Photoshoot / Director / Music Producer) you already shipped.

## What it teaches
The "real multi-agent app" tier: a top-level `SequentialAgent` spine wrapping a `ParallelAgent` per-shot fan-out, **reusing** the crawl agents via `AgentTool` (not re-implementing them).

```
SequentialAgent(
  planner,                    # LlmAgent + output_schema=AdPlan -> state["ad_plan"]
  shot_stage=ParallelAgent(   # MAX_SHOTS=3 fixed slots, concurrent
    shot_1, shot_2, shot_3),  #   each: photoshoot still -> director clip (AgentTool)
  audio_stage,                # music_producer persona (AgentTool): music bed + VO
  assembler)                  # avtool directly: concat + mix + combine, verify-by-existence
root_agent = build_root_agent(AD_PROFILE)
```

## Design highlights
- **Profile factory** (`build_root_agent(profile=AD_PROFILE)`): plain-Python frozen dataclass + factory — deliberately NOT ADK `from_config`/`AgentConfig` YAML (both `@deprecated` **and** `@experimental` in 2.8.0). Ships the `ad` profile only; PR-6's `storyboard` profile slots in additively.
- **Schema-validated plan:** the planner is an `LlmAgent(output_schema=AdPlan, output_key="ad_plan")` with **no tools / no sub_agents** → a schema-validated JSON plan lands in state.
- **Static ParallelAgent, bounded shots:** ADK's `ParallelAgent` has a static `sub_agents` list, so the shot stage has exactly `MAX_SHOTS=3` slots; `AdPlan.shots` is capped (Pydantic `max_length` + planner instruction). Budget: 3 × ≤8s Veo-3 clips = ≤24s hero footage, inside the 15s–2m envelope; extra slots degrade gracefully.
- **Genuine reuse:** `AgentTool` wraps the real sibling `root_agent` objects. Siblings are self-contained uv examples (no `[build-system]`), so they're reused via `sys.path` injection of their project dirs (computed from `__file__`, idempotent, **fail-loud** if a sibling dir is missing) — documented as a first-class co-location teaching point in the README, not a hidden hack.
- **Assembler** wires the avtool server directly (final assembly is a new role no persona covers), with a tool_filter for the concat/mix/combine/info tools; verify-by-existence.

## Source-verified against installed ADK 2.8.0 (README links pinned to `/blob/v2.8.0/`)
`SequentialAgent` (sequential_agent.py:83), `ParallelAgent` (parallel_agent.py:230), `AgentTool` (agent_tool.py:109), `output_schema` (llm_agent.py:404, enforce :1044→state_delta :1045), `output_key` (:419).

## Gate (in progress)
Fresh independent review + a captured credentialed run (deterministic recipe: brand brief → schema-valid plan → per-shot stills+clips → music bed + VO → one assembled ad within budget; every artifact verified by existence/destination-listing, never a resource_link).

Through-line row 5 flipped to a live `ready` link. Rebased on current `main`.