### PR TITLE
feat(genkit-go): Tier 1 image-to-clip flow (nanobanana → veo_i2v)

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
@@ -6,20 +6,21 @@ independently reviewable PR. The through-line of the whole series is the
 **Genkit Developer UI and per-turn tracing** — every tier is meant to be *run*,
 then *read* at `http://localhost:4000`.
 
-> **You are here: Tier 0.** This is the minimal "one tool, one generate" program.
-> It is also the Go counterpart to the JavaScript [Nano Banana sample](../genkit/)
-> (see [Related samples](#related-samples)).
+> **You are here: Tier 1.** A two-step `genkit.DefineFlow` that chains
+> `nanobanana` → `veo_i2v` (image → video). It builds directly on **Tier 0**, the
+> minimal "one tool, one generate" program (also the Go counterpart to the
+> JavaScript [Nano Banana sample](../genkit/); see [Related samples](#related-samples)).
 
 ## The series
 
 | Tier | What it adds | Servers/tools | Status |
 |------|--------------|---------------|--------|
-| **0 · `tier0-image/`** | single tool, single `generate` | `nanobanana` | **STABLE** *(this tier)* |
-| 1 · `tier1-flow/` | `DefineFlow`, linear chain | `nanobanana` → `veo_i2v` | STABLE *(future PR)* |
+| 0 · `tier0-image/` | single tool, single `generate` | `nanobanana` | STABLE |
+| **1 · `tier1-video/`** | `DefineFlow`, linear chain | `nanobanana` → `veo_i2v` | **STABLE** *(this tier)* |
 | 2 · `tier2-producer/` | multi-server producer flow | nb → veo → lyria → avtool | STABLE *(future PR)* |
 | 3 · `tier3-preview/` | agents middleware + interrupt | all, partitioned | PREVIEW *(future PR)* |
 
-Only **Tier 0** ships in this PR. It establishes the shared foundation the later
+Tiers land one per PR. They share the foundation Tier 0 established and later
 tiers consume without changes:
 
 ```
@@ -33,7 +34,8 @@ genkit-go/
       quirks.go          QuirksPrompt: the genmedia footguns the LLM cannot see
     verify/
       verify.go          Verify(ctx, dest): confirm output by LISTING, not by trusting the tool result
-  tier0-image/main.go    Tier 0
+  tier0-image/main.go    Tier 0 — single tool, single generate
+  tier1-video/main.go    Tier 1 — DefineFlow: nanobanana -> veo_i2v
 ```
 
 ## Why lead with the Dev UI
@@ -55,10 +57,11 @@ samples, so every tier of this series leads with it.
   rule below).
 - The genmedia server binary. By default it is fetched for you on first run by
   `bin/genmedia-launch` (see [Where the genmedia binary comes from](#where-the-genmedia-binary-comes-from)).
-  Tier 0 needs only `mcp-nanobanana-go`; Tiers 1+ that touch `avtool` will also
-  require **`ffmpeg`/`ffprobe`** on `PATH`.
+  Tier 0 needs `mcp-nanobanana-go`; Tier 1 also uses `mcp-veo-go` (both ship in
+  the same pinned tarball, so no extra install). Tiers 2+ that touch `avtool` will
+  also require **`ffmpeg`/`ffprobe`** on `PATH`.
 
-Environment variables Tier 0 reads:
+Environment variables the tiers read (Tier 1 requires `GENMEDIA_BUCKET` to be `gs://`):
 
 | Variable | Required | Meaning |
 |----------|----------|---------|
@@ -96,6 +99,65 @@ reading Tier 0's one new thing:
 This is what a genmedia tool call looks like from the inside. In the terminal
 you will also see the program's own `verify:` line confirming the image by
 **listing the destination** — which is the point of the next section.
+
+## Run Tier 1, then read the flow trace
+
+Tier 1 wraps two tool calls in one **`genkit.DefineFlow`** named `image-to-clip`.
+The flow runs four steps in a fixed Go order — it is *deterministic*, not
+LLM-sequenced: the flow decides the order; the model only fills in each tool's
+arguments.
+
+```
+generate-image  ->  nanobanana_image_generation writes a still to GCS
+verify-image    ->  LIST the destination: confirm the still, learn its gs:// URI
+generate-video  ->  veo_i2v turns that still into a clip (explicit Veo-3 model)
+verify-video    ->  LIST the destination: confirm the clip
+```
+
+```bash
+cd experiments/mcp-genmedia/sample-agents/genkit-go
+
+export GOOGLE_CLOUD_PROJECT=your-project
+export GENMEDIA_BUCKET=gs://your-bucket/tier1   # must be gs:// for Tier 1 (see below)
+export GOOGLE_CLOUD_LOCATION=us-central1
+
+# Launch the flow under the Dev UI:
+genkit start -- go run ./tier1-video
+```
+
+Pass a custom subject as arguments to change what gets drawn (then animated):
+`genkit start -- go run ./tier1-video "a paper boat on a rain-soaked street"`.
+
+Then open **`http://localhost:4000`**. Tier 1's one new thing is the **flow span**:
+
+- a single **`image-to-clip` flow span** wrapping the whole run, with the four
+  named step spans nested inside it in order;
+- inside `generate-image` and `generate-video`, the **`generate` span** and its
+  nested tool-call span (`nanobanana_nanobanana_image_generation`, then
+  `veo_veo_i2v`) — so you can see the still's `gcs_bucket_uri`, then the clip's
+  `image_uri`/`bucket`/`model` arguments the model chose; and
+- the **GCS write between the two steps**: `verify-image` is where the still's
+  `gs://` URI is confirmed by listing and carried into `veo_i2v` as `image_uri`.
+
+**The flow is the deterministic contract; the trace is the receipt.** The order
+you read in the trace is the order the Go code fixed, every run.
+
+### Two veo footguns Tier 1 bakes in
+
+- **Explicit Veo-3 model.** `veo_i2v` defaults to `veo-2.0-generate-001` when no
+  `model` is passed, and Veo-2 **rejects** `generate_audio=true` (the tool's own
+  default) — so a "minimal" call fails. `QuirksPrompt` tells the model to pass an
+  explicit Veo-3 model; Tier 1 uses `veo-3.1-fast-generate-001`
+  (`veoModel` in `tier1-video/main.go`).
+- **`resource_link`, carried across a step.** The still's real location is learned
+  by **listing** (`verify-image`), never from nanobanana's `resource_link`, and
+  that listed `gs://` URI is what feeds `veo_i2v`. veo then returns its own
+  `resource_link` for the clip, which `verify-video` again confirms by listing.
+
+> **GCS is required for Tier 1.** `veo_i2v` only accepts a `gs://` input image
+> (the server rejects a non-GCS `image_uri`), so `GENMEDIA_BUCKET` must be a
+> `gs://` URI — a local directory works for Tier 0 but cannot carry the still into
+> the video step here. Tier 1 fails fast with a clear message if it is not `gs://`.
 
 ## The `resource_link` rule
 
@@ -143,7 +205,8 @@ download bridge — `StdioConfig.Command` resolves it directly.
 | Genkit Go | `github.com/firebase/genkit/go v1.13.1` | `go.mod` |
 | Go | `go 1.25` | `go.mod` |
 | genmedia release | `v3.18.0` | `internal/genmedia` `DefaultReleaseTag` + `bin/genmedia-launch` `PINNED_TAG` |
-| Orchestrating model | `vertexai/gemini-2.5-flash` | `tier0-image/main.go` `modelName` |
+| Orchestrating model | `vertexai/gemini-2.5-flash` | `tier{0,1}-*/main.go` `modelName` |
+| Veo model (Tier 1) | `veo-3.1-fast-generate-001` | `tier1-video/main.go` `veoModel` |
 
 ## Related samples
 

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify.go
@@ -24,6 +24,7 @@
 package verify
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -104,12 +105,17 @@ func verifyGCS(ctx context.Context, uri string) (Result, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, "gcloud", "storage", "ls", uri)
-	// CombinedOutput so a non-zero exit's diagnostic (on stderr) is available to
-	// tell "nothing there" apart from a real failure (auth/ADC expiry, denied).
-	out, err := cmd.CombinedOutput()
-	if err != nil {
+	// Keep stdout (the object listing) and stderr (diagnostics) in separate
+	// buffers: on success we parse stdout for the found objects without stderr
+	// noise polluting the listing; on failure we inspect stderr for gcloud's
+	// not-found signature to tell "nothing there" apart from a real failure
+	// (auth/ADC expiry, permission denied, network).
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && isGCSNotFound(out) {
+		if errors.As(err, &exitErr) && isGCSNotFound(stderr.Bytes()) {
 			// A non-zero exit whose diagnostic is gcloud's "no objects matched"
 			// signature is a legitimate "not found", not a tooling failure.
 			return res, nil
@@ -117,17 +123,26 @@ func verifyGCS(ctx context.Context, uri string) (Result, error) {
 		// Anything else (auth/permission/network, or a non-exec error) is a real
 		// failure: surface it so the caller does not misread it as "no output".
 		return res, fmt.Errorf("verify: gcloud storage ls %s failed: %w: %s",
-			uri, err, strings.TrimSpace(string(out)))
+			uri, err, strings.TrimSpace(stderr.String()))
 	}
 
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			res.Entries = append(res.Entries, line)
-		}
-	}
+	res.Entries = parseGCSListing(stdout.Bytes())
 	res.Exists = len(res.Entries) > 0
 	return res, nil
+}
+
+// parseGCSListing turns `gcloud storage ls` stdout into the non-empty, trimmed
+// object/prefix lines it reported. Factored out as a pure function so the
+// success-path parsing is unit-testable without shelling to gcloud.
+func parseGCSListing(stdout []byte) []string {
+	var entries []string
+	for _, line := range strings.Split(strings.TrimSpace(string(stdout)), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			entries = append(entries, line)
+		}
+	}
+	return entries
 }
 
 // isGCSNotFound reports whether gcloud's diagnostic output is its
@@ -137,7 +152,7 @@ func verifyGCS(ctx context.Context, uri string) (Result, error) {
 func isGCSNotFound(output []byte) bool {
 	msg := strings.ToLower(string(output))
 	return strings.Contains(msg, "matched no objects") ||
-		strings.Contains(msg, "no url") && strings.Contains(msg, "matched")
+		(strings.Contains(msg, "no url") && strings.Contains(msg, "matched"))
 }
 
 // verifyLocal stats a local path. If it is a directory, its entries are listed.

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify_test.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestIsGCSNotFound is the load-bearing distinction of the shared success gate:
+// a non-zero `gcloud storage ls` exit whose diagnostic is the "nothing is there"
+// signature is a legitimate empty destination (Exists=false, nil error), while
+// any other non-zero exit (auth/ADC expiry, permission denied, network) is a
+// real failure that must be surfaced so a caller never misreads "listing failed"
+// as "the generation produced nothing." This table pins both sides.
+func TestIsGCSNotFound(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		// --- not-found signatures: destination is empty/absent ---
+		{
+			name:   "current gcloud phrasing",
+			output: "ERROR: (gcloud.storage.ls) One or more URLs matched no objects.",
+			want:   true,
+		},
+		{
+			name:   "older tooling phrasing",
+			output: "CommandException: One or more URLs matched no objects.",
+			want:   true,
+		},
+		{
+			name:   "no url ... matched split phrasing",
+			output: "ERROR: (gcloud.storage.ls) The following URL did not match any objects: gs://b/p",
+			want:   false, // "did not match any objects" is not our signature; be conservative
+		},
+		{
+			name:   "no URL matched wording",
+			output: "ERROR: No URL matched the provided prefix.",
+			want:   true,
+		},
+		{
+			name:   "case insensitivity",
+			output: "one or more urls MATCHED NO OBJECTS.",
+			want:   true,
+		},
+
+		// --- real errors: must NOT be swallowed as not-found ---
+		{
+			name:   "auth / ADC expiry",
+			output: "ERROR: (gcloud.storage.ls) Your credentials are invalid. Reauthenticate with `gcloud auth login`.",
+			want:   false,
+		},
+		{
+			name:   "permission denied",
+			output: "ERROR: (gcloud.storage.ls) HTTPError 403: does not have storage.objects.list access to the bucket.",
+			want:   false,
+		},
+		{
+			name:   "bucket does not exist (403/404 style, not our signature)",
+			output: "ERROR: (gcloud.storage.ls) HTTPError 404: The specified bucket does not exist.",
+			want:   false,
+		},
+		{
+			name:   "network failure",
+			output: "ERROR: (gcloud.storage.ls) Could not reach the server. Check your network connection.",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isGCSNotFound([]byte(tc.output)); got != tc.want {
+				t.Errorf("isGCSNotFound(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseGCSListing pins the success-path parsing of `gcloud storage ls`
+// stdout: non-empty trimmed lines become entries, blank lines and surrounding
+// whitespace are dropped, and empty output yields no entries.
+func TestParseGCSListing(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+		want   []string
+	}{
+		{
+			name:   "single object",
+			stdout: "gs://b/p/img.png\n",
+			want:   []string{"gs://b/p/img.png"},
+		},
+		{
+			name:   "multiple objects and a subfolder prefix",
+			stdout: "gs://b/p/a.png\ngs://b/p/vid/\ngs://b/p/b.png\n",
+			want:   []string{"gs://b/p/a.png", "gs://b/p/vid/", "gs://b/p/b.png"},
+		},
+		{
+			name:   "blank lines and stray whitespace are dropped",
+			stdout: "\n  gs://b/p/a.png  \n\n\tgs://b/p/b.png\n \n",
+			want:   []string{"gs://b/p/a.png", "gs://b/p/b.png"},
+		},
+		{
+			name:   "empty output yields no entries",
+			stdout: "",
+			want:   nil,
+		},
+		{
+			name:   "whitespace-only output yields no entries",
+			stdout: "   \n\t\n",
+			want:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseGCSListing([]byte(tc.stdout))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseGCSListing(%q) = %#v, want %#v", tc.stdout, got, tc.want)
+			}
+		})
+	}
+}

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/tier1-video/main.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/tier1-video/main.go
@@ -1,0 +1,316 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command tier1-video is Tier 1 of the Genkit Go genmedia series: a
+// deterministic genkit.DefineFlow that chains TWO genmedia tools in a fixed Go
+// order — nanobanana (text->image) then veo_i2v (image->video) — into one
+// reproducible, traced unit.
+//
+// The flow "image-to-clip" runs four ordered steps:
+//
+//	generate-image  -> nanobanana_image_generation writes a still to GCS
+//	verify-image    -> LIST the destination to confirm the still and learn its gs:// URI
+//	generate-video  -> veo_i2v turns that still into a clip (explicit Veo-3 model)
+//	verify-video    -> LIST the destination to confirm the clip
+//
+// The intermediate image URI is obtained by LISTING (verify-by-listing), never by
+// trusting the tool's resource_link — the same discipline Tier 0 established, now
+// carrying an artifact from one step into the next.
+//
+// Run it with the Dev UI to read the trace:
+//
+//	export GOOGLE_CLOUD_PROJECT=your-project
+//	export GENMEDIA_BUCKET=gs://your-bucket/tier1   # veo_i2v requires a gs:// destination
+//	export GOOGLE_CLOUD_LOCATION=us-central1
+//	genkit start -- go run ./tier1-video
+//
+// then open http://localhost:4000 and read the "image-to-clip" flow span with the
+// two nested generate spans (nanobanana + veo) and the GCS writes between them.
+// See README.md for the full walkthrough.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+
+	"github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/sample-agents/genkit-go/internal/genmedia"
+	"github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify"
+)
+
+// modelName is the Vertex Gemini model that orchestrates the tool calls. Verified
+// against the googlegenai plugin registry (models.go: gemini-2.5-flash, provider
+// "vertexai"). Single-sourced here; bump in one place. Matches Tier 0.
+const modelName = "vertexai/gemini-2.5-flash"
+
+// veoModel is the explicit Veo-3 model passed to veo_i2v. This is load-bearing:
+// with no model the veo server falls back to "veo-2.0-generate-001", which
+// REJECTS generate_audio=true (the default) and the call fails. The quirks prompt
+// tells the model this; naming the id here keeps it single-sourced and greppable.
+const veoModel = "veo-3.1-fast-generate-001"
+
+// Default prompts. A single positional arg (if any) overrides only the image
+// subject; the video prompt is always defaultVideoPrompt (it is
+// subject-agnostic, describing camera/motion rather than content).
+const (
+	defaultImageSubject = "a photorealistic red panda sitting on a moss-covered rock in a misty forest at dawn"
+	defaultVideoPrompt  = "Animate this scene with a slow, gentle camera push-in; drifting mist and subtle movement."
+)
+
+// ClipRequest is the flow input: what to draw, then how to animate it.
+type ClipRequest struct {
+	ImageSubject string `json:"imageSubject"`
+	VideoPrompt  string `json:"videoPrompt"`
+}
+
+// ClipResult is the flow output: the confirmed (verified-by-listing) artifacts.
+type ClipResult struct {
+	ImageDest string `json:"imageDest"` // per-run prefix the still was written to
+	ImageURI  string `json:"imageUri"`  // the confirmed gs:// URI of the still
+	VideoDest string `json:"videoDest"` // per-run prefix the clip was written to
+	VideoURI  string `json:"videoUri"`  // the confirmed gs:// URI of the clip
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatalf("tier1-video: %v", err)
+	}
+}
+
+func run(ctx context.Context) error {
+	project := firstEnv("GOOGLE_CLOUD_PROJECT", "PROJECT_ID")
+	if project == "" {
+		return fmt.Errorf("set GOOGLE_CLOUD_PROJECT (or PROJECT_ID) to your Google Cloud project")
+	}
+	location := firstEnv("GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION")
+	if location == "" {
+		location = "us-central1"
+	}
+
+	// Base destination for both the still and the clip. veo_i2v requires its
+	// input image on GCS (the server rejects a non-gs:// image_uri), so Tier 1
+	// needs a gs:// bucket — unlike Tier 0, a local dir will not carry an image
+	// into the video step.
+	base := os.Getenv("GENMEDIA_BUCKET")
+	if base == "" {
+		return fmt.Errorf("set GENMEDIA_BUCKET to a gs:// URI for the generated still + clip")
+	}
+	if !verify.IsGCS(base) {
+		return fmt.Errorf("GENMEDIA_BUCKET must be a gs:// URI for Tier 1: veo_i2v only accepts a GCS input image (got %q)", base)
+	}
+
+	// Initialize Genkit with the Vertex AI (Gemini) plugin. genkit.Init also wires
+	// the Dev UI / tracing exporter when launched via `genkit start`.
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{
+		ProjectID: project,
+		Location:  location,
+	}))
+
+	// Connect to BOTH genmedia servers over stdio (launched through
+	// bin/genmedia-launch). The shared genmedia package owns the launch wiring;
+	// "veo" resolves to mcp-veo-go via the same interface Tier 0 established.
+	nano, err := genmedia.NewClient(ctx, g, "nanobanana")
+	if err != nil {
+		return fmt.Errorf("connecting to nanobanana MCP server: %w", err)
+	}
+	defer nano.Disconnect()
+
+	veo, err := genmedia.NewClient(ctx, g, "veo")
+	if err != nil {
+		return fmt.Errorf("connecting to veo MCP server: %w", err)
+	}
+	defer veo.Disconnect()
+
+	nanoTools, err := nano.GetActiveTools(ctx, g)
+	if err != nil {
+		return fmt.Errorf("listing nanobanana tools: %w", err)
+	}
+	veoTools, err := veo.GetActiveTools(ctx, g)
+	if err != nil {
+		return fmt.Errorf("listing veo tools: %w", err)
+	}
+	if len(nanoTools) == 0 || len(veoTools) == 0 {
+		return fmt.Errorf("a genmedia server exposed no tools (nanobanana=%d, veo=%d)", len(nanoTools), len(veoTools))
+	}
+	log.Printf("connected: nanobanana=%d tool(s), veo=%d tool(s)", len(nanoTools), len(veoTools))
+
+	// The flow is the reproducible, traced unit. Two generate steps in a fixed Go
+	// order (deterministic — not LLM-sequenced), each giving the LLM only the one
+	// server's tools so the step calls exactly the tool it must. genkit.Init must
+	// run before DefineFlow so the flow registers and shows up in the Dev UI.
+	flow := genkit.DefineFlow(g, "image-to-clip",
+		func(ctx context.Context, req ClipRequest) (ClipResult, error) {
+			// One run id, two sibling per-run subprefixes, so verify-by-listing
+			// confirms THIS run's still and clip, not a leftover from a prior run.
+			id := runID()
+			imageDest := join(base, id, "image")
+			videoDest := join(base, id, "video")
+			log.Printf("run %s: image -> %s ; video -> %s", id, imageDest, videoDest)
+
+			// Step 1: generate the still. RunWithContext so the nanobanana
+			// generate span nests under this named step in the trace.
+			if _, err := genkit.RunWithContext(ctx, "generate-image",
+				func(ctx context.Context) (string, error) {
+					resp, err := genkit.Generate(ctx, g,
+						ai.WithModelName(modelName),
+						ai.WithSystem(genmedia.QuirksPrompt),
+						ai.WithPrompt(fmt.Sprintf(
+							"Generate an image of %s. Use the nanobanana image tool and write it to Google Cloud Storage with gcs_bucket_uri set to %q.",
+							req.ImageSubject, imageDest)),
+						ai.WithTools(genmedia.ToolRefs(nanoTools)...),
+						ai.WithToolChoice(ai.ToolChoiceAuto),
+					)
+					if err != nil {
+						return "", err
+					}
+					return resp.Text(), nil
+				}); err != nil {
+				return ClipResult{}, fmt.Errorf("generate-image: %w", err)
+			}
+
+			// Step 2: verify-by-listing. The still's confirmed gs:// URI (NOT the
+			// resource_link) is what we carry into veo_i2v.
+			imageURI, err := genkit.RunWithContext(ctx, "verify-image",
+				func(ctx context.Context) (string, error) {
+					return confirmOne(ctx, imageDest)
+				})
+			if err != nil {
+				return ClipResult{}, fmt.Errorf("verify-image: %w", err)
+			}
+			log.Printf("verified still: %s", imageURI)
+
+			// Step 3: image -> video with veo_i2v. Pass the confirmed image URI,
+			// an explicit Veo-3 model, and the GCS destination (veo uses "bucket").
+			if _, err := genkit.RunWithContext(ctx, "generate-video",
+				func(ctx context.Context) (string, error) {
+					resp, err := genkit.Generate(ctx, g,
+						ai.WithModelName(modelName),
+						ai.WithSystem(genmedia.QuirksPrompt),
+						ai.WithPrompt(fmt.Sprintf(
+							"Using the veo image-to-video tool (veo_i2v), generate a short video from the input image. "+
+								"Set image_uri to %q. %s "+
+								"Use the Veo-3 model %q and write the output to Google Cloud Storage with bucket set to %q.",
+							imageURI, req.VideoPrompt, veoModel, videoDest)),
+						ai.WithTools(genmedia.ToolRefs(veoTools)...),
+						ai.WithToolChoice(ai.ToolChoiceAuto),
+					)
+					if err != nil {
+						return "", err
+					}
+					return resp.Text(), nil
+				}); err != nil {
+				return ClipResult{}, fmt.Errorf("generate-video: %w", err)
+			}
+
+			// Step 4: verify-by-listing the clip.
+			videoURI, err := genkit.RunWithContext(ctx, "verify-video",
+				func(ctx context.Context) (string, error) {
+					return confirmOne(ctx, videoDest)
+				})
+			if err != nil {
+				return ClipResult{}, fmt.Errorf("verify-video: %w", err)
+			}
+			log.Printf("verified clip: %s", videoURI)
+
+			return ClipResult{
+				ImageDest: imageDest,
+				ImageURI:  imageURI,
+				VideoDest: videoDest,
+				VideoURI:  videoURI,
+			}, nil
+		})
+
+	// Invoke the flow once so `go run ./tier1-video` executes end to end. Under
+	// `genkit start` the same flow is also invocable from the Dev UI.
+	//
+	// Teaching-material caveat: the positional arg is passed as free text into the
+	// model prompt, which can then call tools — i.e. it is a (benign here, local
+	// dev) prompt-injection surface. A production caller should treat any
+	// untrusted input as adversarial: constrain it and/or validate the tool
+	// arguments the model chooses, rather than trusting free text.
+	req := ClipRequest{ImageSubject: defaultImageSubject, VideoPrompt: defaultVideoPrompt}
+	if len(os.Args) > 1 {
+		req.ImageSubject = strings.Join(os.Args[1:], " ")
+	}
+
+	res, err := flow.Run(ctx, req)
+	if err != nil {
+		return err
+	}
+	log.Printf("DONE: still=%s clip=%s", res.ImageURI, res.VideoURI)
+	return nil
+}
+
+// confirmOne verifies an artifact exists at dest by listing it (never by trusting
+// a tool result) and returns the first confirmed entry — the handoff value carried
+// from one flow step to the next. For nanobanana the entry is a leaf object (the
+// still fed to veo_i2v); for veo it is the output subfolder prefix veo writes into
+// (e.g. .../video/<id>/), which is still a valid non-empty listing confirming the
+// clip exists — the success gate is "the destination is non-empty", not the leaf name.
+func confirmOne(ctx context.Context, dest string) (string, error) {
+	result, err := verify.Verify(ctx, dest)
+	if err != nil {
+		return "", fmt.Errorf("verifying %s: %w", dest, err)
+	}
+	log.Printf("verify: %s", result)
+	for _, e := range result.Entries {
+		log.Printf("  - %s", e)
+	}
+	if !result.Exists || len(result.Entries) == 0 {
+		return "", fmt.Errorf("no artifact found at %s — the step did not produce output there", dest)
+	}
+	return result.Entries[0], nil
+}
+
+// join appends per-run segments to a base destination. gs:// URIs join with "/";
+// local paths use the OS separator. The base is normalized (trailing slash
+// trimmed) first. Tier 1 requires gs://, but join handles both for parity with
+// the shared verify helpers.
+func join(base string, segments ...string) string {
+	if verify.IsGCS(base) {
+		return strings.TrimRight(base, "/") + "/" + strings.Join(segments, "/")
+	}
+	return filepath.Join(append([]string{base}, segments...)...)
+}
+
+// runID returns a per-run segment: a UTC timestamp plus a short random suffix so
+// two runs in the same second do not collide.
+func runID() string {
+	ts := time.Now().UTC().Format("20060102-150405")
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ts // timestamp alone is good enough if randomness is unavailable
+	}
+	return ts + "-" + hex.EncodeToString(b[:])
+}
+
+// firstEnv returns the value of the first set (non-empty) environment variable.
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Tier 1 — image-to-clip flow (nanobanana → veo_i2v)

Second example in the Genkit Go genmedia series: a deterministic `genkit.DefineFlow`
that chains two genmedia MCP tools into one traced flow —
**nanobanana** (text→image) → **veo_i2v** (image→video) — showcasing the Dev-UI
trace of a multi-step flow.

### What it demonstrates
- A real `DefineFlow` ("image-to-clip") with 4 named, traced steps: generate-image,
  verify-image, generate-video, verify-video (nested tool spans visible in the Dev UI).
- **resource_link discipline across the chain:** the intermediate still's `gs://` URI
  handed to `veo_i2v.image_uri` comes only from verify-by-listing
  (`internal/verify`), never from the raw tool result. Both steps' success gates are
  verify-by-listing.
- Explicit Veo model `veo-3.1-fast-generate-001` (the server's veo-2.0 fallback rejects
  `generate_audio`); quirk documented in `quirks.go` + README.
- Veo reused through the shared `internal/genmedia` launch interface (no launcher fork).

### Quality
- Independently reviewed → **APPROVE** (0 Critical/Required); all review findings closed out.
- **Live-validated** on a real GCP project: produced an image (1.72 MiB) and a video
  (3.99 MiB), both confirmed by the sample's own verify-by-listing and independent
  `gcloud storage ls`.
- Gates clean: `go build`/`vet`/`gofmt`/`go test` (incl. new `verify_test.go` table
  tests), `go mod tidy` (no-diff), `go mod verify`.
- Requires `mcp-go >= v0.33.0` (already carried from Tier 0; needed to parse the
  `resource_link` content type genmedia tools return).

### Stacking
This PR is **stacked on Tier 0 (#1818)** — its base is `feat/genkit-go-series-tier0`,
so the diff shows only the Tier 1 addition (4 files). **Merge #1818 first.** If #1818
is squash-merged, this branch will be rebased onto `main` before merge.
