### PR TITLE
ADK genmedia series (6/6): Creative Studio — storyboard profile + headless dogfood packager

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
@@ -39,8 +39,9 @@ or demo that does the same job on another surface.
 | 3 | **Three servers, one agent** — [Music Producer](./music-producer/) | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | **ready** |
 | 4 | **Your first pipeline** — [Scriptwriter / Storyboarder](./scriptwriter-storyboarder/) | `SequentialAgent` + `output_key` state passing between agents | **ready** |
 | 5 | **A real multi-agent app** — [Ad creative-director's assistant](./ad-creative-director/) | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | **ready** |
+| 6 | **Dogfood the studio — Creative Studio (storyboard profile)** — [same engine, storyboard profile + headless CLI](./ad-creative-director/#creative-studio--the-storyboard-profile-dogfood) | one engine, two profiles via a plain-Python profile factory; a machine-readable package + versioned `manifest.json` contract over a headless CLI | **ready** |
 
-> Steps 2–5 are being added as the series rolls out; they're listed here so you
+> Steps 2–6 are being added as the series rolls out; they're listed here so you
 > can see the whole arc. Only linked steps are live today.
 
 ## How the series is organized

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.env.example
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.env.example
@@ -17,3 +17,10 @@ GOOGLE_GENAI_USE_VERTEXAI="True"
 # <bucket>/veo_outputs/ when no bucket is named. Stills/audio default to local
 # ./output. Set this to a REAL bucket you own — a placeholder URI will 403.
 GENMEDIA_BUCKET="your-bucket-name"
+
+# (storyboard profile / `python -m ad_creative_director.package` only) The
+# genmedia suite version recorded DETERMINISTICALLY in the package manifest.json.
+# The manifest never lets the LLM author this — set it to the version you
+# installed (the suite's single source of truth is mcp-genmedia-go/VERSION). If
+# unset, the packager falls back to the series-pinned floor (>= v3.18.1).
+GENMEDIA_SUITE_VERSION="3.18.1"

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.gitignore
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/.gitignore
@@ -12,3 +12,5 @@ wheels/
 # Local secrets and generated media
 .env
 output/
+# Storyboard-profile dogfood packages produced by `python -m ad_creative_director.package`
+packages/

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
@@ -335,6 +335,17 @@ source of truth: `mcp-genmedia-go/VERSION`). If unset, the packager falls back t
 the series-pinned floor (`3.18.1`). This value is recorded in the manifest
 **deterministically — never authored by the LLM.**
 
+**One extra sibling.** The storyboard profile reuses PR-4's beat author, so — on
+top of the three siblings the ad capstone needs
+([`photoshoot/`](../photoshoot/), [`director-videographer/`](../director-videographer/),
+[`music-producer/`](../music-producer/)) — it **also** requires
+[`scriptwriter-storyboarder/`](../scriptwriter-storyboarder/) next to this project
+(**four** siblings in total). That import is **lazy**: it happens only when the
+storyboard planner is built, so the ad capstone / `adk web` never needs this
+fourth sibling and its import surface is unchanged. If you run the storyboard CLI
+without `scriptwriter-storyboarder/` present, the planner build **fails loud** with
+a `RuntimeError` naming the missing sibling.
+
 ### Package layout
 
 ```

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
@@ -237,7 +237,7 @@ plain-Python dataclass + factory, **not** ADK's `from_config` / `AgentConfig`
 YAML, which is `@deprecated` *and* `@experimental` in ADK 2.8.0.
 
 The seam is small on purpose. `AD_PROFILE` keeps the existing behavior exactly —
-`shot_media="clips"` (still → Veo clip per shot), `assembler_recipe="clips_audio"`,
+`shot_media="clips"` (still → Veo clip per shot), `assembler_recipe="video_ad_concat"`,
 `plan_schema=AdPlan`, `plan_state_key="ad_plan"`, `emit_package=False` — so
 `root_agent = build_root_agent(AD_PROFILE)` and `adk web` are unchanged.
 `STORYBOARD_PROFILE` flips exactly the fields it must: `plan_schema=StoryboardPlan`,

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
@@ -1,10 +1,21 @@
-# Ad creative-director's assistant — a real multi-agent app
+# Ad creative-director's assistant — a real multi-agent app (+ Creative Studio)
 
-> **The capstone.** This is the last and largest agent in the series. It reuses
-> the same eight-section template as the rest (**What you'll build · What you'll
-> learn · Prerequisites · Run it · How it works · The gotcha this teaches · See
-> also · Next in the series**), but where the earlier agents each wired one or a
-> few tools, this one **composes the agents you already built**.
+> **The capstone — and a small engine.** This is the last and largest agent in
+> the series. It reuses the same eight-section template as the rest (**What
+> you'll build · What you'll learn · Prerequisites · Run it · How it works · The
+> gotcha this teaches · See also · Next in the series**), but where the earlier
+> agents each wired one or a few tools, this one **composes the agents you
+> already built**.
+>
+> It is also **one engine that serves two audiences through a plain-Python
+> profile factory** — `build_root_agent(profile)`:
+> - the **`ad`** profile (the capstone below): a brand brief → one assembled
+>   short video ad. It is the **default** (`root_agent = build_root_agent(AD_PROFILE)`),
+>   so `adk web` loads it unchanged. Read this first — it teaches the graph.
+> - the **`storyboard`** profile ("**Creative Studio**"): an editorial, stills-only
+>   animatic + a machine-readable **package + `manifest.json`**, run through a
+>   **headless CLI**. It is the series' *dogfood* tool ("we built this to write
+>   about itself"). See **[Creative Studio — the storyboard profile](#creative-studio--the-storyboard-profile-dogfood)**.
 
 ## What you'll build
 
@@ -134,23 +145,44 @@ existence** (media-info + destination listing), never by a returned resource
 link. That trim step is the one place this capstone drops below MCP — see
 *Keeping the audio in sync* below for why.
 
-### Keeping the audio in sync (the one local helper)
+### Keeping below MCP honest (the two local helpers)
 
-There is exactly one spot where the assembler does *not* call an MCP tool. The
-reused Music Producer's Lyria bed is a **fixed ~30-second clip** —
-`lyria_generate_music` has no duration parameter — and avtool always mixes with
-`amix=duration=longest` and exposes no `-shortest`/trim option
+There are exactly **two** spots in this engine where an assembler does *not* call
+an MCP tool. Both are the same honest move — a small, well-labelled local
+`ffmpeg`/`ffprobe` step where avtool doesn't expose the one flag you need — and
+both live in `agent.py`, documented at their definitions, right below the avtool
+wiring:
+
+**1. `trim_audio_to_video_length` (the `ad` profile).** The reused Music
+Producer's Lyria bed is a **fixed ~30-second clip** — `lyria_generate_music` has
+no duration parameter — and avtool always mixes with `amix=duration=longest` and
+exposes no `-shortest`/trim option
 ([`mcp_handlers.go:485`](../../../mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go)
 in combine, `:1310` in layer). So mixing a 30s bed onto a 20s video and combining
 directly yields a **~30s file** whose last ~10s is audio over a frozen/black
-tail. Since modifying the shared avtool server is out of scope for this example,
-the assembler fills the gap with a tiny local helper,
-`trim_audio_to_video_length` — a plain Python function ADK auto-wraps as a
-`FunctionTool` — that shells the already-required `ffprobe`/`ffmpeg` to cut the
-mixed audio to the concatenated-video duration (`-t`) before the final combine.
-It keeps both streams and never touches the video. Real pipelines are full of
-these seams where a managed tool doesn't expose the one flag you need; the honest
-move is a small, well-labelled local step, not pretending the gap isn't there.
+tail. Since modifying the shared avtool server is out of scope, the assembler
+fills the gap with a tiny local helper — a plain Python function ADK auto-wraps
+as a `FunctionTool` — that shells the already-required `ffprobe`/`ffmpeg` to cut
+the mixed audio to the concatenated-video duration (`-t`) before the final
+combine. It keeps both streams and never touches the video.
+
+**2. `build_stills_animatic_slideshow` (the `storyboard` profile).** The
+storyboard profile has no Veo clips — it turns the still panels into a slideshow
+video. avtool's tool surface transforms and combines *existing* media
+(`ffmpeg_combine_audio_and_video`, `ffmpeg_layer_audio_files`,
+`ffmpeg_get_media_info`) but has **no "images → timed slideshow" tool**
+([`mcp-avtool-go/mcp_handlers.go`](../../../mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go)
+registers no such handler). So the assembler builds the slideshow with a second
+local helper — same shape as the trim helper — that shells `ffmpeg`'s concat
+demuxer over the panel stills, pacing each panel so the slideshow length matches
+the narration audio, then hands the result back to avtool to mix and combine. And
+because the narration length and the slideshow length still won't match exactly,
+the storyboard assembler **reuses the very same `trim_audio_to_video_length`** to
+trim before the final combine — one trimmer, two profiles.
+
+Real pipelines are full of these seams where a managed tool doesn't expose the one
+flag (or the one operation) you need; the honest move is a small, well-labelled
+local step, not pretending the gap isn't there.
 
 ### Reuse, not re-implement (and the co-location dependency)
 
@@ -195,12 +227,22 @@ project's own dependencies, so a single `uv sync` here runs the whole thing.
 ### The profile seam (one internal line)
 
 The engine is built by `build_root_agent(profile=AD_PROFILE)`. A `Profile` (a
-frozen dataclass in `profiles.py`) selects the planner's persona, the plan schema
-(`AdPlan`), what each shot slot produces, and the assembler recipe. **This project
-ships the `ad` profile only** — the seam is a thin internal factory so the same
-engine can grow a second audience later without reshaping the graph. It is
-deliberately a plain-Python dataclass + factory, **not** ADK's `from_config` /
-`AgentConfig` YAML, which is `@deprecated` *and* `@experimental` in ADK 2.8.0.
+frozen dataclass in `profiles.py`) selects the planner's persona, the plan schema,
+what each shot slot produces, the assembler recipe, and whether the run emits a
+package. **This project ships two profiles** through that one seam — `AD_PROFILE`
+(the capstone above) and `STORYBOARD_PROFILE` (**[Creative
+Studio](#creative-studio--the-storyboard-profile-dogfood)**, below) — so the same
+graph serves two audiences without being reshaped. It is deliberately a
+plain-Python dataclass + factory, **not** ADK's `from_config` / `AgentConfig`
+YAML, which is `@deprecated` *and* `@experimental` in ADK 2.8.0.
+
+The seam is small on purpose. `AD_PROFILE` keeps the existing behavior exactly —
+`shot_media="clips"` (still → Veo clip per shot), `assembler_recipe="clips_audio"`,
+`plan_schema=AdPlan`, `plan_state_key="ad_plan"`, `emit_package=False` — so
+`root_agent = build_root_agent(AD_PROFILE)` and `adk web` are unchanged.
+`STORYBOARD_PROFILE` flips exactly the fields it must: `plan_schema=StoryboardPlan`,
+`shot_media="stills"` (photoshoot only, **no Veo**), `assembler_recipe="stills_animatic"`,
+`plan_state_key="plan"`, `emit_package=True`.
 
 ## The gotcha this teaches
 
@@ -255,6 +297,111 @@ reuse), and the naming crosswalk that spans all of them is
 [`../NAMING.md`](../NAMING.md) — this is the agent that exercises the whole
 crosswalk.
 
+## Creative Studio — the storyboard profile (dogfood)
+
+The **storyboard** profile turns the same engine into a **Creative Studio**: from
+a subject brief it plans a short **editorial storyboard**, generates a **still
+panel** per beat (photoshoot only — **no Veo**), lays a music bed and a narration
+track, assembles a **stills animatic** (`animatic.mp4`), and — the point of this
+profile — emits a **machine-readable package**: a directory of the real media plus
+a versioned `manifest.json` that a downstream tool can consume without ever
+touching the agent's Python.
+
+This is the series' **dogfood** surface — *"we built the studio to write about
+itself."* It runs through a **headless CLI** (no `adk web`), so it is scriptable
+and its output is a stable data contract, not a chat transcript.
+
+### Run it (headless)
+
+```bash
+uv run python -m ad_creative_director.package \
+    --profile storyboard \
+    --brief "A quiet three-panel storyboard for a lighthouse keeper at dawn; \
+hopeful, cinematic, ends on the lit lamp." \
+    --out packages/lighthouse/
+```
+
+- `--brief` takes literal text **or** `@path/to/brief.txt`.
+- `--out` is optional; it defaults to `packages/<slug>-<UTC-timestamp>/`.
+- **Exit code is the contract**: `0` only when **every** expected artifact is
+  verified to exist; **non-zero** if any is missing (and the manifest records
+  `artifacts_verified: false`). **No stubs, ever** — a missing file is a hard
+  failure, not a placeholder. `packages/` is git-ignored.
+
+Prerequisites are the same as the capstone **minus Veo** (the storyboard profile
+never calls `mcp-veo-go`) **plus** the deterministic suite-version pin: set
+`GENMEDIA_SUITE_VERSION` in `.env` to the suite version you installed (single
+source of truth: `mcp-genmedia-go/VERSION`). If unset, the packager falls back to
+the series-pinned floor (`3.18.1`). This value is recorded in the manifest
+**deterministically — never authored by the LLM.**
+
+### Package layout
+
+```
+packages/lighthouse/
+├── manifest.json        # the versioned contract (read this downstream)
+├── plan.json            # the schema-validated planner output (provenance)
+├── shots/
+│   ├── shot-01.png      # one still panel per storyboard beat
+│   ├── shot-02.png
+│   └── shot-03.png
+├── audio/
+│   ├── narration.wav
+│   └── music.mp3
+└── animatic.mp4         # the assembled stills animatic
+```
+
+### The manifest contract (`manifest_version: "1"`)
+
+The manifest is written by a **thin, deterministic, non-LLM packaging function**
+(`build_manifest` in `package.py`) that reads the schema-validated plan from
+session state, derives each expected artifact path from the shot indices and the
+fixed audio/animatic names, and records `verified: <bool>` for each from a real
+`os.path.exists` check against the package dir — **never** from a returned
+`resource_link`. `artifacts_verified` is `true` **only if every listed path
+exists** (an empty plan never verifies). Both `manifest.json` and `plan.json` are
+written even on failure, so a bad run leaves an inspectable record of *which*
+files were missing.
+
+```jsonc
+{
+  "manifest_version": "1",      // bump only on a breaking schema change
+  "profile": "storyboard",
+  "brief": "A quiet three-panel storyboard …",
+  "created": "2026-09-07T12:00:00Z",   // UTC, seconds precision, Z-suffixed
+  "model": "gemini-3.8-flash",         // engine MODEL, for provenance
+  "suite_version": "3.18.1",           // deterministic (GENMEDIA_SUITE_VERSION)
+  "subject": "a lighthouse keeper at dawn",
+  "music_mood": "hopeful, cinematic",
+  "shots": [
+    { "index": 1, "beat": "…", "prompt": "…", "image": "shots/shot-01.png", "verified": true }
+  ],
+  "audio": { "narration": "audio/narration.wav", "music": "audio/music.mp3" },
+  "assembled": "animatic.mp4",
+  "artifacts_verified": true    // AND of every verified flag above
+}
+```
+
+A consumer (see the archivist in **See also**) reads **only** `manifest.json` —
+a stable, versioned data contract — never the agent's internals. `manifest_version`
+is bumped only on a breaking change to this shape.
+
+### How the storyboard profile differs from the capstone
+
+It is the *same graph*; only the profile fields change (see **The profile seam**
+above). Concretely: the planner emits a `StoryboardPlan` (no per-shot duration
+budget — an editorial board, not a duration-budgeted ad) into `state["plan"]`;
+each shot slot produces a **still only** (the photoshoot tool, no director/Veo);
+the assembler runs the `stills_animatic` recipe — it builds the slideshow with the
+local `build_stills_animatic_slideshow` helper, mixes the audio, **reuses
+`trim_audio_to_video_length`** to match the tracks, and combines to `animatic.mp4`
+(see **Keeping below MCP honest** above for both local helpers). And
+`emit_package=True` is what tells the CLI to run the deterministic packager.
+
+The `ad` capstone is untouched by any of this: `root_agent =
+build_root_agent(AD_PROFILE)`, so `adk web` still loads the ad pipeline exactly as
+before.
+
 ## See also
 
 - **[`countdown-workflow`](../../../../countdown-workflow/)** — a Python pipeline
@@ -270,11 +417,24 @@ crosswalk.
   self-critique loop — is the storytelling craft behind the planner and the
   (future, optional) QC stage. Read it for the technique; this agent is an
   ADK-runnable surface of the same idea. Cited, not forked.
+- **Downstream: the archivist (manifest consumer).** The Creative Studio profile
+  exists to be *consumed*, not just watched. A downstream tool — the series'
+  archivist, which assembles blog/marketing posts — reads **only** the
+  [`manifest.json` contract](#the-manifest-contract-manifest_version-1): it runs
+  the CLI (or is handed a finished package dir), then reads the versioned manifest
+  for verified artifact paths and provenance (`profile`, `model`, `suite_version`,
+  `created`). It never imports this agent's Python and never re-implements the
+  pipeline — the dependency is the **stable, versioned data contract over the
+  headless entrypoint**, nothing more. That separation is the whole point of the
+  deterministic packager: the studio can change internally as long as
+  `manifest_version` holds.
 
 ## Next in the series
 
 You've reached the capstone — head back to the [series overview](../README.md)
 to see the whole arc, from a nine-line single-tool agent to this multi-agent ad
-pipeline. From here, the natural extensions (an optional `LoopAgent` QC stage, or
-a second planner profile) build directly on the profile seam and the reuse
-pattern you just saw.
+pipeline. This example already grows a **second** audience on the profile seam —
+the [Creative Studio storyboard profile](#creative-studio--the-storyboard-profile-dogfood)
+and its headless package/manifest dogfood tool. From here, the natural next
+extension (an optional `LoopAgent` QC stage) builds directly on the same profile
+seam and reuse pattern you just saw.

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
@@ -30,9 +30,12 @@ NOT re-author them.
     )
 
 The engine is built behind `build_root_agent(profile=AD_PROFILE)` (see
-profiles.py) so a future audience is purely additive; THIS PR ships the `ad`
-profile only, and `root_agent = build_root_agent(AD_PROFILE)` so `adk web` shows
-the ad capstone by default.
+profiles.py). It ships TWO profiles: the `ad` capstone (default, above) and the
+editorial `storyboard` profile (stills-only, board-paced animatic + package/
+manifest) reached through the headless `package` CLI (see package.py). Both use
+the SAME graph shape; only the per-stage builders branch on the Profile.
+`root_agent = build_root_agent(AD_PROFILE)` so `adk web` shows the ad capstone by
+default, unchanged.
 
 --------------------------------------------------------------------------------
 ADK 2.8.0 constructs used here are source-verified against the installed 2.8.0
@@ -155,16 +158,24 @@ if project_id:
 # idempotent, and a missing sibling fails LOUD with an actionable message — a
 # reader who copied only this dir gets help, not an opaque ImportError.
 _SERIES_ROOT = Path(__file__).resolve().parents[2]
-for _sibling in ("photoshoot", "director-videographer", "music-producer"):
+# The `storyboard` profile (PR-6) reuses PR-4's scriptwriter-storyboarder too, so
+# it is a required sibling of the engine alongside the three the ad profile uses.
+for _sibling in (
+    "photoshoot",
+    "director-videographer",
+    "music-producer",
+    "scriptwriter-storyboarder",
+):
     _project_dir = _SERIES_ROOT / _sibling
     if not _project_dir.is_dir():
         raise RuntimeError(
-            "ad-creative-director is the capstone: it COMPOSES the crawl "
-            f"personas and needs the sibling example project '{_sibling}/' at "
-            f"{_project_dir}, but that directory is missing. Check out the whole "
-            "adk-genmedia-series/ (photoshoot/, director-videographer/, "
-            "music-producer/ next to ad-creative-director/), not just this "
-            "folder. See this project's README, section 'How it works'."
+            "ad-creative-director is the profile-driven engine: it COMPOSES the "
+            f"crawl/walk personas and needs the sibling example project "
+            f"'{_sibling}/' at {_project_dir}, but that directory is missing. "
+            "Check out the whole adk-genmedia-series/ (photoshoot/, "
+            "director-videographer/, music-producer/, scriptwriter-storyboarder/ "
+            "next to ad-creative-director/), not just this folder. See this "
+            "project's README, section 'How it works'."
         )
     if str(_project_dir) not in sys.path:
         sys.path.insert(0, str(_project_dir))
@@ -172,14 +183,25 @@ for _sibling in ("photoshoot", "director-videographer", "music-producer"):
 from photoshoot.agent import root_agent as photoshoot_agent  # noqa: E402
 from director_videographer.agent import root_agent as director_agent  # noqa: E402
 from music_producer.agent import root_agent as music_producer_agent  # noqa: E402
+# REUSE PR-4's beat AUTHOR (the scriptwriter LEAF — text only, output_key=
+# "shot_list"), NOT the storyboarder image half: in the storyboard profile the
+# stills come from the shot stage reusing Photoshoot (addendum §4.4). Importing
+# scriptwriter_storyboarder.agent constructs its SequentialAgent, which sets
+# `scriptwriter.parent_agent` — that is fine: we reuse `scriptwriter` via
+# AgentTool, and AgentTool runs it in its OWN Runner and never adds it to a
+# sub_agents list, so there is no "already has a parent agent" conflict
+# (base_agent.py:704-712 only fires when an agent is added as a sub_agent).
+from scriptwriter_storyboarder.agent import scriptwriter  # noqa: E402
 
 # Wrap each persona as a callable tool. AgentTool(name=agent.name), so the tool
-# names the LLM sees are "photoshoot", "director_videographer", "music_producer".
-# These wrappers are stateless config, safe to share across the parallel shot
-# slots (each call gets its own isolated Runner + session; see the header).
+# names the LLM sees are "photoshoot", "director_videographer", "music_producer",
+# "scriptwriter". These wrappers are stateless config, safe to share across the
+# parallel shot slots (each call gets its own isolated Runner + session; see the
+# header).
 photoshoot_tool = AgentTool(agent=photoshoot_agent)
 director_tool = AgentTool(agent=director_agent)
 music_producer_tool = AgentTool(agent=music_producer_agent)
+scriptwriter_tool = AgentTool(agent=scriptwriter)
 
 
 # ============================================================================
@@ -220,19 +242,72 @@ Return ONLY the plan as JSON matching the required schema — no preamble.
 """
 
 
+# The storyboard planner's construct-level base. Unlike the ad planner it (a)
+# has a TOOL — it REUSES PR-4's scriptwriter to author the editorial beats rather
+# than re-authoring beat planning from scratch — and (b) has NO duration budget
+# (board-paced, addendum §6). `output_schema` (StoryboardPlan) and `tools` are
+# used TOGETHER: ADK exposes the tool during the thought loop and enforces the
+# schema only on the final reply (llm_agent.py:404-418, docstring verbatim: "The
+# ADK supports using output_schema and tools together. It works by exposing tools
+# during the thought loop and enforcing structure only on the final output.").
+# There are NO `{...}` templates here: the planner is the FIRST stage and reads
+# the user's brief directly.
+STORYBOARD_PLANNER_BASE = f"""\
+You are the planner for an editorial storyboard. Turn the user's brief into a
+board-paced storyboard plan of AT MOST {MAX_SHOTS} panels. There is NO ad
+duration budget — the story sets the pace, not a clock.
+
+# Author the beats by REUSING the scriptwriter (do not invent them cold)
+First call the `scriptwriter` tool with the user's brief to get a numbered shot
+list of editorial beats (it returns plain text: Scene / Action / Look per shot).
+Use that as the backbone of your plan — it is the series' walk-tier beat author,
+and reusing it keeps this profile consistent with what the series already taught.
+You MAY tighten or trim it to at most {MAX_SHOTS} panels, but do not discard it
+and re-author from scratch.
+
+# Structure the result into the required plan
+Turn the scriptwriter's beats into the plan: a `subject` (what the storyboard is
+about), a `music_mood` for the bed, and a `shots` list (1..{MAX_SHOTS} panels).
+For EACH panel provide: `beat` (the editorial moment), `prompt` (art-direction
+for the still — subject, composition, lens, light, mood; this drives the
+nanobanana still, there is no motion/clip), and `narration_line` (one neutral,
+explanatory voiceover line). Keep the combined narration concise: all
+`narration_line`s together should be well under ~800 characters (the TTS cap the
+audio stage honors).
+
+Return ONLY the plan as JSON matching the required schema — no preamble.
+"""
+
+
 def _build_planner(profile: Profile) -> LlmAgent:
+    # The storyboard profile reuses PR-4's scriptwriter to author beats and emits
+    # a StoryboardPlan; the ad profile plans clips with no tools (unchanged).
+    if profile.shot_media == "stills":
+        return LlmAgent(
+            model=MODEL,
+            name="storyboard_planner",
+            description=(
+                "Reuses PR-4's scriptwriter to author editorial beats, then "
+                "emits a schema-validated StoryboardPlan into "
+                f"state['{profile.plan_state_key}']."
+            ),
+            instruction=STORYBOARD_PLANNER_BASE + profile.planner_persona,
+            tools=[scriptwriter_tool],
+            output_schema=profile.plan_schema,
+            output_key=profile.plan_state_key,
+        )
     return LlmAgent(
         model=MODEL,
         name="creative_director",
         description=(
             "Turns a brand brief + target duration into a schema-validated, "
-            "duration-budgeted shot plan (AdPlan) in state['ad_plan']."
+            f"duration-budgeted shot plan (AdPlan) in state['{profile.plan_state_key}']."
         ),
         instruction=PLANNER_BASE + profile.planner_persona,
         # output_schema makes the reply a schema-validated JSON plan; output_key
-        # lands it in state['ad_plan'] for the downstream stages to read.
+        # lands it in state[plan_state_key] for the downstream stages to read.
         output_schema=profile.plan_schema,
-        output_key="ad_plan",
+        output_key=profile.plan_state_key,
     )
 
 
@@ -293,10 +368,79 @@ fabricate a path or URI.
 """
 
 
+# ---------------------------------------------------------------------------
+# Stills-only shot slot (storyboard profile). NO director, NO Veo anywhere —
+# addendum §6: the storyboard is a stills board (cheaper/faster/deterministic
+# docs tool). Each slot reuses ONLY the Photoshoot persona and saves its still
+# into the package's shots/ dir with an index-derived name the deterministic
+# packager can predict (shot-0N.png). Reads its panel from state[<plan key>]
+# and the destination dir from state['shots_dir'] (both seeded by the package
+# CLI; see package.py).
+def _stills_slot_instruction(index: int, plan_key: str) -> str:
+    human = index + 1
+    return f"""\
+You are the unit that produces STORYBOARD PANEL {human}. The planner's storyboard
+plan is injected below from session state, and the destination directory for the
+stills is also injected:
+
+<plan>
+{{{plan_key}}}
+</plan>
+
+Save stills into this directory (an absolute path):
+<shots_dir>{{shots_dir}}</shots_dir>
+
+# 1. Find YOUR panel
+Read the plan's `shots` list (0-indexed) and take element [{index}] — that is
+YOUR panel ({human}). If the list has fewer than {human} shots, then this slot
+has no work: say "panel {human}: no shot in plan" and STOP without calling any
+tool. Do NOT borrow another slot's panel and do NOT invent one.
+
+# 2. Generate ONE still (reuse the Photoshoot persona as a tool)
+Call the `photoshoot` tool with YOUR panel's `prompt` as the shot description.
+Tell it to save LOCALLY by passing output_directory="{{shots_dir}}" and
+output_filename="shot-{human:02d}.png" so the file lands at
+{{shots_dir}}/shot-{human:02d}.png with a predictable name. There is NO clip and
+NO video for this profile — do NOT call any director or Veo tool; a still is the
+whole job. The Photoshoot persona art-directs, calls nanobanana, and verifies the
+file by existence. Capture the exact local path it reports.
+
+# 3. Report
+End with one labelled line for panel {human}:
+  panel {human} still -> <local path> (verified)
+If the still could not be verified, say so plainly for panel {human} — do not
+fabricate a path.
+"""
+
+
 def _build_shot_stage(profile: Profile) -> ParallelAgent:
-    # profile.shot_media == "clips" for the ad profile: still (photoshoot) then
-    # clip (director) per slot. Kept on the Profile so a future stills-only
-    # audience is a one-line change, not a graph rewrite.
+    # profile.shot_media selects what each of the MAX_SHOTS fixed slots produces:
+    #   "clips"  -> still (photoshoot) then clip (director): the ad path.
+    #   "stills" -> still ONLY (photoshoot), no director/Veo: the storyboard path.
+    if profile.shot_media == "stills":
+        shot_slots = [
+            LlmAgent(
+                model=MODEL,
+                name=f"panel_{i + 1}",
+                description=(
+                    f"Produces storyboard panel {i + 1}: a still (photoshoot) "
+                    f"only, reading shots[{i}] from the plan; no-ops if absent."
+                ),
+                instruction=_stills_slot_instruction(i, profile.plan_state_key),
+                tools=[photoshoot_tool],
+            )
+            for i in range(MAX_SHOTS)
+        ]
+        return ParallelAgent(
+            name="panels",
+            description=(
+                f"Runs {MAX_SHOTS} per-panel slots concurrently; each turns its "
+                "plan panel into a verified nanobanana still (no clip/Veo)."
+            ),
+            sub_agents=shot_slots,
+        )
+
+    # profile.shot_media == "clips" — the ad path (unchanged from PR-5).
     shot_slots = [
         LlmAgent(
             model=MODEL,
@@ -370,7 +514,60 @@ If either could not be verified, say so plainly — do not fabricate a path.
 """
 
 
+# The storyboard audio stage: same reuse of the Music Producer persona, but it
+# reads a StoryboardPlan (narration_line per panel, not vo_line) and writes the
+# two files into the package's audio/ dir with predictable names the packager can
+# find (music.mp3, narration.wav).
+STORYBOARD_AUDIO_INSTRUCTION = """\
+You are the audio department for an editorial storyboard animatic. The planner's
+storyboard plan is injected below, and the destination directory for the audio:
+
+<plan>
+{plan}
+</plan>
+
+Save audio into this directory (an absolute path):
+<audio_dir>{audio_dir}</audio_dir>
+
+Produce TWO audio artifacts by delegating to the `music_producer` persona tool
+(it wires lyria for music and gemini TTS for voice, and verifies each file by
+existence):
+
+# 1. The music bed
+Ask `music_producer` to generate a music bed matching the plan's `music_mood`,
+saved LOCALLY into {audio_dir} with the name `music.mp3` (lyria writes MP3 on the
+default model; give it a local destination so a file is actually written).
+
+# 2. The narration
+Concatenate the plan's per-panel `narration_line`s, in panel order, into ONE
+continuous explainer narration script and ask `music_producer` to generate it as
+speech, saved LOCALLY into {audio_dir} with the name `narration.wav`. The gemini
+TTS tool caps `text` at 800 characters — if the combined narration exceeds that,
+tell the user to shorten the narration lines rather than truncating silently. You
+want the narration as its OWN file; you do NOT need the persona's mixed output
+(the assembler mixes music and narration against the animatic in the next stage).
+
+# 3. Report
+End with two labelled lines, each with the concrete verified local path:
+  music bed -> {audio_dir}/music.mp3 (verified)
+  narration -> {audio_dir}/narration.wav (verified)
+If either could not be verified, say so plainly — do not fabricate a path.
+"""
+
+
 def _build_audio_stage(profile: Profile) -> LlmAgent:
+    if profile.shot_media == "stills":
+        return LlmAgent(
+            model=MODEL,
+            name="audio",
+            description=(
+                "Reuses the Music Producer persona to produce a music bed (from "
+                "music_mood) and an explainer narration (from the panels' "
+                "narration_lines) as files in the package's audio/ dir."
+            ),
+            instruction=STORYBOARD_AUDIO_INSTRUCTION,
+            tools=[music_producer_tool],
+        )
     return LlmAgent(
         model=MODEL,
         name="audio",
@@ -472,6 +669,121 @@ def trim_audio_to_video_length(
     )
 
 
+def build_stills_animatic_slideshow(
+    image_paths: list[str],
+    output_path: str,
+    narration_audio_path: str = "",
+    seconds_per_image: float = 3.0,
+) -> str:
+    """Build a silent slideshow video (.mp4) from an ordered list of still images.
+
+    This is the storyboard profile's SECOND "one spot below MCP" (the ad profile
+    has one: `trim_audio_to_video_length`). It exists because avtool genuinely has
+    NO stills->video tool: its surface is ffmpeg_get_media_info,
+    ffmpeg_convert_audio_wav_to_mp3, ffmpeg_video_to_gif,
+    ffmpeg_combine_audio_and_video, ffmpeg_overlay_image_on_video,
+    ffmpeg_adjust_volume, ffmpeg_layer_audio_files, and
+    ffmpeg_concatenate_media_files (mcp-avtool-go/mcp_handlers.go:57, 116, 218,
+    367, 532, 1035, 1158, 652) — every one needs existing media as input; none
+    turns a set of PNGs into a timed video. Modifying the shared avtool server is
+    out of scope, so this helper fills the gap by shelling the already-required
+    ffmpeg (no new dependency), and the avtool server still does the audio mix +
+    combine (the established reuse). Documented in the README "one spot below MCP".
+
+    The slideshow is BOARD-PACED: if `narration_audio_path` is given and exists,
+    each image is shown for narration_duration / len(images) seconds so the video
+    length matches the narration (the storyboard has no ad duration budget — the
+    narration sets the pace, addendum §6). Otherwise each image is shown for
+    `seconds_per_image` seconds.
+
+    Args:
+      image_paths: ordered local paths to the still images (shots/shot-01.png …).
+      output_path: local path to write the slideshow .mp4 to, e.g.
+        <package>/slideshow.mp4.
+      narration_audio_path: optional local path to the narration audio; when
+        present its measured duration drives the per-image time (board-pacing).
+      seconds_per_image: fallback per-image duration when no narration is given.
+
+    Returns:
+      A human-readable status string with the resulting video path and duration
+      (verify by existence), or an "ERROR: …" string on any failure (fail-loud;
+      the caller must NOT claim success on an ERROR return).
+    """
+    for tool in ("ffprobe", "ffmpeg"):
+        if shutil.which(tool) is None:
+            return (
+                f"ERROR: '{tool}' is not on PATH. ffmpeg and ffprobe are required "
+                "for the storyboard animatic (see the project prerequisites)."
+            )
+    if not image_paths:
+        return "ERROR: no image paths were given; cannot build a slideshow."
+    for p in image_paths:
+        if not os.path.isfile(p):
+            return f"ERROR: still not found at '{p}'. Pass the verified paths from the panel stage."
+
+    per_image = seconds_per_image
+    if narration_audio_path:
+        if not os.path.isfile(narration_audio_path):
+            return f"ERROR: narration audio not found at '{narration_audio_path}'."
+        try:
+            narration_dur = _ffprobe_duration_seconds(narration_audio_path)
+            if narration_dur > 0:
+                per_image = max(0.5, narration_dur / len(image_paths))
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            return f"ERROR: could not read narration duration with ffprobe: {exc}"
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    # Use the ffmpeg concat demuxer: a temp list naming each image with a
+    # `duration`. The concat demuxer needs the LAST image repeated with no
+    # trailing duration so the final panel is held for its full time. Scale to
+    # even dimensions and force yuv420p so the .mp4 is broadly playable.
+    import tempfile
+
+    list_lines = []
+    for p in image_paths:
+        abs_p = os.path.abspath(p)
+        list_lines.append(f"file '{abs_p}'")
+        list_lines.append(f"duration {per_image:.3f}")
+    # Repeat the last file (concat demuxer quirk) so its duration is honored.
+    list_lines.append(f"file '{os.path.abspath(image_paths[-1])}'")
+    list_text = "\n".join(list_lines) + "\n"
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as list_file:
+        list_file.write(list_text)
+        list_path = list_file.name
+
+    try:
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", list_path,
+                "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
+                "-r", "25", "-pix_fmt", "yuv420p", output_path,
+            ],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        return f"ERROR: ffmpeg slideshow build failed: {exc.stderr or exc}"
+    finally:
+        try:
+            os.unlink(list_path)
+        except OSError:
+            pass
+
+    if not os.path.isfile(output_path):
+        return f"ERROR: expected slideshow at '{output_path}' but it was not written."
+    try:
+        dur = _ffprobe_duration_seconds(output_path)
+    except (subprocess.CalledProcessError, ValueError):
+        dur = per_image * len(image_paths)
+    return (
+        f"Built the silent slideshow at '{output_path}': {len(image_paths)} "
+        f"panels x {per_image:.2f}s = {dur:.2f}s (verified: file exists). Use it "
+        "as the video input to the audio mix + combine steps."
+    )
+
+
 # ---------------------------------------------------------------------------
 # The assembler wires the avtool server (LlmAgent tool orchestration) plus the
 # one local helper above.
@@ -560,8 +872,112 @@ duration, and confirm it fits the 15s-2m budget.
 """
 
 
+# The storyboard assembler wires avtool for the audio mix + combine + info, and
+# has TWO local ffmpeg helpers: build_stills_animatic_slideshow (stills->silent
+# video — avtool has no such tool) and the SAME trim_audio_to_video_length the ad
+# assembler uses (do NOT write a second trimmer). The Lyria bed is a fixed ~30s
+# clip and avtool mixes with amix=duration=longest with no -shortest, so the mixed
+# music+narration must be trimmed to the slideshow length before combining, or the
+# animatic gets a tail over a frozen last panel — the exact trap the ad path hit.
+storyboard_assembler_avtool = MCPToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="mcp-avtool-go",
+            env=server_env,
+        ),
+        timeout=300,
+    ),
+    tool_filter=[
+        "ffmpeg_layer_audio_files",
+        "ffmpeg_combine_audio_and_video",
+        "ffmpeg_get_media_info",
+    ],
+)
+
+
+STILLS_ANIMATIC_INSTRUCTION = """\
+You are the editor who assembles the final editorial ANIMATIC (a stills board set
+to narration + music). The planner's storyboard plan is injected for reference,
+and the package directory where the final file must land:
+
+<plan>
+{plan}
+</plan>
+
+Write the final animatic into this directory (an absolute path):
+<package_dir>{package_dir}</package_dir>
+
+The panel stage produced one verified still per panel (local, named
+shot-01.png, shot-02.png, … under {package_dir}/shots) and the audio stage
+produced a verified music bed ({package_dir}/audio/music.mp3) and a verified
+narration ({package_dir}/audio/narration.wav). The exact paths are in the
+conversation above — read them from there; do NOT guess names.
+
+There is NO Veo clip in this profile — you build the video FROM the stills. Work
+in this order and verify by existence at the end:
+
+# 1. Build the silent slideshow FROM the stills
+Call the `build_stills_animatic_slideshow` tool with `image_paths` = the verified
+still paths IN PANEL ORDER, `output_path="{package_dir}/slideshow.mp4"`, and
+`narration_audio_path="{package_dir}/audio/narration.wav"` (so the slideshow is
+board-paced to the narration length). Use the video path it reports. If it
+returns an ERROR, stop and report it — do not continue.
+
+# 2. Mix the music bed + narration -> one audio track
+Call `ffmpeg_layer_audio_files` with `input_audio_uris` =
+["{package_dir}/audio/music.mp3", "{package_dir}/audio/narration.wav"],
+`output_filename="animatic_mix.m4a"`, `output_local_dir="{package_dir}"`.
+
+# 3. Trim the mixed audio to the SLIDESHOW length
+The Lyria bed is a fixed ~30s clip and avtool mixes with amix=duration=longest,
+so the mixed audio is usually LONGER than the slideshow — combining directly
+leaves audio over a frozen last panel. Call `trim_audio_to_video_length` with
+`audio_path` = the mixed audio (step 2), `video_path` = the slideshow (step 1),
+and `output_path="{package_dir}/animatic_mix_fit.m4a"`. Use its returned audio
+path as the audio input to the next step.
+
+# 4. Lay the (fitted) audio over the slideshow -> the animatic
+Call `ffmpeg_combine_audio_and_video` with `input_video_uri` = the slideshow from
+step 1, `input_audio_uri` = the fitted audio from step 3,
+`output_filename="animatic.mp4"`, `output_local_dir="{package_dir}"`. The final
+file MUST be exactly {package_dir}/animatic.mp4 so the packager can find it.
+
+# 5. VERIFY the animatic by existence — never a resource_link
+Call `ffmpeg_get_media_info` on {package_dir}/animatic.mp4 and report its
+duration, and tell the user to list the destination (e.g.
+`ls -l {package_dir}/animatic.mp4`). A tool returning successfully or a bare
+resource_link is NOT proof — the destination listing / media info IS. If the file
+cannot be verified, say so plainly; do not claim success.
+
+End with the concrete verified path of {package_dir}/animatic.mp4 and its
+measured duration.
+"""
+
+
 def _build_assembler(profile: Profile) -> LlmAgent:
-    # profile.assembler_recipe == "video_ad_concat" for the ad profile.
+    if profile.assembler_recipe == "stills_animatic":
+        return LlmAgent(
+            model=MODEL,
+            name="assembler",
+            description=(
+                "Builds a silent slideshow from the panels' stills, mixes music "
+                "+ narration, trims the audio to the slideshow length, lays it "
+                "over the slideshow via avtool, and verifies animatic.mp4 by "
+                "existence."
+            ),
+            instruction=STILLS_ANIMATIC_INSTRUCTION,
+            # avtool for mix/combine/info, plus TWO local ffmpeg helpers: the new
+            # stills->video slideshow builder and the SAME trim helper the ad
+            # assembler uses (bare callables ADK auto-wraps in FunctionTools:
+            # llm_agent.py:206-207).
+            tools=[
+                storyboard_assembler_avtool,
+                build_stills_animatic_slideshow,
+                trim_audio_to_video_length,
+            ],
+        )
+
+    # profile.assembler_recipe == "video_ad_concat" — the ad path (unchanged).
     return LlmAgent(
         model=MODEL,
         name="assembler",
@@ -583,11 +999,14 @@ def _build_assembler(profile: Profile) -> LlmAgent:
 # The engine — one factory, the ad profile as default
 # ============================================================================
 def build_root_agent(profile: Profile = AD_PROFILE) -> SequentialAgent:
-    """Build the capstone SequentialAgent for the given profile.
+    """Build the engine's SequentialAgent for the given profile.
 
-    THIS PR ships the `ad` profile only. The factory seam keeps a future
-    audience (e.g. an editorial storyboard profile) purely additive — no change
-    to this graph shape, just a different Profile passed in.
+    The same graph shape serves both audiences — only the per-stage builders
+    branch on the Profile's fields (shot_media, assembler_recipe, plan_schema,
+    plan_state_key). `AD_PROFILE` (default) is the ad capstone; `STORYBOARD_PROFILE`
+    is the editorial storyboard/dogfood profile reached via the `package` CLI.
+    `root_agent` below is built with AD_PROFILE, so `adk web` loads the ad
+    capstone unchanged.
     """
     return SequentialAgent(
         name=f"ad_creative_director_{profile.name}",

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
@@ -158,13 +158,17 @@ if project_id:
 # idempotent, and a missing sibling fails LOUD with an actionable message — a
 # reader who copied only this dir gets help, not an opaque ImportError.
 _SERIES_ROOT = Path(__file__).resolve().parents[2]
-# The `storyboard` profile (PR-6) reuses PR-4's scriptwriter-storyboarder too, so
-# it is a required sibling of the engine alongside the three the ad profile uses.
+# These three siblings are what the DEFAULT (ad) profile composes, so they are
+# required at module load: `root_agent = build_root_agent(AD_PROFILE)` imports this
+# module, and `adk web` must construct the ad capstone. The `storyboard` profile
+# ALSO reuses PR-4's scriptwriter-storyboarder, but that sibling is imported LAZILY
+# (only when the storyboard planner is built — see `_load_scriptwriter_tool`), so
+# the ad path's import surface stays byte-identical to PR-5: adk web needs only
+# these three, never scriptwriter-storyboarder.
 for _sibling in (
     "photoshoot",
     "director-videographer",
     "music-producer",
-    "scriptwriter-storyboarder",
 ):
     _project_dir = _SERIES_ROOT / _sibling
     if not _project_dir.is_dir():
@@ -183,25 +187,54 @@ for _sibling in (
 from photoshoot.agent import root_agent as photoshoot_agent  # noqa: E402
 from director_videographer.agent import root_agent as director_agent  # noqa: E402
 from music_producer.agent import root_agent as music_producer_agent  # noqa: E402
-# REUSE PR-4's beat AUTHOR (the scriptwriter LEAF — text only, output_key=
-# "shot_list"), NOT the storyboarder image half: in the storyboard profile the
-# stills come from the shot stage reusing Photoshoot (addendum §4.4). Importing
-# scriptwriter_storyboarder.agent constructs its SequentialAgent, which sets
-# `scriptwriter.parent_agent` — that is fine: we reuse `scriptwriter` via
-# AgentTool, and AgentTool runs it in its OWN Runner and never adds it to a
-# sub_agents list, so there is no "already has a parent agent" conflict
-# (base_agent.py:704-712 only fires when an agent is added as a sub_agent).
-from scriptwriter_storyboarder.agent import scriptwriter  # noqa: E402
 
-# Wrap each persona as a callable tool. AgentTool(name=agent.name), so the tool
-# names the LLM sees are "photoshoot", "director_videographer", "music_producer",
-# "scriptwriter". These wrappers are stateless config, safe to share across the
+# Wrap each ad-profile persona as a callable tool. AgentTool(name=agent.name), so
+# the tool names the LLM sees are "photoshoot", "director_videographer",
+# "music_producer". These wrappers are stateless config, safe to share across the
 # parallel shot slots (each call gets its own isolated Runner + session; see the
-# header).
+# header). The storyboard profile's scriptwriter tool is built lazily in
+# `_load_scriptwriter_tool` so the ad path never imports that sibling.
 photoshoot_tool = AgentTool(agent=photoshoot_agent)
 director_tool = AgentTool(agent=director_agent)
 music_producer_tool = AgentTool(agent=music_producer_agent)
-scriptwriter_tool = AgentTool(agent=scriptwriter)
+
+
+def _load_scriptwriter_tool() -> AgentTool:
+    """Lazily import PR-4's scriptwriter LEAF and wrap it as a callable tool.
+
+    Called ONLY when the storyboard planner is built (`_build_planner`, stills
+    branch), never at module load — so the AD profile's import surface stays
+    byte-identical to PR-5: `adk web` (root_agent = build_root_agent(AD_PROFILE))
+    needs only the three ad siblings above and NOT scriptwriter-storyboarder.
+
+    The storyboard profile REUSES the scriptwriter LEAF (the text beat author,
+    output_key="shot_list"), NOT the storyboarder image half — in this profile the
+    stills come from the shot stage reusing Photoshoot (addendum §4.4). Importing
+    scriptwriter_storyboarder.agent constructs its SequentialAgent, which sets
+    `scriptwriter.parent_agent`; that is fine — AgentTool runs the wrapped agent in
+    its OWN Runner and never adds it to a sub_agents list, so there is no "already
+    has a parent agent" conflict (base_agent.py:704-712 only fires when an agent is
+    added as a sub_agent).
+
+    Fails LOUD (RuntimeError naming the missing sibling) if scriptwriter-
+    storyboarder/ is absent — the storyboard profile's extra co-location
+    requirement, documented in the README's Creative Studio section.
+    """
+    _project_dir = _SERIES_ROOT / "scriptwriter-storyboarder"
+    if not _project_dir.is_dir():
+        raise RuntimeError(
+            "The 'storyboard' profile REUSES PR-4's scriptwriter to author "
+            "editorial beats, so it needs the sibling example project "
+            f"'scriptwriter-storyboarder/' at {_project_dir}, but that directory "
+            "is missing. Check out the whole adk-genmedia-series/ tree next to "
+            "ad-creative-director/. (The AD profile / `adk web` does NOT need this "
+            "sibling.) See this project's README, section 'Creative Studio'."
+        )
+    if str(_project_dir) not in sys.path:
+        sys.path.insert(0, str(_project_dir))
+    from scriptwriter_storyboarder.agent import scriptwriter  # noqa: E402
+
+    return AgentTool(agent=scriptwriter)
 
 
 # ============================================================================
@@ -283,6 +316,10 @@ def _build_planner(profile: Profile) -> LlmAgent:
     # The storyboard profile reuses PR-4's scriptwriter to author beats and emits
     # a StoryboardPlan; the ad profile plans clips with no tools (unchanged).
     if profile.shot_media == "stills":
+        # Build the scriptwriter tool HERE (lazily) — this is the only place the
+        # storyboard profile pulls in the scriptwriter-storyboarder sibling, so the
+        # ad path never imports it (see _load_scriptwriter_tool).
+        scriptwriter_tool = _load_scriptwriter_tool()
         return LlmAgent(
             model=MODEL,
             name="storyboard_planner",
@@ -517,17 +554,21 @@ If either could not be verified, say so plainly — do not fabricate a path.
 # The storyboard audio stage: same reuse of the Music Producer persona, but it
 # reads a StoryboardPlan (narration_line per panel, not vo_line) and writes the
 # two files into the package's audio/ dir with predictable names the packager can
-# find (music.mp3, narration.wav).
-STORYBOARD_AUDIO_INSTRUCTION = """\
+# find (music.mp3, narration.wav). `plan_key` is threaded the way
+# _stills_slot_instruction does it: `{{{plan_key}}}` becomes the state template
+# `{plan}` (for the shipped profile), while `{{audio_dir}}` stays a runtime state
+# template. Resolved text is identical for plan_state_key="plan".
+def _storyboard_audio_instruction(plan_key: str) -> str:
+    return f"""\
 You are the audio department for an editorial storyboard animatic. The planner's
 storyboard plan is injected below, and the destination directory for the audio:
 
 <plan>
-{plan}
+{{{plan_key}}}
 </plan>
 
 Save audio into this directory (an absolute path):
-<audio_dir>{audio_dir}</audio_dir>
+<audio_dir>{{audio_dir}}</audio_dir>
 
 Produce TWO audio artifacts by delegating to the `music_producer` persona tool
 (it wires lyria for music and gemini TTS for voice, and verifies each file by
@@ -535,13 +576,13 @@ existence):
 
 # 1. The music bed
 Ask `music_producer` to generate a music bed matching the plan's `music_mood`,
-saved LOCALLY into {audio_dir} with the name `music.mp3` (lyria writes MP3 on the
+saved LOCALLY into {{audio_dir}} with the name `music.mp3` (lyria writes MP3 on the
 default model; give it a local destination so a file is actually written).
 
 # 2. The narration
 Concatenate the plan's per-panel `narration_line`s, in panel order, into ONE
 continuous explainer narration script and ask `music_producer` to generate it as
-speech, saved LOCALLY into {audio_dir} with the name `narration.wav`. The gemini
+speech, saved LOCALLY into {{audio_dir}} with the name `narration.wav`. The gemini
 TTS tool caps `text` at 800 characters — if the combined narration exceeds that,
 tell the user to shorten the narration lines rather than truncating silently. You
 want the narration as its OWN file; you do NOT need the persona's mixed output
@@ -549,8 +590,8 @@ want the narration as its OWN file; you do NOT need the persona's mixed output
 
 # 3. Report
 End with two labelled lines, each with the concrete verified local path:
-  music bed -> {audio_dir}/music.mp3 (verified)
-  narration -> {audio_dir}/narration.wav (verified)
+  music bed -> {{audio_dir}}/music.mp3 (verified)
+  narration -> {{audio_dir}}/narration.wav (verified)
 If either could not be verified, say so plainly — do not fabricate a path.
 """
 
@@ -565,7 +606,7 @@ def _build_audio_stage(profile: Profile) -> LlmAgent:
                 "music_mood) and an explainer narration (from the panels' "
                 "narration_lines) as files in the package's audio/ dir."
             ),
-            instruction=STORYBOARD_AUDIO_INSTRUCTION,
+            instruction=_storyboard_audio_instruction(profile.plan_state_key),
             tools=[music_producer_tool],
         )
     return LlmAgent(
@@ -895,22 +936,27 @@ storyboard_assembler_avtool = MCPToolset(
 )
 
 
-STILLS_ANIMATIC_INSTRUCTION = """\
+# `plan_key` is threaded the way _stills_slot_instruction does it: `{{{plan_key}}}`
+# becomes the state template `{plan}` (for the shipped profile), while
+# `{{package_dir}}` stays a runtime state template. Resolved text is identical for
+# plan_state_key="plan".
+def _stills_animatic_instruction(plan_key: str) -> str:
+    return f"""\
 You are the editor who assembles the final editorial ANIMATIC (a stills board set
 to narration + music). The planner's storyboard plan is injected for reference,
 and the package directory where the final file must land:
 
 <plan>
-{plan}
+{{{plan_key}}}
 </plan>
 
 Write the final animatic into this directory (an absolute path):
-<package_dir>{package_dir}</package_dir>
+<package_dir>{{package_dir}}</package_dir>
 
 The panel stage produced one verified still per panel (local, named
-shot-01.png, shot-02.png, … under {package_dir}/shots) and the audio stage
-produced a verified music bed ({package_dir}/audio/music.mp3) and a verified
-narration ({package_dir}/audio/narration.wav). The exact paths are in the
+shot-01.png, shot-02.png, … under {{package_dir}}/shots) and the audio stage
+produced a verified music bed ({{package_dir}}/audio/music.mp3) and a verified
+narration ({{package_dir}}/audio/narration.wav). The exact paths are in the
 conversation above — read them from there; do NOT guess names.
 
 There is NO Veo clip in this profile — you build the video FROM the stills. Work
@@ -918,38 +964,38 @@ in this order and verify by existence at the end:
 
 # 1. Build the silent slideshow FROM the stills
 Call the `build_stills_animatic_slideshow` tool with `image_paths` = the verified
-still paths IN PANEL ORDER, `output_path="{package_dir}/slideshow.mp4"`, and
-`narration_audio_path="{package_dir}/audio/narration.wav"` (so the slideshow is
+still paths IN PANEL ORDER, `output_path="{{package_dir}}/slideshow.mp4"`, and
+`narration_audio_path="{{package_dir}}/audio/narration.wav"` (so the slideshow is
 board-paced to the narration length). Use the video path it reports. If it
 returns an ERROR, stop and report it — do not continue.
 
 # 2. Mix the music bed + narration -> one audio track
 Call `ffmpeg_layer_audio_files` with `input_audio_uris` =
-["{package_dir}/audio/music.mp3", "{package_dir}/audio/narration.wav"],
-`output_filename="animatic_mix.m4a"`, `output_local_dir="{package_dir}"`.
+["{{package_dir}}/audio/music.mp3", "{{package_dir}}/audio/narration.wav"],
+`output_filename="animatic_mix.m4a"`, `output_local_dir="{{package_dir}}"`.
 
 # 3. Trim the mixed audio to the SLIDESHOW length
 The Lyria bed is a fixed ~30s clip and avtool mixes with amix=duration=longest,
 so the mixed audio is usually LONGER than the slideshow — combining directly
 leaves audio over a frozen last panel. Call `trim_audio_to_video_length` with
 `audio_path` = the mixed audio (step 2), `video_path` = the slideshow (step 1),
-and `output_path="{package_dir}/animatic_mix_fit.m4a"`. Use its returned audio
+and `output_path="{{package_dir}}/animatic_mix_fit.m4a"`. Use its returned audio
 path as the audio input to the next step.
 
 # 4. Lay the (fitted) audio over the slideshow -> the animatic
 Call `ffmpeg_combine_audio_and_video` with `input_video_uri` = the slideshow from
 step 1, `input_audio_uri` = the fitted audio from step 3,
-`output_filename="animatic.mp4"`, `output_local_dir="{package_dir}"`. The final
-file MUST be exactly {package_dir}/animatic.mp4 so the packager can find it.
+`output_filename="animatic.mp4"`, `output_local_dir="{{package_dir}}"`. The final
+file MUST be exactly {{package_dir}}/animatic.mp4 so the packager can find it.
 
 # 5. VERIFY the animatic by existence — never a resource_link
-Call `ffmpeg_get_media_info` on {package_dir}/animatic.mp4 and report its
+Call `ffmpeg_get_media_info` on {{package_dir}}/animatic.mp4 and report its
 duration, and tell the user to list the destination (e.g.
-`ls -l {package_dir}/animatic.mp4`). A tool returning successfully or a bare
+`ls -l {{package_dir}}/animatic.mp4`). A tool returning successfully or a bare
 resource_link is NOT proof — the destination listing / media info IS. If the file
 cannot be verified, say so plainly; do not claim success.
 
-End with the concrete verified path of {package_dir}/animatic.mp4 and its
+End with the concrete verified path of {{package_dir}}/animatic.mp4 and its
 measured duration.
 """
 
@@ -965,7 +1011,7 @@ def _build_assembler(profile: Profile) -> LlmAgent:
                 "over the slideshow via avtool, and verifies animatic.mp4 by "
                 "existence."
             ),
-            instruction=STILLS_ANIMATIC_INSTRUCTION,
+            instruction=_stills_animatic_instruction(profile.plan_state_key),
             # avtool for mix/combine/info, plus TWO local ffmpeg helpers: the new
             # stills->video slideshow builder and the SAME trim helper the ad
             # assembler uses (bare callables ADK auto-wraps in FunctionTools:

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/package.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/package.py
@@ -1,0 +1,398 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Headless dogfood entrypoint — the `storyboard` profile's package/manifest CLI.
+
+This is the "we built this to write about itself" tool: it runs the storyboard
+profile of the engine HEADLESSLY (no adk web), lets the generation sub-agents
+write real media into a package directory, and then a THIN, DETERMINISTIC,
+NON-LLM packaging function reads the schema-validated plan out of session state,
+re-verifies every expected artifact BY EXISTENCE, and writes a versioned
+`manifest.json` + `plan.json`. The archivist (or any downstream tool) consumes
+ONLY `manifest.json` — a stable, versioned data contract, never the agent's
+Python internals.
+
+    uv run python -m ad_creative_director.package \\
+        --profile storyboard \\
+        --brief "<brief text | @path/to/brief.txt>" \\
+        --out packages/<slug>/         # default packages/<slug>-<UTC-timestamp>/
+
+Exit code: 0 on full success; NON-ZERO if any expected artifact is unverified
+(and the manifest records `artifacts_verified: false`). No stubs, ever — a
+missing file is a hard failure, not a placeholder.
+
+--------------------------------------------------------------------------------
+The ADK 2.8.0 headless-runner API used below is source-verified against the
+installed 2.8.0 (== tag v2.8.0 of github.com/google/adk-python). There is no
+pre-existing `driver.py` in the merged series to copy, so this entrypoint is
+authored from scratch against these APIs:
+
+  * InMemoryRunner  — runners.py:2716 (class), :2729 (__init__): a Runner with
+    in-memory session/artifact/memory services; takes `agent=` and `app_name=`.
+  * Runner.run_async — runners.py:1240: async generator; takes `user_id`,
+    `session_id`, `new_message`, optional `state_delta`; yields Events until the
+    invocation completes.
+  * session_service.create_session — base_session_service.py:70: takes
+    `app_name`, `user_id`, optional `state` (seed dict) and `session_id`. We seed
+    the package/shots/audio dirs here so the sub-agents write predictable names.
+  * session_service.get_session — base_session_service.py:92: read the final
+    session back to pull `state[<plan key>]` (the planner's output_schema plan).
+  * Runner.close — runners.py:2684: closes plugin/MCP resources on exit.
+
+The plan lands in state as a DICT (not the Pydantic object): for a
+`type[BaseModel]` output_schema ADK stores
+`schema.model_validate_json(text).model_dump(exclude_none=True)`
+(utils/_schema_utils.py:141-142; write at llm_agent.py:1044-1045). So the
+deterministic packager below treats `state[plan_key]` as a dict.
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import json
+import os
+import re
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants sourced deterministically (NOT LLM-authored). See --help / the
+# validation recipe.
+# ---------------------------------------------------------------------------
+MANIFEST_VERSION = "1"
+
+# The genmedia suite version recorded in the manifest. Sourced deterministically,
+# never from the LLM: the credentialed runner sets GENMEDIA_SUITE_VERSION to the
+# installed suite's version (the single source of truth is the suite's VERSION
+# file, mcp-genmedia-go/VERSION); if unset we fall back to the series-pinned floor
+# the whole series targets (>= v3.18.1 for muxable Lyria audio). The recipe
+# documents setting the env var so the manifest reflects the ACTUAL suite used.
+SUITE_VERSION_DEFAULT = "3.18.1"
+
+
+def _suite_version() -> str:
+    return os.getenv("GENMEDIA_SUITE_VERSION", SUITE_VERSION_DEFAULT).strip() or (
+        SUITE_VERSION_DEFAULT
+    )
+
+
+def _utc_now_iso() -> str:
+    """UTC timestamp, seconds precision, Z-suffixed (e.g. 2026-09-07T12:00:00Z)."""
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+def _slugify(text: str, max_words: int = 6) -> str:
+    """A filesystem-safe slug from the first few words of the brief."""
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    slug = "-".join(words[:max_words]) if words else "storyboard"
+    return slug or "storyboard"
+
+
+# ===========================================================================
+# The DETERMINISTIC packager (non-LLM). This is the real integration contract.
+# It is deliberately free of any ADK/LLM import so it is unit-testable with a
+# tiny local fixture (see the validation recipe / project log).
+# ===========================================================================
+def build_manifest(
+    plan: dict[str, Any],
+    package_dir: Path,
+    *,
+    profile: str,
+    brief: str,
+    model: str,
+    created: str | None = None,
+    suite_version: str | None = None,
+) -> dict[str, Any]:
+    """Build the versioned manifest dict by VERIFYING each expected file exists.
+
+    Deterministic, non-LLM. Reads the schema-validated plan (a dict), derives the
+    expected artifact paths from the shot indices (shots/shot-0N.png), the fixed
+    audio names, and the assembled animatic, and records `verified: <bool>` for
+    each from an actual `os.path.exists` check against `package_dir` — never a
+    resource_link. `artifacts_verified` is True ONLY if EVERY listed path exists.
+
+    Args:
+      plan: the planner's output (dict) — expects a "shots" list of
+        {beat, prompt, ...} and optional "subject"/"music_mood".
+      package_dir: the package root; all manifest paths are relative to it.
+      profile: the profile name ("storyboard").
+      brief: the original brief text.
+      model: the Gemini model constant used (recorded for provenance).
+      created: UTC timestamp; defaults to now.
+      suite_version: the genmedia suite version; defaults to `_suite_version()`.
+
+    Returns:
+      The manifest dict (manifest_version "1"; see module docstring / addendum
+      §4.2c). The caller writes it to manifest.json.
+    """
+    created = created or _utc_now_iso()
+    suite_version = suite_version or _suite_version()
+    package_dir = Path(package_dir)
+
+    def _exists(rel: str) -> bool:
+        return (package_dir / rel).is_file()
+
+    shots_out: list[dict[str, Any]] = []
+    all_verified = True
+    raw_shots = plan.get("shots") or []
+    for i, shot in enumerate(raw_shots, start=1):
+        rel = f"shots/shot-{i:02d}.png"
+        verified = _exists(rel)
+        all_verified = all_verified and verified
+        shots_out.append(
+            {
+                "index": i,
+                "beat": shot.get("beat", ""),
+                "prompt": shot.get("prompt", ""),
+                "image": rel,
+                "verified": verified,
+            }
+        )
+
+    # An empty plan must NEVER verify true (defense in depth; the StoryboardPlan
+    # schema already enforces min_length=1, but the packager does not trust that).
+    if not shots_out:
+        all_verified = False
+
+    narration_rel = "audio/narration.wav"
+    music_rel = "audio/music.mp3"
+    assembled_rel = "animatic.mp4"
+    narration_ok = _exists(narration_rel)
+    music_ok = _exists(music_rel)
+    assembled_ok = _exists(assembled_rel)
+    all_verified = all_verified and narration_ok and music_ok and assembled_ok
+
+    return {
+        "manifest_version": MANIFEST_VERSION,
+        "profile": profile,
+        "brief": brief,
+        "created": created,
+        "model": model,
+        "suite_version": suite_version,
+        "subject": plan.get("subject", ""),
+        "music_mood": plan.get("music_mood", ""),
+        "shots": shots_out,
+        "audio": {"narration": narration_rel, "music": music_rel},
+        "assembled": assembled_rel,
+        "artifacts_verified": all_verified,
+    }
+
+
+def write_package(
+    plan: dict[str, Any],
+    package_dir: Path,
+    *,
+    profile: str,
+    brief: str,
+    model: str,
+) -> dict[str, Any]:
+    """Write manifest.json + plan.json into the package dir; return the manifest.
+
+    `plan.json` is the schema-validated planner output (provenance). `manifest.json`
+    is the versioned contract the archivist reads. Both are written even when
+    `artifacts_verified` is False, so a failed run leaves an inspectable record of
+    WHICH files were missing (the caller then exits non-zero).
+    """
+    package_dir = Path(package_dir)
+    package_dir.mkdir(parents=True, exist_ok=True)
+    manifest = build_manifest(
+        plan, package_dir, profile=profile, brief=brief, model=model
+    )
+    (package_dir / "plan.json").write_text(
+        json.dumps(plan, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    (package_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+# ===========================================================================
+# The headless run (imports ADK + the engine lazily, so the deterministic
+# packager above stays import-light and unit-testable without ADK installed).
+# ===========================================================================
+def _read_brief(brief_arg: str) -> str:
+    """Resolve --brief: literal text, or @path to read the brief from a file."""
+    if brief_arg.startswith("@"):
+        path = Path(brief_arg[1:]).expanduser()
+        if not path.is_file():
+            raise SystemExit(f"ERROR: --brief file not found: {path}")
+        return path.read_text(encoding="utf-8").strip()
+    return brief_arg.strip()
+
+
+async def _run_storyboard(profile, brief: str, package_dir: Path) -> dict[str, Any]:
+    """Run the storyboard root_agent headlessly and return the plan dict."""
+    # Lazy imports: ADK + the engine are only needed for the live run.
+    from google.genai import types
+    from google.adk.runners import InMemoryRunner
+
+    from .agent import build_root_agent
+
+    shots_dir = package_dir / "shots"
+    audio_dir = package_dir / "audio"
+    for d in (package_dir, shots_dir, audio_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    root_agent = build_root_agent(profile)
+    app_name = "creative_studio"
+    user_id = "cli"
+    session_id = uuid.uuid4().hex
+
+    runner = InMemoryRunner(agent=root_agent, app_name=app_name)
+    try:
+        # Seed the destination dirs into session state so the sub-agents write
+        # predictable, packager-findable names into <out>/shots and <out>/audio.
+        await runner.session_service.create_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+            state={
+                "package_dir": str(package_dir.resolve()),
+                "shots_dir": str(shots_dir.resolve()),
+                "audio_dir": str(audio_dir.resolve()),
+            },
+        )
+        message = types.Content(role="user", parts=[types.Part(text=brief)])
+        async for event in runner.run_async(
+            user_id=user_id, session_id=session_id, new_message=message
+        ):
+            # Surface a light trace so the operator can follow the run.
+            author = getattr(event, "author", None)
+            if author:
+                print(f"[{author}] event", file=sys.stderr)
+
+        session = await runner.session_service.get_session(
+            app_name=app_name, user_id=user_id, session_id=session_id
+        )
+    finally:
+        await runner.close()
+
+    if session is None:
+        raise SystemExit("ERROR: session vanished after the run; cannot package.")
+    plan = session.state.get(profile.plan_state_key)
+    if not isinstance(plan, dict):
+        raise SystemExit(
+            "ERROR: the planner did not write a schema-validated plan to "
+            f"state['{profile.plan_state_key}'] (got {type(plan).__name__}). "
+            "Cannot build a manifest from a missing plan."
+        )
+    return plan
+
+
+def _resolve_profile(name: str):
+    """Map the --profile string to a Profile object (lazy import of the engine)."""
+    from .profiles import AD_PROFILE, STORYBOARD_PROFILE
+
+    profiles = {"ad": AD_PROFILE, "storyboard": STORYBOARD_PROFILE}
+    if name not in profiles:
+        raise SystemExit(f"ERROR: unknown --profile '{name}'.")
+    return profiles[name]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m ad_creative_director.package",
+        description=(
+            "Headless dogfood entrypoint: run the storyboard profile and emit a "
+            "package dir + versioned manifest.json (verified by existence)."
+        ),
+    )
+    parser.add_argument(
+        "--profile",
+        default="storyboard",
+        choices=["ad", "storyboard"],
+        help=(
+            "Which profile to run. The package/manifest contract is the "
+            "storyboard profile's dogfood tool; 'ad' is accepted for symmetry "
+            "but the ad capstone's home is `adk web`."
+        ),
+    )
+    parser.add_argument(
+        "--brief",
+        required=True,
+        help="The brief text, or @path to read it from a file.",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help=(
+            "Output package directory. Defaults to "
+            "packages/<slug>-<UTC-timestamp>/."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.profile != "storyboard":
+        raise SystemExit(
+            "ERROR: only --profile storyboard emits a package/manifest. The 'ad' "
+            "profile's surface is `adk web` (root_agent = AD_PROFILE)."
+        )
+
+    brief = _read_brief(args.brief)
+    if not brief:
+        raise SystemExit("ERROR: --brief is empty.")
+
+    profile = _resolve_profile(args.profile)
+
+    if args.out:
+        package_dir = Path(args.out)
+    else:
+        slug = _slugify(brief)
+        ts = _utc_now_iso().replace(":", "").replace("-", "")
+        package_dir = Path("packages") / f"{slug}-{ts}"
+
+    # Reuse the engine's single MODEL constant for provenance (lazy import).
+    from .agent import MODEL
+
+    plan = asyncio.run(_run_storyboard(profile, brief, package_dir))
+    manifest = write_package(
+        plan, package_dir, profile=profile.name, brief=brief, model=MODEL
+    )
+
+    print(f"\nPackage written to: {package_dir}")
+    print(f"  manifest.json  artifacts_verified={manifest['artifacts_verified']}")
+    for shot in manifest["shots"]:
+        mark = "OK " if shot["verified"] else "MISSING"
+        print(f"  [{mark}] {shot['image']}")
+    for label, rel in (
+        ("narration", manifest["audio"]["narration"]),
+        ("music", manifest["audio"]["music"]),
+        ("animatic", manifest["assembled"]),
+    ):
+        exists = (package_dir / rel).is_file()
+        print(f"  [{'OK ' if exists else 'MISSING'}] {rel} ({label})")
+
+    if not manifest["artifacts_verified"]:
+        print(
+            "\nFAILED: one or more expected artifacts are missing; "
+            "artifacts_verified=false. Exiting non-zero.",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nSUCCESS: every expected artifact verified by existence.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
@@ -14,11 +14,14 @@
 
 """The profile seam — a plain-Python dataclass + factory input.
 
-The capstone is built behind `build_root_agent(profile)` (see agent.py) so the
-same engine can later grow a second audience (e.g. an editorial `storyboard`
-profile) without reworking the graph. THIS PR ships the `ad` profile ONLY; the
-README presents "the ad creative-director's assistant" and the seam stays a thin
-internal one-liner, not reader-facing overhead.
+The engine is built behind `build_root_agent(profile)` (see agent.py) so the
+same graph serves two audiences without reworking it. It ships TWO profiles:
+  * `AD_PROFILE` — the ad creative-director capstone (Veo clips, single final
+    file). It is the DEFAULT: `root_agent = build_root_agent(AD_PROFILE)`, so
+    `adk web` shows the ad capstone unchanged.
+  * `STORYBOARD_PROFILE` — the editorial "Creative Studio" storyboard profile
+    (nanobanana stills, board-paced animatic, package + manifest). It is reached
+    through the headless `package` CLI (see package.py) — the dogfood tool.
 
 DESIGN CONSTRAINT (deliberate): profiles are a **frozen dataclass + factory**,
 using only stable ADK constructor APIs. We do NOT use ADK's `from_config` /
@@ -31,7 +34,7 @@ from dataclasses import dataclass
 
 from pydantic import BaseModel
 
-from .schemas import AdPlan
+from .schemas import AdPlan, StoryboardPlan
 
 
 @dataclass(frozen=True)
@@ -39,13 +42,27 @@ class Profile:
     """Selects what the one engine produces for a given audience.
 
     Attributes:
-      name: short profile id, used in the root agent's name ("ad").
-      planner_persona: tone/audience prose appended to the shared planner
-        instruction (PLANNER_BASE in agent.py).
-      plan_schema: the planner's `output_schema` (AdPlan for the ad profile).
-      shot_media: what each per-shot slot produces ("clips": still -> Veo clip).
-      assembler_recipe: which avtool assembly the assembler runs
-        ("video_ad_concat": concat clips + mix music/VO + combine).
+      name: short profile id, used in the root agent's name ("ad" |
+        "storyboard").
+      planner_persona: tone/audience prose appended to the profile's planner
+        instruction base (see agent.py).
+      plan_schema: the planner's `output_schema` (AdPlan | StoryboardPlan).
+      shot_media: what each per-shot slot produces —
+        "clips": photoshoot still -> Veo clip (director); the ad path.
+        "stills": photoshoot still ONLY (no director, no Veo); the storyboard
+        path (addendum §6: cheaper/faster/deterministic docs tool).
+      assembler_recipe: which assembly the assembler runs —
+        "video_ad_concat": concat clips + mix music/VO + trim + combine (ad).
+        "stills_animatic": stills -> silent slideshow + mix music/narration +
+        trim + combine into animatic.mp4 (storyboard).
+      emit_package: False (ad: single final file) | True (storyboard: a package
+        directory + a machine-readable manifest.json, produced by the headless
+        `package` CLI's deterministic packager — see package.py).
+      plan_state_key: the session-state key the planner writes its schema-
+        validated plan to and every downstream stage reads via `{key}`
+        templating. "ad_plan" for the ad profile (unchanged from PR-5), "plan"
+        for the storyboard profile (the key the addendum §4.2d/§4.4 packager
+        reads).
     """
 
     name: str
@@ -53,6 +70,9 @@ class Profile:
     plan_schema: type[BaseModel]
     shot_media: str
     assembler_recipe: str
+    # Additive fields (defaults preserve the PR-5 AD_PROFILE behavior exactly).
+    emit_package: bool = False
+    plan_state_key: str = "ad_plan"
 
 
 # The tone/audience half of the planner instruction for the ad profile. The
@@ -75,4 +95,33 @@ AD_PROFILE = Profile(
     plan_schema=AdPlan,
     shot_media="clips",
     assembler_recipe="video_ad_concat",
+    # emit_package / plan_state_key left at their defaults (False / "ad_plan"),
+    # so AD_PROFILE is byte-for-byte the PR-5 behavior.
+)
+
+
+# The tone/audience half of the planner instruction for the storyboard profile.
+# The construct-level half (author the beats by REUSING PR-4's scriptwriter, then
+# emit a schema-valid StoryboardPlan) lives in STORYBOARD_PLANNER_BASE in
+# agent.py so any future editorial audience can share it.
+_STORYBOARD_PLANNER_PERSONA = """\
+
+# Your brief and voice (editorial storyboard director)
+You are an editorial/documentary storyboard director for a journalist, marketer,
+or devrel writer (including THIS series, which uses you to illustrate its own
+posts). Your register is explanatory and neutral — you inform, you do not sell.
+There is NO ad duration budget: the board is paced by the story, and the
+narration reads as explainer voiceover, not a brand CTA. Give each panel a clear
+editorial beat, an art-directed still prompt, and one neutral narration line.
+"""
+
+
+STORYBOARD_PROFILE = Profile(
+    name="storyboard",
+    planner_persona=_STORYBOARD_PLANNER_PERSONA,
+    plan_schema=StoryboardPlan,
+    shot_media="stills",
+    assembler_recipe="stills_animatic",
+    emit_package=True,
+    plan_state_key="plan",
 )

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Schema-validated shot plan for the ad creative-director capstone.
+"""Schema-validated shot plans for the profile-driven creative-studio engine.
+
+This module defines the two planner `output_schema`s the engine ships:
+  * `AdPlan` — the `ad` profile (Veo clips, duration-budgeted). Default.
+  * `StoryboardPlan` — the `storyboard` profile (nanobanana stills, board-paced,
+    NO duration budget). See the note above `StoryboardShot` below.
 
 `AdPlan` is the planner's `output_schema`. Giving the planner an `output_schema`
 turns its reply into a schema-validated JSON spine that lands in session state
@@ -38,11 +43,20 @@ MAX_SHOTS sub-agents and each reads `shots[i]` if present / no-ops if absent.
 The budget math for MAX_SHOTS is justified in agent.py and the README.
 """
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # The only clip durations Veo-3 supports (see the Director persona + agent.py
 # budget note). Enforced in-schema below so a bad plan fails at validation time.
 VALID_SHOT_DURATIONS = (4, 6, 8)
+
+# The finished-ad duration envelope (15s-2m). `total_duration_seconds` is bounded
+# to this per-field (ge/le below), and — closing PR-5 review FYI-1 — the SUM of
+# the per-shot `duration_seconds` is bounded to the same envelope by an AdPlan
+# cross-field validator, because per-field bounds alone did not guarantee the
+# aggregate (three legal 8s shots sum to 24s — fine — but three legal 4s shots
+# sum to 12s, which is below the 15s floor even though each shot is valid).
+MIN_TOTAL_DURATION_SECONDS = 15
+MAX_TOTAL_DURATION_SECONDS = 120
 
 # Fixed number of per-shot slots the ParallelAgent fans out to. Veo-3 clips are
 # 4, 6, or 8 seconds each (see the Director persona + agent.py budget note), so
@@ -121,5 +135,102 @@ class AdPlan(BaseModel):
             f"The hero shots, in order. AT MOST {MAX_SHOTS} shots — the shot "
             "stage has a fixed number of parallel slots."
         ),
+        max_length=MAX_SHOTS,
+    )
+
+    @model_validator(mode="after")
+    def _sum_of_shot_durations_in_envelope(self) -> "AdPlan":
+        # Cross-field invariant (closes PR-5 review FYI-1). Each shot's
+        # `duration_seconds` is individually valid (one of 4/6/8) and
+        # `total_duration_seconds` is individually in [15, 120], but neither
+        # guarantees the ASSEMBLED hero-footage length — the sum of the per-shot
+        # durations — lands in the 15s-2m envelope. Enforce it here so a plan
+        # whose shots are each legal but sum out of range fails LOUD at
+        # validation time rather than producing an out-of-budget ad. Runs after
+        # the per-field validators, so `shots` are already grid-valid here.
+        total = sum(shot.duration_seconds for shot in self.shots)
+        if not (
+            MIN_TOTAL_DURATION_SECONDS <= total <= MAX_TOTAL_DURATION_SECONDS
+        ):
+            raise ValueError(
+                "the sum of the per-shot duration_seconds must be within "
+                f"[{MIN_TOTAL_DURATION_SECONDS}, {MAX_TOTAL_DURATION_SECONDS}] "
+                f"seconds (the 15s-2m ad envelope), got {total}s from "
+                f"{[shot.duration_seconds for shot in self.shots]}. Adjust the "
+                "shot durations (each still one of 4/6/8) so they sum into range."
+            )
+        return self
+
+
+# ============================================================================
+# StoryboardPlan — the `storyboard` (journalism/marketing) profile's plan
+# ============================================================================
+# The storyboard profile is a SECOND audience for the same engine (see
+# profiles.py / agent.py). It is board-paced and narration-driven, NOT ad-
+# budgeted: there is deliberately NO veo, NO clip, and — per the design addendum
+# §6 ("Duration model: board-paced; narration length drives it, not a hard ad
+# budget") — NO hard duration budget. Consequences for this schema:
+#   * StoryboardShot carries NO `duration_seconds` (stills, not Veo clips), so
+#     the Veo-3 duration grid is irrelevant here.
+#   * StoryboardPlan carries NO total-duration field, so the AdPlan aggregate
+#     sum-in-[15,120] invariant above DOES NOT APPLY to StoryboardPlan (N/A by
+#     design — the animatic length is driven by the narration at assembly time).
+# The only shared constraint is the fixed shot-slot cap: the shot stage reuses
+# the same MAX_SHOTS ParallelAgent, so `shots` is bounded to [1, MAX_SHOTS].
+
+
+class StoryboardShot(BaseModel):
+    """One storyboard panel: an editorial beat, its still, and its narration."""
+
+    beat: str = Field(
+        description=(
+            "The editorial beat this panel covers — what this moment of the "
+            "story explains or shows (e.g. 'establish the problem')."
+        )
+    )
+    prompt: str = Field(
+        description=(
+            "Art-direction for the still: subject, composition, lens, light, "
+            "and mood. This drives the Photoshoot (nanobanana) still — there is "
+            "no motion/clip in the storyboard profile."
+        )
+    )
+    narration_line: str = Field(
+        description=(
+            "The explainer voiceover line spoken over this panel (editorial, "
+            "neutral register). Concatenated in order into the narration track."
+        )
+    )
+
+
+class StoryboardPlan(BaseModel):
+    """A board-paced, narration-driven editorial storyboard plan.
+
+    The planner's `output_schema` for the `storyboard` profile. Unlike `AdPlan`
+    there is NO duration budget (see the note above): the animatic's length is
+    set by the narration at assembly time, so this schema has no total-duration
+    field and the AdPlan aggregate-duration invariant does not apply.
+    """
+
+    subject: str = Field(
+        description=(
+            "The brand, product, story, or subject the storyboard is about "
+            "(editorial framing, not necessarily an advertiser)."
+        )
+    )
+    music_mood: str = Field(
+        description=(
+            "The mood/genre for the music bed (e.g. 'calm, contemplative "
+            "documentary underscore'), handed to the Music Producer (lyria) "
+            "persona."
+        )
+    )
+    shots: list[StoryboardShot] = Field(
+        description=(
+            f"The storyboard panels, in order. Between 1 and {MAX_SHOTS} shots "
+            "— the shot stage has a fixed number of parallel slots, and an "
+            "empty plan must not yield a zero-shot package."
+        ),
+        min_length=1,
         max_length=MAX_SHOTS,
     )

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/tests/test_package.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/tests/test_package.py
@@ -1,0 +1,151 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test for the DETERMINISTIC packager — the load-bearing non-generative
+contract of the storyboard/dogfood profile.
+
+The rest of the series follows a no-unit-test convention (the agents are demoed
+live), but `build_manifest`/`write_package` (package.py) are pure, non-LLM code
+that produces the versioned `manifest.json` the archivist depends on, so it is
+worth locking cheaply. This test is deliberately **import-light**: it loads
+`package.py` directly via importlib, BYPASSING the package `__init__` (which
+imports `agent`, and therefore ADK), so it runs with NO ADK / credentials / suite
+binaries — exactly like the offline fixture in the validation recipe.
+
+Runnable either way:
+    pytest tests/test_package.py          # collected as test_* functions
+    python tests/test_package.py          # plain-Python, prints PASS/exits non-zero
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+# Load package.py directly (no `import ad_creative_director` -> no ADK).
+_PKG_PY = Path(__file__).resolve().parents[1] / "ad_creative_director" / "package.py"
+_spec = importlib.util.spec_from_file_location("_pkg_under_test", _PKG_PY)
+package = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(package)
+
+# A 2-panel plan (exercises the shot-0N.png index derivation for N>1).
+_PLAN = {
+    "subject": "a lighthouse keeper at dawn",
+    "music_mood": "hopeful, cinematic",
+    "shots": [
+        {"beat": "keeper wakes", "prompt": "dim room, first light"},
+        {"beat": "lamp lit", "prompt": "the lens glows against the dawn"},
+    ],
+}
+
+
+def _seed_all_artifacts(d: Path) -> None:
+    """Write every expected artifact for a full 2-panel package."""
+    (d / "shots").mkdir(parents=True, exist_ok=True)
+    (d / "audio").mkdir(parents=True, exist_ok=True)
+    (d / "shots" / "shot-01.png").write_text("x")
+    (d / "shots" / "shot-02.png").write_text("x")
+    (d / "audio" / "narration.wav").write_text("x")
+    (d / "audio" / "music.mp3").write_text("x")
+    (d / "animatic.mp4").write_text("x")
+
+
+def test_all_present_verifies_true_with_exact_shot_names() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        _seed_all_artifacts(d)
+        m = package.build_manifest(
+            _PLAN, d, profile="storyboard", brief="b", model="gemini-3.8-flash"
+        )
+        assert m["artifacts_verified"] is True
+        assert m["manifest_version"] == "1"
+        # Exact index-derived names + all verified flags true, in order.
+        assert [s["image"] for s in m["shots"]] == [
+            "shots/shot-01.png",
+            "shots/shot-02.png",
+        ]
+        assert [s["index"] for s in m["shots"]] == [1, 2]
+        assert all(s["verified"] for s in m["shots"])
+        assert m["audio"] == {
+            "narration": "audio/narration.wav",
+            "music": "audio/music.mp3",
+        }
+        assert m["assembled"] == "animatic.mp4"
+
+
+def test_one_missing_still_verifies_false_with_correct_flags() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        _seed_all_artifacts(d)
+        (d / "shots" / "shot-02.png").unlink()  # drop exactly one still
+        m = package.build_manifest(
+            _PLAN, d, profile="storyboard", brief="b", model="gemini-3.8-flash"
+        )
+        assert m["artifacts_verified"] is False
+        # Per-shot flags reflect reality: panel 1 present, panel 2 missing.
+        assert m["shots"][0]["verified"] is True
+        assert m["shots"][1]["verified"] is False
+
+
+def test_missing_audio_or_animatic_verifies_false() -> None:
+    for missing in ("audio/narration.wav", "audio/music.mp3", "animatic.mp4"):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _seed_all_artifacts(d)
+            (d / missing).unlink()
+            m = package.build_manifest(
+                _PLAN, d, profile="storyboard", brief="b", model="gemini-3.8-flash"
+            )
+            assert m["artifacts_verified"] is False, missing
+
+
+def test_empty_plan_never_verifies() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        # Even with the fixed audio/animatic present, an empty plan must fail.
+        (d / "audio").mkdir()
+        (d / "audio" / "narration.wav").write_text("x")
+        (d / "audio" / "music.mp3").write_text("x")
+        (d / "animatic.mp4").write_text("x")
+        m = package.build_manifest(
+            {"shots": []}, d, profile="storyboard", brief="b", model="m"
+        )
+        assert m["artifacts_verified"] is False
+        assert m["shots"] == []
+
+
+def test_write_package_writes_both_files_and_returns_manifest() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp) / "pkg"
+        # No artifacts on disk -> manifest still written, artifacts_verified false.
+        m = package.write_package(
+            _PLAN, d, profile="storyboard", brief="b", model="gemini-3.8-flash"
+        )
+        assert (d / "manifest.json").is_file()
+        assert (d / "plan.json").is_file()
+        assert m["artifacts_verified"] is False
+        # manifest.json on disk matches the returned dict; plan.json is the plan.
+        on_disk = json.loads((d / "manifest.json").read_text())
+        assert on_disk == m
+        assert json.loads((d / "plan.json").read_text()) == _PLAN
+
+
+if __name__ == "__main__":
+    _tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in _tests:
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"\nALL {len(_tests)} PACKAGER TESTS PASS")


### PR DESCRIPTION
## What & why

Step 6 of the ADK genmedia example series. This is the **"one engine, two profiles"** generalization of the merged PR-5 ad creative-director capstone — **additive, in place** (no new sibling dir, no rename). The existing example now hosts BOTH:

- **`AD_PROFILE`** — the ad capstone, **unchanged**. `root_agent = build_root_agent(AD_PROFILE)`, so `adk web` shows the same `ad_creative_director_ad` agent it did after PR-5.
- **`STORYBOARD_PROFILE`** (NEW) — an editorial "Creative Studio" storyboard profile (nanobanana stills, board-paced `animatic.mp4`, **no Veo**), reached through a new **headless `package` CLI** that emits a package directory + a **versioned, machine-readable `manifest.json`** — the series' own dogfood tool.

## Highlights

- **Profile seam**: plain-Python frozen `dataclass` + `build_root_agent(profile)` factory. Two additive `Profile` fields (`emit_package`, `plan_state_key`) with defaults that preserve AD_PROFILE behavior exactly. **Never** ADK `from_config`/`AgentConfig` (both `@deprecated` + `@experimental` in 2.8.0).
- **Reuse, don't re-author**: the storyboard planner composes PR-4's scriptwriter leaf via `AgentTool` (+`output_schema=StoryboardPlan`, using ADK 2.8.0's supported output_schema+tools coexistence); stills reuse PR-1 Photoshoot; audio reuses PR-3 Music Producer — all via the established sys.path co-location (fail-loud on a missing sibling).
- **Deterministic, non-LLM packager**: reads the schema-validated plan, verifies every artifact **by existence** (never a `resource_link`), and writes `manifest.json` (`manifest_version:"1"`) + `plan.json`. `artifacts_verified:true` only if ALL exist; non-zero exit on any miss; no stubs.
- **Schema hardening (bundled)**: `AdPlan` now enforces `sum(shots[*].duration_seconds) ∈ [15,120]` via a `@model_validator` (closes a PR-5 review FYI). `StoryboardPlan` is board-paced with no duration budget (invariant N/A, noted in-schema).
- **Two documented "one spot below MCP" ffmpeg helpers** in the storyboard assembler (a stills→silent-slideshow builder, and the reused `trim_audio_to_video_length`) — avtool exposes neither a stills→video op nor a trim flag (source-cited).

## Verification

- Offline gates (dev): `py_compile` all modules; AdPlan schema smoke (valid / sum>120 / off-grid / **new** sum<15 all behave); StoryboardPlan smoke (1/empty/4); deterministic-packager fixture (all-present→verified; any-missing→non-zero + `artifacts_verified:false`).
- Credentialed end-to-end validation (non-Veo stack: nanobanana + lyria + gemini-TTS + avtool/ffmpeg) per `briefs/pr6-validation-recipe.md`, with every artifact verified by existence/destination-listing, an animatic audio-in-sync check, and a both-profiles graph-construction sanity confirming the ad capstone is unchanged.

Part of the ADK genmedia example series (steps 1–5 previously merged).