### PR TITLE
ADK genmedia series (7): Editor's QC Room — an optional self-critique LoopAgent

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/README.md
@@ -38,7 +38,7 @@ or demo that does the same job on another surface.
 | 2 | **Now with video** — [Director / Videographer](./director-videographer/) | one tool again, but the Veo gotchas (verify by *listing*; explicit Veo-3 model) | **ready** |
 | 3 | **Three servers, one agent** — [Music Producer](./music-producer/) | multiple `MCPToolset`s, `tool_name_prefix`, and the naming crosswalk | **ready** |
 | 4 | **Your first pipeline** — [Scriptwriter / Storyboarder](./scriptwriter-storyboarder/) | `SequentialAgent` + `output_key` state passing between agents | **ready** |
-| 5 | **A real multi-agent app** — [Ad creative-director's assistant](./ad-creative-director/) | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents | **ready** |
+| 5 | **A real multi-agent app** — [Ad creative-director's assistant](./ad-creative-director/) | `SequentialAgent` ⊃ `ParallelAgent` + `AgentTool`; composing the persona agents; plus an optional self-critique `LoopAgent` ("Editor's QC Room") that re-assembles until an objective check passes or a small iteration cap is hit — both profiles | **ready** |
 | 6 | **Dogfood the studio — Creative Studio (storyboard profile)** — [same engine, storyboard profile + headless CLI](./ad-creative-director/#creative-studio--the-storyboard-profile-dogfood) | one engine, two profiles via a plain-Python profile factory; a machine-readable package + versioned `manifest.json` contract over a headless CLI | **ready** |
 
 > Steps 2–6 are being added as the series rolls out; they're listed here so you

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/README.md
@@ -52,6 +52,11 @@ schema-validated JSON plan via `output_schema`.** Concretely:
 - **The static-fan-out constraint.** `ParallelAgent`'s sub-agent list is fixed at
   build time — you'll see how to reconcile that with a runtime-variable shot
   count.
+- **`LoopAgent` — a bounded self-critique loop.** The optional **Editor's QC
+  Room** wraps the assembler with a critic and re-assembles until an *objective,
+  measured* check passes (the critic **escalates**) or a small `max_iterations`
+  cap is hit — the framework-level guarantee against an infinite loop. It applies
+  to **both** profiles.
 
 ## Prerequisites
 
@@ -113,9 +118,12 @@ SequentialAgent(name="ad_creative_director_ad", sub_agents=[
     planner,                       # LlmAgent(output_schema=AdPlan, output_key="ad_plan")
     ParallelAgent(name="shots", sub_agents=[shot_1, shot_2, shot_3]),
     audio,                         # LlmAgent(tools=[music_producer_tool])
-    assembler,                     # LlmAgent(tools=[avtool, trim_audio_to_video_length])
+    LoopAgent(name="editor_qc", max_iterations=2, sub_agents=[   # PR-7 QC loop (both profiles)
+        assembler,                 # LlmAgent(tools=[avtool, trim_audio_to_video_length])
+        critic,                    # LlmAgent(output_schema=QCVerdict, tools=[probe, exit_loop])
+    ]),
 ])
-root_agent = build_root_agent(AD_PROFILE)   # adk web loads the ad capstone
+root_agent = build_root_agent(AD_PROFILE)   # adk web loads the ad capstone (now with the QC loop)
 ```
 
 **Stage 1 — the planner** is an `LlmAgent` with an `output_schema` (`AdPlan`) and
@@ -144,6 +152,11 @@ the video's length**, lays it over the video, and **verifies the final file by
 existence** (media-info + destination listing), never by a returned resource
 link. That trim step is the one place this capstone drops below MCP — see
 *Keeping the audio in sync* below for why.
+
+When a profile enables QC (both shipped profiles do), stage four is not the bare
+assembler but a **`LoopAgent` — the "Editor's QC Room"** — that pairs the
+assembler with a critic and re-assembles until the cut passes an objective check
+or a small cap is hit. See **[The Editor's QC Room](#the-editors-qc-room-a-bounded-self-critique-loop)**.
 
 ### Keeping below MCP honest (the two local helpers)
 
@@ -297,6 +310,84 @@ reuse), and the naming crosswalk that spans all of them is
 [`../NAMING.md`](../NAMING.md) — this is the agent that exercises the whole
 crosswalk.
 
+## The Editor's QC Room (a bounded self-critique loop)
+
+The series' one remaining major ADK construct is a **`LoopAgent`**, and this is
+where it lives: an optional **"Editor's QC Room"** that turns stage four from a
+one-shot assembler into a **self-critique + bounded re-assemble** loop. It is
+**profile-agnostic** — it wraps assembly for **both** the `ad` capstone *and* the
+`storyboard` animatic. It ships **on** for both profiles (`enable_qc=True`), so
+`adk web` now runs it; set `enable_qc=False` on a profile to get the pre-QC
+one-shot assembler back.
+
+```python
+# build_root_agent(profile), when profile.enable_qc:
+LoopAgent(
+    name="editor_qc",
+    max_iterations=profile.qc_max_iterations,   # = 2
+    sub_agents=[assembler, critic],             # assembler FIRST, critic SECOND
+)
+```
+
+**Assembler-first, critic-second.** Each iteration the `LoopAgent` runs its
+sub-agents in order and restarts from the top next pass
+([`loop_agent.py:98`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/agents/loop_agent.py#L98)
+/ [`:126`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/agents/loop_agent.py#L126)
+@ v2.8.0), so putting the assembler first means the critic always has a **real,
+just-built cut** to measure — there is no first-iteration critic with nothing to
+review. The **single** assembler instance lives **only** inside the loop (an ADK
+agent may have exactly one parent —
+[`base_agent.py:704-712`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/agents/base_agent.py#L704),
+which fires for `sub_agents` but not for `AgentTool`), never also as a bare fourth
+stage.
+
+**The critic is objective, not cosmetic.** It is an `LlmAgent` with
+`output_schema=QCVerdict` (`{acceptable, issues, correction_notes}`) and
+`output_key="qc_verdict"`. It does not *opine* — it **measures** with a tiny local
+`ffprobe` helper (`probe_media_durations`, reusing the same `_ffprobe_duration_seconds`
+the assembler uses) and judges from the numbers, verifying the final file **by
+existence** (never a `resource_link` or a tool's success text):
+
+- **Existence** — the final `.mp4` must actually exist on disk.
+- **Audio/video sync** — the final cut must not run more than **1.0s** longer than
+  the video-only track. This is the check with teeth (see below).
+- **Duration budget** — *ad profile only:* the final cut must be within the
+  **15–120s** budget. The storyboard is board-paced and has **no** budget check.
+
+**Two ways the loop stops — and it *always* stops:**
+
+1. **The critic escalates.** When the cut passes, the critic calls a one-line
+   `exit_loop` tool that sets `tool_context.actions.escalate = True`. The
+   `LoopAgent` checks `event.actions.escalate` on every event it sees and stops
+   ([`loop_agent.py:116-117`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/agents/loop_agent.py#L116)
+   @ v2.8.0).
+2. **The `max_iterations` cap.** Even if the critic *never* escalates, the loop is
+   bounded by `max_iterations` (=2): the run condition is `times_looped <
+   self.max_iterations`
+   ([`loop_agent.py:95-97`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/agents/loop_agent.py#L95),
+   incremented at [`:127`](https://github.com/google/adk-python/blob/v2.8.0/src/google/adk/agents/loop_agent.py#L127)
+   @ v2.8.0). This cap is the framework-level **guarantee of no infinite loop**.
+
+**The concrete defect it catches (and fixes) on-camera.** This is the same
+Lyria-overrun trap that `trim_audio_to_video_length` exists for — now caught
+*visibly* by the QC room. When QC is on, the assembler's **first** pass deliberately
+**skips the fit-trim** and combines the audio directly, so the fixed **~30-second**
+Lyria music bed genuinely overruns the ~12–24s ad video (or the board-paced
+animatic). The critic measures it — *final 30.1s vs video 20.0s, +10.1s > 1.0s* —
+writes `acceptable=false` with `correction_notes` ("re-run
+`trim_audio_to_video_length` … then re-combine"), and the loop iterates. On the
+second pass the assembler reads that verdict (via the optional `{qc_verdict?}`
+instruction template, which renders empty on the first pass), applies the trim,
+and re-combines; the critic re-measures — now in sync — sets `acceptable=true`, and
+escalates. The loop stops **at or before** the cap, and the final artifact is the
+corrected cut. Nothing about the defect is faked: it is a real measured
+consequence of skipping a real step, caught by a real measurement.
+
+> **Why gate the skipped trim behind `enable_qc`?** So the defect is a property of
+> *the QC demonstration*, not of the assembler itself: with `enable_qc=False` the
+> assembler is byte-for-byte the pre-QC one that always trims. The QC room is where
+> the trap is taught, so that is the only place the trap is allowed to appear.
+
 ## Creative Studio — the storyboard profile (dogfood)
 
 The **storyboard** profile turns the same engine into a **Creative Studio**: from
@@ -426,8 +517,9 @@ before.
   [`experiments/mcp-genmedia/skills/story-generator/SKILL.md`](../../../skills/story-generator/SKILL.md).
   Its "writers room → per-scene generation" shape — and its "Editor's QC Room"
   self-critique loop — is the storytelling craft behind the planner and the
-  (future, optional) QC stage. Read it for the technique; this agent is an
-  ADK-runnable surface of the same idea. Cited, not forked.
+  [QC `LoopAgent` stage](#the-editors-qc-room-a-bounded-self-critique-loop). Read
+  it for the technique; this agent is an ADK-runnable surface of the same idea.
+  Cited, not forked.
 - **Downstream: the archivist (manifest consumer).** The Creative Studio profile
   exists to be *consumed*, not just watched. A downstream tool — the series'
   archivist, which assembles blog/marketing posts — reads **only** the
@@ -446,6 +538,7 @@ You've reached the capstone — head back to the [series overview](../README.md)
 to see the whole arc, from a nine-line single-tool agent to this multi-agent ad
 pipeline. This example already grows a **second** audience on the profile seam —
 the [Creative Studio storyboard profile](#creative-studio--the-storyboard-profile-dogfood)
-and its headless package/manifest dogfood tool. From here, the natural next
-extension (an optional `LoopAgent` QC stage) builds directly on the same profile
-seam and reuse pattern you just saw.
+and its headless package/manifest dogfood tool — and a **self-critique
+`LoopAgent`**, the [Editor's QC Room](#the-editors-qc-room-a-bounded-self-critique-loop),
+that re-assembles until an objective check passes. Both build directly on the same
+profile seam and reuse pattern you just saw.

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/agent.py
@@ -78,6 +78,27 @@ ADK 2.8.0 constructs used here are source-verified against the installed 2.8.0
     plain (non-`?`) placeholder raises KeyError if absent (:174), which is what
     we want: the planner always runs first, so a missing plan is a real failure.
 
+  * LoopAgent        — agents/loop_agent.py:57 (class; @deprecated :53-56, same
+    "in favor of Workflow" caveat as Sequential/Parallel above). Used ONLY when a
+    profile sets enable_qc (PR-7): the 4th stage becomes
+    LoopAgent(sub_agents=[assembler, critic], max_iterations=profile.qc_max_iterations)
+    — the "Editor's QC Room". It stops on EITHER exit, both source-verified:
+    (i) the max_iterations HARD CAP — while-condition :95-97
+    (`not self.max_iterations or times_looped < self.max_iterations`), times_looped
+    incremented :127 — the guarantee against an infinite loop even if the critic
+    never escalates; (ii) a sub_agent ESCALATING — it checks `event.actions.escalate`
+    on every yielded event (:116-117) and stops. It runs its sub_agents in order
+    each pass (:98) and restarts at index 0 each loop (:126), so assembler-FIRST
+    means the critic always reviews a real cut. The critic escalates via the local
+    `exit_loop` tool (tool_context.actions.escalate = True; ToolContext == Context
+    in 2.8.0, `Context.actions` at context.py:290 -> events/event_actions.py:125
+    `escalate`). Because an agent can have only ONE parent (base_agent.py:704-712,
+    which fires for sub_agents ONLY, not AgentTool), the SINGLE assembler instance
+    is placed in EXACTLY ONE tree position — inside the loop when QC is on, else
+    the bare 4th sub_agent; never both. The assembler reads the critic's verdict on
+    a re-run via the OPTIONAL template `{qc_verdict?}` (instructions_utils.py:136,
+    :170-172 renders '' when the key is absent — i.e. on the first pass).
+
   * FunctionTool     — tools/function_tool.py:99 (class), :106 (__init__ takes a
     `func` and reads its docstring as the tool description). A bare callable in
     an LlmAgent's `tools` list is auto-wrapped in one: llm_agent.py:206-207
@@ -109,16 +130,17 @@ import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
-from google.adk.agents import LlmAgent, ParallelAgent, SequentialAgent
+from google.adk.agents import LlmAgent, LoopAgent, ParallelAgent, SequentialAgent
 from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools.mcp_tool.mcp_toolset import (
     MCPToolset,
     StdioConnectionParams,
     StdioServerParameters,
 )
+from google.adk.tools.tool_context import ToolContext
 
 from .profiles import AD_PROFILE, Profile
-from .schemas import MAX_SHOTS
+from .schemas import MAX_SHOTS, QCVerdict
 
 load_dotenv()
 
@@ -127,6 +149,11 @@ load_dotenv()
 # GOOGLE_CLOUD_LOCATION="global" in your .env (see .env.example). The default
 # Lyria model reused via the Music Producer persona is also global-only.
 MODEL = "gemini-3.8-flash"
+
+# The session-state key the QC critic writes its QCVerdict to and the assembler
+# reads (via the optional {qc_verdict?} template) on a re-assemble. Only used when
+# a profile sets enable_qc (PR-7, the Editor's QC Room).
+QC_STATE_KEY = "qc_verdict"
 
 project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
@@ -1000,44 +1027,279 @@ measured duration.
 """
 
 
+# ---------------------------------------------------------------------------
+# QC LOOP support (PR-7). When a profile sets enable_qc, the assembler runs INSIDE
+# the editor_qc LoopAgent, ahead of the critic, so its instruction gets this
+# preamble prepended. The preamble is GATED behind profile.enable_qc so the
+# default (enable_qc=False) assembler instruction stays byte-identical to PR-6.
+#
+# It deliberately makes the FIRST pass skip the audio fit-trim (step 3) so the
+# fixed ~30s Lyria music bed GENUINELY overruns the video — a REAL, measured
+# defect for the critic to catch, never a hardcoded "always-fail-once" flag. On a
+# failed re-run the assembler applies the trim as the correction notes instruct.
+# This makes the Editor's QC Room the place the series' Lyria-overrun trap (the
+# whole reason trim_audio_to_video_length exists) is caught AND fixed on-camera.
+#
+# The ad and storyboard base instructions share the same numbered-step spine
+# (1 build/concat, 2 mix, 3 fit-trim, 4 combine, 5 verify), so ONE preamble drives
+# both. `{qc_verdict?}` renders '' on the first pass (key absent) and the previous
+# verdict dict on a re-run (instructions_utils.py:136, :170-172).
+_QC_ASSEMBLER_PREAMBLE = f"""\
+# Editor's QC Room — you run INSIDE a review loop
+You are assembling this cut inside an "Editor's QC Room" loop: after you finish, a
+critic MEASURES the result and either ACCEPTS it (the loop stops) or sends it back
+with correction notes for you to fix on the next pass. The previous pass's QC
+verdict is injected here — it is EMPTY on your first pass:
+
+<qc_verdict>
+{{{QC_STATE_KEY}?}}
+</qc_verdict>
+
+HOW TO USE IT (this OVERRIDES the fit-trim guidance in the numbered steps below):
+- If <qc_verdict> is EMPTY (this is your FIRST pass): perform the numbered steps
+  below but SKIP step 3 (the audio fit-trim) — in step 4 combine the mixed audio
+  from step 2 DIRECTLY over the video. Do not pre-emptively trim; the critic needs
+  a real cut to measure.
+- If <qc_verdict> contains a verdict with "acceptable": false: the previous cut
+  FAILED QC. Read its "correction_notes" and "issues" and APPLY the fix — in
+  particular DO perform step 3 now (call `trim_audio_to_video_length` on the mixed
+  audio against the video), then re-run step 4 (combine) and step 5 (verify) to
+  produce a fresh final file. Address EVERY item in the verdict's "issues".
+
+Everything else about the assembly is exactly as described below.
+
+"""
+
+
 def _build_assembler(profile: Profile) -> LlmAgent:
     if profile.assembler_recipe == "stills_animatic":
-        return LlmAgent(
-            model=MODEL,
-            name="assembler",
-            description=(
-                "Builds a silent slideshow from the panels' stills, mixes music "
-                "+ narration, trims the audio to the slideshow length, lays it "
-                "over the slideshow via avtool, and verifies animatic.mp4 by "
-                "existence."
-            ),
-            instruction=_stills_animatic_instruction(profile.plan_state_key),
-            # avtool for mix/combine/info, plus TWO local ffmpeg helpers: the new
-            # stills->video slideshow builder and the SAME trim helper the ad
-            # assembler uses (bare callables ADK auto-wraps in FunctionTools:
-            # llm_agent.py:206-207).
-            tools=[
-                storyboard_assembler_avtool,
-                build_stills_animatic_slideshow,
-                trim_audio_to_video_length,
-            ],
+        instruction = _stills_animatic_instruction(profile.plan_state_key)
+        description = (
+            "Builds a silent slideshow from the panels' stills, mixes music "
+            "+ narration, trims the audio to the slideshow length, lays it "
+            "over the slideshow via avtool, and verifies animatic.mp4 by "
+            "existence."
         )
-
-    # profile.assembler_recipe == "video_ad_concat" — the ad path (unchanged).
-    return LlmAgent(
-        model=MODEL,
-        name="assembler",
-        description=(
+        # avtool for mix/combine/info, plus TWO local ffmpeg helpers: the new
+        # stills->video slideshow builder and the SAME trim helper the ad
+        # assembler uses (bare callables ADK auto-wraps in FunctionTools:
+        # llm_agent.py:206-207).
+        tools = [
+            storyboard_assembler_avtool,
+            build_stills_animatic_slideshow,
+            trim_audio_to_video_length,
+        ]
+    else:
+        # profile.assembler_recipe == "video_ad_concat" — the ad path.
+        instruction = ASSEMBLER_INSTRUCTION
+        description = (
             "Concatenates the per-shot clips, mixes music + VO, trims the audio "
             "to the video length, lays it over the video via avtool, and verifies "
             "the final ad by existence."
-        ),
-        instruction=ASSEMBLER_INSTRUCTION,
+        )
         # avtool MCPToolset for the transform steps, plus one local ffmpeg helper
         # (a bare callable ADK auto-wraps in a FunctionTool: llm_agent.py:206-207)
         # that fills avtool's missing audio-trim; see the AUDIO/VIDEO DURATION note
         # in the module docstring.
-        tools=[assembler_avtool, trim_audio_to_video_length],
+        tools = [assembler_avtool, trim_audio_to_video_length]
+
+    if profile.enable_qc:
+        # PR-7: this assembler lives inside the editor_qc LoopAgent. Prepend the QC
+        # preamble so it skips the fit-trim on the first pass (a real overrun for
+        # the critic to catch) and applies the correction notes on a re-run. Gated
+        # here so the enable_qc=False instruction is byte-identical to PR-6.
+        instruction = _QC_ASSEMBLER_PREAMBLE + instruction
+
+    return LlmAgent(
+        model=MODEL,
+        name="assembler",
+        description=description,
+        instruction=instruction,
+        tools=tools,
+    )
+
+
+# ============================================================================
+# Stage 4b — the QC critic (LlmAgent + output_schema=QCVerdict) [enable_qc only]
+# ============================================================================
+# Built ONLY when profile.enable_qc. It runs SECOND inside the editor_qc LoopAgent
+# (after the assembler), MEASURES the just-assembled cut with a local ffprobe
+# helper (reusing _ffprobe_duration_seconds — no second ffprobe), and writes a
+# structured QCVerdict to state["qc_verdict"]. If the cut passes it calls
+# `exit_loop` to escalate (stops the loop); otherwise it writes actionable
+# correction_notes the assembler reads via `{qc_verdict?}` on the next iteration.
+
+# The audio/video sync tolerance. Post-trim runs measured ~0.003s / ~0.015s of
+# skew in PR-5/PR-6, while the untrimmed ~30s Lyria bed overruns a 12-24s ad video
+# (or a board-paced animatic) by many seconds — so a 1.0s threshold cleanly
+# separates a good cut from the overrun defect without flapping on sub-second
+# container rounding.
+QC_SYNC_TOLERANCE_SECONDS = 1.0
+
+
+def exit_loop(tool_context: ToolContext) -> str:
+    """Call ONLY when the assembled cut passes QC; stops the QC loop.
+
+    Sets the LoopAgent escalate signal (tool_context.actions.escalate = True) so
+    the Editor's QC Room stops iterating. Do NOT call this if the cut still has
+    issues — emit the QCVerdict with correction_notes and do not escalate instead.
+    """
+    tool_context.actions.escalate = True
+    return "QC passed: escalate set — the Editor's QC Room loop will stop."
+
+
+def probe_media_durations(media_paths: list[str]) -> str:
+    """Measure each media file's duration in seconds (ffprobe) for QC review.
+
+    Pass the local paths the assembler reported — e.g. the video-only track and
+    the final combined cut — and this returns, per file, whether it EXISTS and its
+    measured duration, so the critic can compare them objectively (audio/video
+    sync, and the total-duration budget for the ad profile). It verifies BY
+    EXISTENCE: a missing file is reported as MISSING, never assumed present. Never
+    trust a resource_link or a tool's success text as proof — THIS measurement is
+    the proof.
+
+    Args:
+      media_paths: local paths to probe, e.g. ["./output/ad_video.mp4",
+        "./output/final_ad.mp4"].
+
+    Returns:
+      One line per path: "<path>: EXISTS, duration=<n>s" or "<path>: MISSING ...".
+    """
+    if shutil.which("ffprobe") is None:
+        return (
+            "ERROR: 'ffprobe' is not on PATH. ffmpeg and ffprobe are required to "
+            "measure the assembled cut (see the project prerequisites)."
+        )
+    lines: list[str] = []
+    for p in media_paths:
+        if not p:
+            continue
+        if not os.path.isfile(p):
+            lines.append(f"{p}: MISSING (file does not exist)")
+            continue
+        try:
+            dur = _ffprobe_duration_seconds(p)
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            lines.append(f"{p}: EXISTS but duration unreadable ({exc})")
+            continue
+        lines.append(f"{p}: EXISTS, duration={dur:.3f}s")
+    if not lines:
+        return "ERROR: no media paths were given to probe."
+    return "\n".join(lines)
+
+
+def _ad_critic_instruction() -> str:
+    return f"""\
+You are the QC reviewer in the ad editor's "Editor's QC Room". The just-assembled
+cut is described in the conversation above; the creative director's plan is
+injected for reference (shot order, total_duration_seconds):
+
+<ad_plan>
+{{ad_plan}}
+</ad_plan>
+
+Your job is an OBJECTIVE, reproducible pass/fail on the assembled cut — decide
+from MEASURED facts, never a tool's success text and never a resource_link.
+
+# 1. Measure (verify BY EXISTENCE)
+Read the exact paths the assembler reported: the concatenated VIDEO-only track
+(e.g. ./output/ad_video.mp4) and the FINAL combined cut (e.g.
+./output/final_ad.mp4). Call `probe_media_durations` with BOTH paths.
+
+# 2. Judge against these objective checks
+- EXISTENCE: the final cut file must EXIST. If probe reports it MISSING, it FAILS.
+- AUDIO/VIDEO SYNC: the final cut's duration must NOT exceed the video-only
+  track's duration by more than {QC_SYNC_TOLERANCE_SECONDS:.1f}s. If the assembler
+  skipped the audio fit-trim, the ~30s Lyria music bed overruns the video and the
+  final cut is many seconds longer than ad_video.mp4 — that FAILS.
+- DURATION BUDGET: the final cut's duration must be within the 15-120s ad budget.
+
+# 3. Verdict
+Emit a QCVerdict:
+- If EVERY check passes: set "acceptable": true, leave "issues" and
+  "correction_notes" empty, AND call the `exit_loop` tool to stop the QC loop.
+- If ANY check fails: set "acceptable": false, list the concrete MEASURED problems
+  in "issues" (e.g. "final 30.10s exceeds video 20.00s by 10.10s > 1.0s"), and
+  write actionable "correction_notes" telling the assembler how to fix it — for
+  the overrun, "re-run trim_audio_to_video_length on the mixed audio against the
+  concatenated video, then re-combine and re-verify". Do NOT call exit_loop when
+  the cut fails.
+
+Return ONLY the QCVerdict as JSON matching the required schema — no preamble.
+"""
+
+
+def _storyboard_critic_instruction(plan_key: str) -> str:
+    return f"""\
+You are the QC reviewer in the editorial animatic's "Editor's QC Room". The
+just-assembled animatic is described in the conversation above; the planner's
+storyboard plan is injected for reference:
+
+<plan>
+{{{plan_key}}}
+</plan>
+
+Your job is an OBJECTIVE, reproducible pass/fail on the assembled animatic —
+decide from MEASURED facts, never a tool's success text and never a resource_link.
+NOTE the storyboard profile is board-paced and has NO ad duration budget, so DO
+NOT apply any 15-120s budget check here.
+
+# 1. Measure (verify BY EXISTENCE)
+Read the exact paths the assembler reported: the silent SLIDESHOW video (e.g.
+{{package_dir}}/slideshow.mp4) and the FINAL animatic ({{package_dir}}/animatic.mp4).
+Call `probe_media_durations` with BOTH paths.
+
+# 2. Judge against these objective checks
+- EXISTENCE: {{package_dir}}/animatic.mp4 must EXIST. If probe reports it MISSING,
+  it FAILS.
+- AUDIO/VIDEO SYNC: the final animatic's duration must NOT exceed the slideshow's
+  duration by more than {QC_SYNC_TOLERANCE_SECONDS:.1f}s. If the assembler skipped
+  the audio fit-trim, the ~30s Lyria music bed overruns the slideshow and the
+  animatic is many seconds longer than slideshow.mp4 — that FAILS.
+
+# 3. Verdict
+Emit a QCVerdict:
+- If EVERY check passes: set "acceptable": true, leave "issues" and
+  "correction_notes" empty, AND call the `exit_loop` tool to stop the QC loop.
+- If ANY check fails: set "acceptable": false, list the concrete MEASURED problems
+  in "issues", and write actionable "correction_notes" — for the overrun, "re-run
+  trim_audio_to_video_length on the mixed audio against the slideshow, then
+  re-combine to animatic.mp4 and re-verify". Do NOT call exit_loop when the cut
+  fails.
+
+Return ONLY the QCVerdict as JSON matching the required schema — no preamble.
+"""
+
+
+def _build_critic(profile: Profile) -> LlmAgent:
+    # output_schema (QCVerdict) and tools are used TOGETHER: ADK exposes the tools
+    # during the thought loop and enforces the schema only on the final reply
+    # (llm_agent.py:414-417) — the same pattern the storyboard planner already
+    # ships. The critic measures with probe_media_durations and escalates with
+    # exit_loop when the cut passes.
+    if profile.assembler_recipe == "stills_animatic":
+        instruction = _storyboard_critic_instruction(profile.plan_state_key)
+        description = (
+            "Measures the assembled animatic (slideshow vs final) via ffprobe and "
+            "emits a QCVerdict; escalates (exit_loop) when it passes, else writes "
+            "correction_notes for a bounded re-assemble."
+        )
+    else:
+        instruction = _ad_critic_instruction()
+        description = (
+            "Measures the assembled ad (video vs final + 15-120s budget) via "
+            "ffprobe and emits a QCVerdict; escalates (exit_loop) when it passes, "
+            "else writes correction_notes for a bounded re-assemble."
+        )
+    return LlmAgent(
+        model=MODEL,
+        name="critic",
+        description=description,
+        instruction=instruction,
+        output_schema=QCVerdict,
+        output_key=QC_STATE_KEY,
+        tools=[probe_media_durations, exit_loop],
     )
 
 
@@ -1053,7 +1315,36 @@ def build_root_agent(profile: Profile = AD_PROFILE) -> SequentialAgent:
     is the editorial storyboard/dogfood profile reached via the `package` CLI.
     `root_agent` below is built with AD_PROFILE, so `adk web` loads the ad
     capstone unchanged.
+
+    When `profile.enable_qc` (PR-7, both shipped profiles), the 4th stage is the
+    "Editor's QC Room": a `LoopAgent(sub_agents=[assembler, critic],
+    max_iterations=profile.qc_max_iterations)`. The assembler runs FIRST (builds/
+    rebuilds the cut), the critic runs SECOND (measures it and either escalates to
+    stop or writes correction notes). The SINGLE assembler instance lives ONLY
+    inside the loop here — never also as a bare sub_agent — so the single-parent
+    guard (base_agent.py:704-712) is respected. The `max_iterations` cap is the
+    hard guarantee against an infinite loop (loop_agent.py:95-97).
     """
+    assembler = _build_assembler(profile)
+    if profile.enable_qc:
+        # The Editor's QC Room. Assembler-first so the critic always reviews a real
+        # cut (LoopAgent runs sub_agents in order each pass and restarts at index 0
+        # — loop_agent.py:98/:126). The cap bounds the loop even if the critic never
+        # escalates. `assembler` is placed ONCE (here), never also below.
+        final_stage = LoopAgent(
+            name="editor_qc",
+            description=(
+                "The Editor's QC Room: re-assembles the cut until the critic's "
+                "objective check passes (escalate) or the max_iterations cap is "
+                "reached — whichever comes first (no infinite loop)."
+            ),
+            sub_agents=[assembler, _build_critic(profile)],
+            max_iterations=profile.qc_max_iterations,
+        )
+    else:
+        # Pre-PR-7 shape: the assembler is the bare 4th stage.
+        final_stage = assembler
+
     return SequentialAgent(
         name=f"ad_creative_director_{profile.name}",
         description=(
@@ -1064,7 +1355,7 @@ def build_root_agent(profile: Profile = AD_PROFILE) -> SequentialAgent:
             _build_planner(profile),
             _build_shot_stage(profile),
             _build_audio_stage(profile),
-            _build_assembler(profile),
+            final_stage,
         ],
     )
 

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/profiles.py
@@ -63,6 +63,17 @@ class Profile:
         templating. "ad_plan" for the ad profile (unchanged from PR-5), "plan"
         for the storyboard profile (the key the addendum §4.2d/§4.4 packager
         reads).
+      enable_qc: when True, the 4th (assembler) stage is wrapped in a `LoopAgent`
+        — the "Editor's QC Room" (PR-7). The assembler runs FIRST each iteration
+        (builds/rebuilds the cut) and a critic runs SECOND: it MEASURES the cut
+        (ffprobe) and either escalates to stop the loop (cut acceptable) or writes
+        correction notes the assembler reads on the next iteration. False (the
+        default) preserves the pre-PR-7 behavior exactly — a bare assembler as the
+        4th stage, no loop. Both shipped profiles set it True.
+      qc_max_iterations: the LoopAgent's hard `max_iterations` cap — the guarantee
+        against an infinite loop even if the critic never escalates
+        (google-adk loop_agent.py:95-97). Small on purpose (2): one pass to build
+        + catch, one to fix + accept. Only consulted when enable_qc is True.
     """
 
     name: str
@@ -73,6 +84,10 @@ class Profile:
     # Additive fields (defaults preserve the PR-5 AD_PROFILE behavior exactly).
     emit_package: bool = False
     plan_state_key: str = "ad_plan"
+    # PR-7 QC LoopAgent ("Editor's QC Room"). Defaults (enable_qc=False) preserve
+    # the pre-PR-7 behavior; both shipped profiles below set enable_qc=True.
+    enable_qc: bool = False
+    qc_max_iterations: int = 2
 
 
 # The tone/audience half of the planner instruction for the ad profile. The
@@ -96,7 +111,10 @@ AD_PROFILE = Profile(
     shot_media="clips",
     assembler_recipe="video_ad_concat",
     # emit_package / plan_state_key left at their defaults (False / "ad_plan"),
-    # so AD_PROFILE is byte-for-byte the PR-5 behavior.
+    # so the ad clip/plan pipeline is byte-for-byte the PR-5 behavior.
+    # PR-7: the QC LoopAgent applies to BOTH profiles (profile-agnostic on the
+    # engine), so the ad capstone / `adk web` now runs the Editor's QC Room too.
+    enable_qc=True,
 )
 
 
@@ -124,4 +142,8 @@ STORYBOARD_PROFILE = Profile(
     assembler_recipe="stills_animatic",
     emit_package=True,
     plan_state_key="plan",
+    # PR-7: the storyboard animatic also gets the Editor's QC Room (profile-
+    # agnostic). Its critic uses NO duration budget — only existence + audio/video
+    # sync — because the storyboard is board-paced (addendum §6).
+    enable_qc=True,
 )

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/ad_creative_director/schemas.py
@@ -19,6 +19,12 @@ This module defines the two planner `output_schema`s the engine ships:
   * `StoryboardPlan` — the `storyboard` profile (nanobanana stills, board-paced,
     NO duration budget). See the note above `StoryboardShot` below.
 
+It also defines `QCVerdict` — the `output_schema` of the PR-7 "Editor's QC Room"
+critic (both profiles). The critic MEASURES the assembled cut and writes a
+`QCVerdict` to `state["qc_verdict"]`; the `LoopAgent` stops on escalate (an
+acceptable cut) or the `max_iterations` cap. See `QCVerdict` at the end of this
+module and `_build_critic` in agent.py.
+
 `AdPlan` is the planner's `output_schema`. Giving the planner an `output_schema`
 turns its reply into a schema-validated JSON spine that lands in session state
 (`state["ad_plan"]`) instead of free text — every downstream stage reads a
@@ -233,4 +239,50 @@ class StoryboardPlan(BaseModel):
         ),
         min_length=1,
         max_length=MAX_SHOTS,
+    )
+
+
+# ============================================================================
+# QCVerdict — the "Editor's QC Room" critic's output_schema (PR-7, both profiles)
+# ============================================================================
+# The critic (an LlmAgent with output_schema=QCVerdict, output_key="qc_verdict")
+# runs SECOND inside the editor_qc LoopAgent, after the assembler. It MEASURES the
+# just-assembled cut (ffprobe) and emits this structured verdict into session
+# state. The LoopAgent stops when the critic escalates (an acceptable cut, via the
+# exit_loop tool) OR when the max_iterations cap is hit. On a non-acceptable
+# verdict the assembler reads `correction_notes` via the optional `{qc_verdict?}`
+# template on the next iteration and re-assembles. `acceptable` is REQUIRED (no
+# default) so a malformed verdict fails LOUD at validation time rather than being
+# silently treated as a pass.
+
+
+class QCVerdict(BaseModel):
+    """The QC critic's objective pass/fail verdict on one assembled cut."""
+
+    acceptable: bool = Field(
+        description=(
+            "True IFF the assembled cut passes every objective QC check: the final "
+            "file EXISTS, the audio/video durations are in sync (the final cut is "
+            "not more than the sync tolerance longer than the video-only track), "
+            "and — for the ad profile ONLY — the total duration is within the "
+            "15-120s budget. When True the critic also calls the `exit_loop` tool "
+            "to stop the QC loop; when False it does NOT escalate."
+        )
+    )
+    issues: list[str] = Field(
+        default_factory=list,
+        description=(
+            "The concrete, MEASURED problems found (empty when acceptable). Each "
+            "is an objective, reproducible fact, e.g. 'final 30.10s exceeds video "
+            "20.00s by 10.10s (> 1.0s sync tolerance)'."
+        ),
+    )
+    correction_notes: str = Field(
+        default="",
+        description=(
+            "Actionable instructions the assembler applies on the next iteration "
+            "to fix the issues (empty when acceptable), e.g. 're-run "
+            "trim_audio_to_video_length on the mixed audio against the video, then "
+            "re-combine and re-verify'."
+        ),
     )

--- a/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/tests/test_schemas.py
+++ b/experiments/mcp-genmedia/sample-agents/adk-genmedia-series/ad-creative-director/tests/test_schemas.py
@@ -1,0 +1,98 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import-light unit test for the PR-7 QC critic schema (`QCVerdict`).
+
+Like `test_package.py`, this loads `schemas.py` DIRECTLY via importlib, BYPASSING
+the package `__init__` (which imports `agent`, and therefore ADK). `schemas.py`
+imports only `pydantic`, so this runs with NO ADK / credentials / suite binaries —
+it needs only `pydantic` installed (the same dependency the engine already pins).
+
+It locks the load-bearing contract of the Editor's QC Room verdict: `acceptable`
+is REQUIRED (a malformed verdict must fail LOUD, never be silently treated as a
+pass), and `issues`/`correction_notes` default to empty for an accepting verdict.
+
+Runnable either way:
+    pytest tests/test_schemas.py          # collected as test_* functions
+    python tests/test_schemas.py          # plain-Python, prints PASS/exits non-zero
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Load schemas.py directly (no `import ad_creative_director` -> no ADK).
+_SCHEMAS_PY = (
+    Path(__file__).resolve().parents[1] / "ad_creative_director" / "schemas.py"
+)
+_spec = importlib.util.spec_from_file_location("_schemas_under_test", _SCHEMAS_PY)
+schemas = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(schemas)
+
+QCVerdict = schemas.QCVerdict
+
+
+def test_accepting_verdict_defaults_empty() -> None:
+    v = QCVerdict(acceptable=True)
+    assert v.acceptable is True
+    assert v.issues == []
+    assert v.correction_notes == ""
+
+
+def test_failing_verdict_carries_issues_and_notes() -> None:
+    v = QCVerdict(
+        acceptable=False,
+        issues=["final 30.10s exceeds video 20.00s by 10.10s (> 1.0s)"],
+        correction_notes=(
+            "re-run trim_audio_to_video_length on the mixed audio against the "
+            "video, then re-combine and re-verify"
+        ),
+    )
+    assert v.acceptable is False
+    assert len(v.issues) == 1
+    assert "trim_audio_to_video_length" in v.correction_notes
+
+
+def test_acceptable_is_required_fails_loud() -> None:
+    # A verdict without `acceptable` must NOT validate — it must never be silently
+    # treated as a pass. (pydantic raises ValidationError, a subclass of
+    # ValueError; we assert on ValueError to avoid importing pydantic here.)
+    raised = False
+    try:
+        QCVerdict(issues=["x"])  # type: ignore[call-arg]
+    except ValueError:
+        raised = True
+    assert raised, "QCVerdict(acceptable=...) must be required"
+
+
+def test_validate_json_roundtrip_matches_write_path() -> None:
+    # Mirrors ADK's write path: model_validate_json(...).model_dump(). The stored
+    # state value is a dict, which is what the assembler reads via {qc_verdict?}.
+    v = QCVerdict.model_validate_json(
+        '{"acceptable": false, "issues": ["overrun"], '
+        '"correction_notes": "re-trim and re-combine"}'
+    )
+    dumped = v.model_dump(exclude_none=True)
+    assert dumped["acceptable"] is False
+    assert dumped["issues"] == ["overrun"]
+    assert dumped["correction_notes"] == "re-trim and re-combine"
+
+
+if __name__ == "__main__":
+    _tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in _tests:
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"\nALL {len(_tests)} QCVerdict SCHEMA TESTS PASS")


### PR DESCRIPTION
Step 7 of the ADK genmedia example series (optional): adds the one major ADK construct the series hadn't shown yet — a **`LoopAgent`** — as a profile-agnostic, bounded **self-critique + re-assemble** stage ("Editor's QC Room"). Additive and gated: the new profile field defaults preserve the PR-6 engine byte-for-byte; both shipped profiles opt in.

## What ships
- 4th (assembler) stage becomes `LoopAgent(name="editor_qc", sub_agents=[assembler, critic], max_iterations=2)` when `enable_qc`. **Assembler-first** so the critic always reviews a real cut; the **single** assembler instance lives only inside the loop (single-parent guard respected). Two exits: the `max_iterations` hard cap (anti-infinite-loop) and the critic escalating via a tiny `exit_loop` tool (`tool_context.actions.escalate = True`). Applies to **both** profiles.
- `schemas.py`: `QCVerdict{acceptable (REQUIRED — fails loud), issues, correction_notes}`.
- `profiles.py`: additive `enable_qc=False` / `qc_max_iterations=2`; both shipped profiles set `enable_qc=True` (storyboard critic uses NO duration budget — board-paced).
- `agent.py`: the critic (`LlmAgent`, `output_schema=QCVerdict`, `output_key="qc_verdict"`, tools=`[probe_media_durations, exit_loop]`), a QC assembler preamble prepended ONLY under `enable_qc`, and the loop wiring. `root_agent` stays `AD_PROFILE` (`adk web` still loads the ad capstone).
- Import-light `tests/test_schemas.py` (QCVerdict contract); capstone README gains an "Editor's QC Room" section (states it applies to both profiles); series README row 5 only.

## The concrete QC issue demonstrated (genuine, not faked)
The **Lyria audio-bed overrun**: under `enable_qc` the assembler's first pass skips the fit-trim, so the ~30s music bed genuinely overruns the ~20s video. The critic MEASURES it with ffprobe (`|final − video| > 1.0s`), returns `acceptable=false` + correction notes, and does not escalate; the next pass runs `trim_audio_to_video_length`, re-verifies, and the critic escalates (`acceptable=true`) — the loop stops at iteration 2 ≤ cap.

## Behavioral note
Turning QC on for both profiles means `adk web` (the ad capstone) now runs the QC loop — the originally-intended Tier-3 "optional LoopAgent QC" flavor. `enable_qc=False` is byte-identical to PR-6.

## Quality gates (added on merge by the EM)
Fresh independent code review + a captured credentialed run showing the critic catching AND correcting the real measured overrun within the cap, with no infinite loop; verify-by-existence throughout.