### PR TITLE
ADK genmedia series (8): add the series to the sample-agents catalog

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/README.md
+++ b/experiments/mcp-genmedia/sample-agents/README.md
@@ -4,6 +4,7 @@
 This directory contains sample agents which use the Genmedia MCP tools.
 
 * Google Cloud Vertex AI's Agent Development Kit (adk)
+* A guided, multi-part ADK genmedia example series ([adk-genmedia-series](./adk-genmedia-series/README.md))
 * Google Firebase Genkit (genkit)
 * Google Gemini CLI (geminicli)
 * Google Antigravity (antigravity)


### PR DESCRIPTION
The `adk-genmedia-series/` directory (a complete multi-part guided ADK genmedia example series with its own README) sits alongside `adk/`, `genkit/`, `geminicli/`, `antigravity/`, and `mcp-inspector/` but was missing from the parent `sample-agents/README.md` index, making it invisible from the catalog.

This adds a single relative cross-link bullet pointing to `./adk-genmedia-series/README.md`, matching the existing list style. One file changed, +1 line.