### PR TITLE
feat(mcp-avtool-go): add media trim/cut tool

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
@@ -56,6 +56,12 @@ The `avtool` provides the following functionalities, exposed as MCP tools:
     *   Input: Array of URIs for the input audio files.
     *   Output: Mixed audio file. Can be saved locally and/or to a GCS bucket.
 
+*   **`ffmpeg_trim_media`**:
+    *   Trims (cuts) a single segment from an audio or video file, keeping only the portion between a start time and an end time (or for a given duration). Works identically for audio and video.
+    *   Inputs: URI of the input media file, start time (seconds), and either a duration or an end time (seconds). Optional `re_encode` flag.
+    *   By default the segment is extracted with a fast, lossless stream copy (`-c copy`). Because a stream copy can only begin on a keyframe, the cut may start at the nearest keyframe at or before the requested start time, so it may not be exactly frame-accurate. Set `re_encode=true` for a frame-accurate cut (slower, slightly lossy). If a stream copy is not possible for the chosen output container, the tool automatically falls back to a re-encode.
+    *   Output: The trimmed media file (input container/extension preserved by default). Can be saved locally and/or to a GCS bucket.
+
 ## Requirements
 
 *   **Go**: Version 1.18 or higher (as per `go.mod` if specified, otherwise latest stable).

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -98,6 +98,7 @@ func main() {
 	addLayerAudioTool(s, cfg)
 	addCreateGifTool(s, cfg)
 	addGetMediaInfoTool(s, cfg)
+	addTrimMediaTool(s, cfg)
 
 	switch transport {
 	case "sse":

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/compositing_recipes.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/compositing_recipes.md
@@ -85,3 +85,25 @@ This command is used to layer multiple audio files together.
 ```
 ffmpeg -y -i <input_audio_uri_1> -i <input_audio_uri_2> ... -filter_complex "amix=inputs=<number_of_inputs>:duration=longest" <output_file_name>.mp3
 ```
+
+### Trim Media
+
+This command extracts a single segment from an audio or video file, keeping only the
+portion beginning at `<start_time>` (in seconds) and lasting `<duration>` seconds. The
+same recipe works for both audio and video because `-ss`/`-t` operate on any stream
+type.
+
+Fast, lossless stream copy (default). Seeking to a keyframe means the cut may not be
+exactly frame-accurate; `-avoid_negative_ts make_zero` normalizes the copied
+timestamps to start at zero:
+
+```
+ffmpeg -y -ss <start_time> -i <input_media_uri> -t <duration> -c copy -avoid_negative_ts make_zero <output_file_name>
+```
+
+Frame-accurate re-encode (used when `re_encode` is requested, or automatically as a
+fallback when a stream copy is not possible for the chosen output container):
+
+```
+ffmpeg -y -ss <start_time> -i <input_media_uri> -t <duration> <output_file_name>
+```

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffmpeg_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffmpeg_commands.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/mcp-genmedia-go/mcp-common"
@@ -31,6 +32,55 @@ func runFFmpegCommand(ctx context.Context, args ...string) (string, error) {
 	}
 	log.Printf("FFMpeg command successful. Output (last few lines):\n%s", common.GetTail(string(output), 5)) // getTail from file_utils.go
 	return string(output), nil
+}
+
+// formatSeconds renders a number of seconds as a plain decimal string suitable for
+// passing to ffmpeg's -ss/-t options (e.g. 12.5 -> "12.5", 3 -> "3"). It avoids
+// scientific notation and trailing zeros so the emitted command is easy to read.
+func formatSeconds(seconds float64) string {
+	return strconv.FormatFloat(seconds, 'f', -1, 64)
+}
+
+// buildTrimArgs constructs the ffmpeg argument list for extracting a segment that
+// begins at startSeconds and lasts durationSeconds.
+//
+// When streamCopy is true the segment is copied without re-encoding (-c copy). This
+// is fast and lossless, but because ffmpeg can only start a stream copy on a
+// keyframe, the actual cut point is the nearest keyframe at or before the requested
+// start, so the result may not be frame-accurate. -avoid_negative_ts make_zero keeps
+// the copied timestamps starting from zero so players don't stumble on the leading
+// gap.
+//
+// When streamCopy is false the segment is re-encoded, which decodes from the nearest
+// keyframe and writes exactly the requested range — frame-accurate at the cost of a
+// slower, lossy pass.
+func buildTrimArgs(localInput, tempOutput string, startSeconds, durationSeconds float64, streamCopy bool) []string {
+	args := []string{"-y", "-ss", formatSeconds(startSeconds), "-i", localInput, "-t", formatSeconds(durationSeconds)}
+	if streamCopy {
+		args = append(args, "-c", "copy", "-avoid_negative_ts", "make_zero")
+	}
+	args = append(args, tempOutput)
+	return args
+}
+
+// executeTrimMedia runs the trim operation. It first attempts the requested mode
+// (stream copy unless reEncode is set). If a stream copy fails — some codec/container
+// combinations cannot be copied into the chosen output container — it automatically
+// retries with a re-encode so the caller still gets a usable clip. The boolean return
+// reports whether the output was produced by re-encoding.
+func executeTrimMedia(ctx context.Context, localInput, tempOutput string, startSeconds, durationSeconds float64, reEncode bool) (bool, error) {
+	if !reEncode {
+		_, err := runFFmpegCommand(ctx, buildTrimArgs(localInput, tempOutput, startSeconds, durationSeconds, true)...)
+		if err == nil {
+			return false, nil
+		}
+		log.Printf("Stream-copy trim failed (%v); retrying with a re-encode fallback.", err)
+	}
+	_, err := runFFmpegCommand(ctx, buildTrimArgs(localInput, tempOutput, startSeconds, durationSeconds, false)...)
+	if err != nil {
+		return true, err
+	}
+	return true, nil
 }
 
 // Note: Specific ffmpeg command functions (like convertAudioToMP3, createGIF etc.) will be added here later.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -47,4 +48,32 @@ func executeGetMediaInfo(ctx context.Context, localInputMedia string) (string, e
 		localInputMedia,
 	}
 	return runFFprobeCommand(ctx, ffprobeArgs...)
+}
+
+// probeMediaDurationSeconds returns the total duration of a media file in seconds,
+// parsed from the container's format metadata. It is used to validate trim ranges
+// against the actual length of the input. A non-nil error indicates the duration
+// could not be determined (e.g. a stream without a known duration), in which case
+// callers should skip range validation rather than reject the request.
+func probeMediaDurationSeconds(ctx context.Context, localInputMedia string) (float64, error) {
+	infoJSON, err := executeGetMediaInfo(ctx, localInputMedia)
+	if err != nil {
+		return 0, fmt.Errorf("failed to probe media info: %w", err)
+	}
+	var info struct {
+		Format struct {
+			Duration string `json:"duration"`
+		} `json:"format"`
+	}
+	if err := json.Unmarshal([]byte(infoJSON), &info); err != nil {
+		return 0, fmt.Errorf("failed to parse media info: %w", err)
+	}
+	if strings.TrimSpace(info.Format.Duration) == "" {
+		return 0, fmt.Errorf("media info did not report a container duration")
+	}
+	seconds, err := strconv.ParseFloat(info.Format.Duration, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse duration %q: %w", info.Format.Duration, err)
+	}
+	return seconds, nil
 }

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
@@ -1029,6 +1029,174 @@ func ffmpegConcatenateMediaHandler(ctx context.Context, request mcp.CallToolRequ
 	return mcp.NewToolResultText(strings.Join(messageParts, " ")), nil
 }
 
+// addTrimMediaTool defines and registers the 'ffmpeg_trim_media' tool.
+// This tool extracts a single contiguous segment (a cut/trim) from an audio or video
+// file. It works identically for audio and video because it operates on ffmpeg's
+// -ss/-t seek-and-duration options, which apply to any stream type.
+func addTrimMediaTool(s *server.MCPServer, cfg *common.Config) {
+	tool := mcp.NewTool("ffmpeg_trim_media",
+		mcp.WithDescription("Trims (cuts) a single segment from an audio or video file, keeping only the portion between a start time and an end time (or for a given duration). Works for both audio and video inputs. "+
+			"By default the segment is extracted with a fast, lossless stream copy (no re-encode). Because a stream copy can only begin on a keyframe, the actual cut may start at the nearest keyframe at or before the requested start time, so it may not be exactly frame-accurate. "+
+			"Set re_encode=true for a frame-accurate cut at the exact start time; this re-encodes the segment, which is slower and slightly lossy. If a stream copy is not possible for the chosen output container, the tool automatically falls back to a re-encode."),
+		mcp.WithString("input_media_uri", mcp.Required(), mcp.Description("URI of the input audio or video file (local path or gs://).")),
+		mcp.WithNumber("start_time", mcp.Required(), mcp.Description("Start time of the segment to keep, in seconds from the beginning of the file (e.g., 5 or 12.5). Must be within the file's duration.")),
+		mcp.WithNumber("duration", mcp.Description("Optional. Length of the segment to keep, in seconds (e.g., 10). Provide either 'duration' or 'end_time'. If both are given, 'duration' takes precedence.")),
+		mcp.WithNumber("end_time", mcp.Description("Optional. End time of the segment to keep, in seconds from the beginning of the file. Must be greater than 'start_time'. Used only when 'duration' is not provided.")),
+		mcp.WithBoolean("re_encode", mcp.DefaultBool(false), mcp.Description("Optional. When true, re-encodes the segment for a frame-accurate cut at the exact start time instead of the default fast, lossless stream copy. Defaults to false.")),
+		mcp.WithString("output_filename", mcp.Description("Optional. Desired name for the output file (e.g., 'clip.mp4'). The client-provided extension is honored and selects the output format. Takes precedence over the deprecated output_file_name. If omitted, a unique name is generated and the input's extension is preserved. An existing file of the same name is overwritten.")),
+		mcp.WithString("output_file_name", mcp.Description("Optional (deprecated; use output_filename). Desired name for the output file (e.g., 'clip.mp4').")),
+		mcp.WithString("output_local_dir", mcp.Description("Optional. Local directory to save the output file.")),
+		mcp.WithString("output_gcs_bucket", mcp.Description("Optional. GCS bucket to upload the output file to (uses GENMEDIA_BUCKET if set and this is empty).")),
+	)
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return ffmpegTrimMediaHandler(ctx, request, cfg)
+	})
+}
+
+// ffmpegTrimMediaHandler is the handler for the 'ffmpeg_trim_media' tool. It prepares
+// the input, resolves the requested time range (start plus either an explicit duration
+// or an end time), validates the range against the file's actual duration, and then
+// extracts the segment. The output container defaults to the input's extension so a
+// stream copy stays valid, unless the caller specifies an output filename with its own
+// extension.
+func ffmpegTrimMediaHandler(ctx context.Context, request mcp.CallToolRequest, cfg *common.Config) (*mcp.CallToolResult, error) {
+	tr := otel.Tracer(serviceName)
+	ctx, span := tr.Start(ctx, "ffmpeg_trim_media")
+	defer span.End()
+
+	startTime := time.Now()
+	argsMap, err := getArguments(request)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	log.Printf("Handling %s request with arguments: %v", "ffmpeg_trim_media", argsMap)
+
+	inputMediaURI, _ := argsMap["input_media_uri"].(string)
+	if strings.TrimSpace(inputMediaURI) == "" {
+		return mcp.NewToolResultError("Parameter 'input_media_uri' is required."), nil
+	}
+
+	startSeconds, hasStart := argsMap["start_time"].(float64)
+	if !hasStart {
+		return mcp.NewToolResultError("Parameter 'start_time' is required and must be a number (seconds)."), nil
+	}
+	if startSeconds < 0 {
+		return mcp.NewToolResultError("Parameter 'start_time' must not be negative."), nil
+	}
+
+	durationSeconds, hasDuration := argsMap["duration"].(float64)
+	endSeconds, hasEnd := argsMap["end_time"].(float64)
+
+	switch {
+	case hasDuration:
+		if durationSeconds <= 0 {
+			return mcp.NewToolResultError("Parameter 'duration' must be greater than 0."), nil
+		}
+	case hasEnd:
+		if endSeconds <= startSeconds {
+			return mcp.NewToolResultError("Parameter 'end_time' must be greater than 'start_time'."), nil
+		}
+		durationSeconds = endSeconds - startSeconds
+	default:
+		return mcp.NewToolResultError("Either 'duration' or 'end_time' must be provided."), nil
+	}
+
+	reEncode, _ := argsMap["re_encode"].(bool)
+	outputFileName := resolveAVToolOutputFilename(argsMap)
+	outputLocalDir, _ := argsMap["output_local_dir"].(string)
+	outputGCSBucket, _ := argsMap["output_gcs_bucket"].(string)
+	outputGCSBucket = strings.TrimSpace(outputGCSBucket)
+
+	if outputGCSBucket == "" && cfg.GenmediaBucket != "" {
+		outputGCSBucket = cfg.GenmediaBucket
+		log.Printf("Handler ffmpeg_trim_media: 'output_gcs_bucket' parameter not provided, using default from GENMEDIA_BUCKET: %s", outputGCSBucket)
+	}
+	if outputGCSBucket != "" {
+		outputGCSBucket = strings.TrimPrefix(outputGCSBucket, "gs://")
+	}
+
+	span.SetAttributes(
+		attribute.String("input_media_uri", inputMediaURI),
+		attribute.Float64("start_time", startSeconds),
+		attribute.Float64("duration", durationSeconds),
+		attribute.Bool("re_encode", reEncode),
+		attribute.String("output_file_name", outputFileName),
+		attribute.String("output_local_dir", outputLocalDir),
+		attribute.String("output_gcs_bucket", outputGCSBucket),
+	)
+
+	localInputMedia, inputCleanup, err := common.PrepareInputFile(ctx, inputMediaURI, "trim_input", cfg.ProjectID)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to prepare input media: %v", err)), nil
+	}
+	defer inputCleanup()
+
+	// Validate the requested range against the file's actual duration when it can be
+	// determined. If the duration is unknown (some streams don't report one), skip
+	// validation and let ffmpeg handle it rather than rejecting a valid request.
+	if mediaDuration, probeErr := probeMediaDurationSeconds(ctx, localInputMedia); probeErr != nil {
+		log.Printf("Handler ffmpeg_trim_media: could not determine input duration, skipping range validation: %v", probeErr)
+	} else if startSeconds >= mediaDuration {
+		return mcp.NewToolResultError(fmt.Sprintf("Parameter 'start_time' (%.3fs) is at or beyond the input's duration (%.3fs).", startSeconds, mediaDuration)), nil
+	}
+
+	// Default the output container to the input's extension so a stream copy remains
+	// valid. A client-provided output filename extension overrides this.
+	defaultOutputExt := strings.ToLower(strings.TrimPrefix(filepath.Ext(localInputMedia), "."))
+	if defaultOutputExt == "" {
+		defaultOutputExt = "mp4"
+	}
+	if outputFileName != "" {
+		if userExt := strings.ToLower(strings.TrimPrefix(filepath.Ext(outputFileName), ".")); userExt != "" {
+			defaultOutputExt = userExt
+		}
+	}
+
+	tempOutputFile, finalOutputFilename, outputCleanup, err := common.HandleOutputPreparation(outputFileName, defaultOutputExt)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to prepare output file: %v", err)), nil
+	}
+	defer outputCleanup()
+
+	usedReEncode, ffmpegErr := executeTrimMedia(ctx, localInputMedia, tempOutputFile, startSeconds, durationSeconds, reEncode)
+	if ffmpegErr != nil {
+		span.RecordError(ffmpegErr)
+		return mcp.NewToolResultError(fmt.Sprintf("FFMpeg trim failed: %v", ffmpegErr)), nil
+	}
+	span.SetAttributes(attribute.Bool("used_re_encode", usedReEncode))
+
+	finalLocalPath, finalGCSPath, processErr := common.ProcessOutputAfterFFmpeg(ctx, tempOutputFile, finalOutputFilename, outputLocalDir, outputGCSBucket, cfg.ProjectID)
+	if processErr != nil {
+		span.RecordError(processErr)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to process FFMpeg output: %v", processErr)), nil
+	}
+
+	duration := time.Since(startTime)
+	span.SetAttributes(attribute.Float64("duration_ms", float64(duration.Milliseconds())))
+
+	var messageParts []string
+	mode := "stream copy (no re-encode)"
+	if usedReEncode {
+		mode = "re-encode"
+	}
+	messageParts = append(messageParts, fmt.Sprintf("Trim of %.3fs starting at %.3fs (%s) completed in %v.", durationSeconds, startSeconds, mode, duration))
+	if outputLocalDir != "" && finalLocalPath != "" {
+		messageParts = append(messageParts, fmt.Sprintf("Output saved locally to: %s.", finalLocalPath))
+	} else if finalLocalPath != "" && (outputGCSBucket == "" || finalGCSPath == "") {
+		messageParts = append(messageParts, fmt.Sprintf("Temporary output was at: %s (cleaned up if not moved/uploaded).", finalLocalPath))
+	}
+	if finalGCSPath != "" {
+		messageParts = append(messageParts, fmt.Sprintf("Output uploaded to GCS: %s.", finalGCSPath))
+	}
+	if len(messageParts) == 1 {
+		messageParts = append(messageParts, "No specific output location requested beyond temporary processing.")
+	}
+	return mcp.NewToolResultText(strings.Join(messageParts, " ")), nil
+}
+
 // addAdjustVolumeTool defines and registers the 'ffmpeg_adjust_volume' tool.
 // This tool allows for changing the volume of an audio file by a specified decibel (dB) level.
 func addAdjustVolumeTool(s *server.MCPServer, cfg *common.Config) {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/trim_media_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/trim_media_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildTrimArgs verifies the ffmpeg argument construction for both the
+// stream-copy and re-encode paths, including decimal time formatting.
+func TestBuildTrimArgs(t *testing.T) {
+	t.Run("stream copy places -ss before -i, adds -c copy", func(t *testing.T) {
+		got := buildTrimArgs("in.mp4", "out.mp4", 12.5, 10, true)
+		want := []string{"-y", "-ss", "12.5", "-i", "in.mp4", "-t", "10", "-c", "copy", "-avoid_negative_ts", "make_zero", "out.mp4"}
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Errorf("buildTrimArgs stream-copy = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("re-encode omits -c copy", func(t *testing.T) {
+		got := buildTrimArgs("in.wav", "out.wav", 0, 3, false)
+		want := []string{"-y", "-ss", "0", "-i", "in.wav", "-t", "3", "out.wav"}
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Errorf("buildTrimArgs re-encode = %v, want %v", got, want)
+		}
+		if strings.Contains(strings.Join(got, " "), "-c copy") {
+			t.Errorf("re-encode args should not contain -c copy: %v", got)
+		}
+	})
+}
+
+// TestFormatSeconds ensures times render as plain decimals without scientific
+// notation or trailing zeros, which keeps the emitted ffmpeg command readable.
+func TestFormatSeconds(t *testing.T) {
+	cases := map[float64]string{
+		0:      "0",
+		3:      "3",
+		12.5:   "12.5",
+		0.25:   "0.25",
+		90.125: "90.125",
+		3600:   "3600",
+	}
+	for in, want := range cases {
+		if got := formatSeconds(in); got != want {
+			t.Errorf("formatSeconds(%v) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds a new MCP tool, **`ffmpeg_trim_media`**, to `mcp-avtool-go`. It extracts a single contiguous segment (a cut/trim) from an audio **or** video file, given a start time plus either a duration or an end time. avtool previously had no trim/cut operation — this fills a common gap for the audio/video transform pipeline (e.g. trimming chirp3 TTS output before chaining).

## How it works

- **Default: fast, lossless stream copy** (`ffmpeg -ss <start> -i <input> -t <duration> -c copy -avoid_negative_ts make_zero <out>`). No re-encode.
- **Precision tradeoff (documented in the tool description):** a stream copy can only begin on a keyframe, so the actual cut may start at the nearest keyframe at or before the requested start time and may not be exactly frame-accurate.
- **`re_encode=true`** re-encodes for a frame-accurate cut at the exact start time (slower, slightly lossy).
- **Automatic fallback:** if a stream copy isn't possible for the chosen output container, the tool re-encodes automatically so callers still get a usable clip.
- Works identically for audio and video, since `-ss`/`-t` apply to any stream type.

## Conventions followed

- GCS + local I/O via `PrepareInputFile` / `ProcessOutputAfterFFmpeg` (accepts `gs://` and local paths).
- `output_filename` / deprecated `output_file_name` precedence, container-preserving extension handling (input extension preserved by default).
- Time parameters as numeric seconds (`start_time`, `duration`, `end_time`), consistent with the genmedia suite's duration-in-seconds convention.
- OpenTelemetry spans and the same error-handling/message style as the other 8 tools.
- Registered in `avtool.go` alongside the existing tools.

## Validation / error handling

- Requires `start_time` and one of `duration` / `end_time`; rejects negative start, non-positive duration, and `end_time <= start_time`.
- Probes the input's actual duration via ffprobe and rejects a `start_time` at/beyond the file length. If duration can't be determined, validation is skipped and ffmpeg handles it (no false rejections).

## Verification

- `go build ./...` and `go vet ./...` — pass.
- `go test ./...` — pass (added unit tests for the argument builder and time formatting).
- **Empirical ffmpeg runs** on generated 10s sample video (H.264/AAC) and 10s WAV audio, driving the actual handler:
  - Video stream-copy, start=2s dur=4s → output ~4.24s ✅
  - Video re-encode, start=1s end=7s → output 6.000s (frame-accurate) ✅
  - Audio stream-copy, start=3s dur=2.5s → output ~2.51s ✅
  - `start_time` beyond duration → rejected with a clear message ✅
  - neither duration nor end_time → rejected ✅

## Docs

Updated `README.md` and `compositing_recipes.md` with the new tool and its ffmpeg recipes.