### PR TITLE
feat(mcp-avtool-go): add EBU R128 loudness normalization tool

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
@@ -62,6 +62,13 @@ The `avtool` provides the following functionalities, exposed as MCP tools:
     *   By default the segment is extracted with a fast, lossless stream copy (`-c copy`). Because a stream copy can only begin on a keyframe, the cut may start at the nearest keyframe at or before the requested start time, so it may not be exactly frame-accurate. Set `re_encode=true` for a frame-accurate cut (slower, slightly lossy). If a stream copy is not possible for the chosen output container, the tool automatically falls back to a re-encode.
     *   Output: The trimmed media file (input container/extension preserved by default). Can be saved locally and/or to a GCS bucket.
 
+*   **`ffmpeg_normalize_loudness`**:
+    *   Normalizes the perceived loudness of an audio file (or the audio track of a video file) to a target level using EBU R128 loudness normalization. Works for both pure-audio inputs and videos with an audio track.
+    *   Uses the accurate two-pass `loudnorm` method: a first pass measures the input's actual integrated loudness, true peak, loudness range and threshold, and a second pass applies a linear correction toward the target using those measurements. This is more accurate than a single-pass normalize.
+    *   Inputs: URI of the input media file. Optional `target_loudness` (integrated LUFS, default `-16`), `target_true_peak` (dBTP, default `-1.5`), and `target_loudness_range` (LU, default `11`). The `-16` LUFS default suits streaming/web/podcast playback; use `-23` for EBU R128 broadcast delivery.
+    *   When the input is a video, its video stream is copied unchanged and only the audio is normalized. The audio sample rate is preserved. Fails if the input has no audio stream.
+    *   Output: The loudness-normalized media file (input container/extension preserved by default). Can be saved locally and/or to a GCS bucket.
+
 ## Requirements
 
 *   **Go**: Version 1.18 or higher (as per `go.mod` if specified, otherwise latest stable).

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -99,6 +99,7 @@ func main() {
 	addCreateGifTool(s, cfg)
 	addGetMediaInfoTool(s, cfg)
 	addTrimMediaTool(s, cfg)
+	addNormalizeLoudnessTool(s, cfg)
 
 	switch transport {
 	case "sse":

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
@@ -50,6 +50,51 @@ func executeGetMediaInfo(ctx context.Context, localInputMedia string) (string, e
 	return runFFprobeCommand(ctx, ffprobeArgs...)
 }
 
+// mediaStreamInfo summarizes the stream layout of a media file: whether it carries
+// audio and/or video, plus the first audio stream's sample rate (empty when unknown).
+type mediaStreamInfo struct {
+	HasAudio   bool
+	HasVideo   bool
+	SampleRate string
+}
+
+// probeMediaStreamInfo inspects a media file with ffprobe and reports which stream
+// types it contains and the audio sample rate. Callers use it to reject inputs that
+// have no audio stream and to preserve the source sample rate through filters that
+// would otherwise resample.
+func probeMediaStreamInfo(ctx context.Context, localInputMedia string) (mediaStreamInfo, error) {
+	var result mediaStreamInfo
+
+	infoJSON, err := executeGetMediaInfo(ctx, localInputMedia)
+	if err != nil {
+		return result, fmt.Errorf("failed to probe media info: %w", err)
+	}
+
+	var info struct {
+		Streams []struct {
+			CodecType  string `json:"codec_type"`
+			SampleRate string `json:"sample_rate"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal([]byte(infoJSON), &info); err != nil {
+		return result, fmt.Errorf("failed to parse media info: %w", err)
+	}
+
+	for _, stream := range info.Streams {
+		switch stream.CodecType {
+		case "audio":
+			result.HasAudio = true
+			if result.SampleRate == "" {
+				result.SampleRate = strings.TrimSpace(stream.SampleRate)
+			}
+		case "video":
+			result.HasVideo = true
+		}
+	}
+
+	return result, nil
+}
+
 // probeMediaDurationSeconds returns the total duration of a media file in seconds,
 // parsed from the container's format metadata. It is used to validate trim ranges
 // against the actual length of the input. A non-nil error indicates the duration

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands.go
@@ -1,0 +1,154 @@
+// Package main implements an MCP server for audio and video processing.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Default EBU R128 loudness targets. -16 LUFS integrated is the common target for
+// streaming/web/podcast playback (Spotify, Apple Podcasts, YouTube all sit at or
+// near it), which matches this server's role of levelling generated speech and
+// media for downstream playback. A -1.5 dBTP true-peak ceiling leaves headroom for
+// lossy-codec inter-sample overshoot, and an 11 LU loudness range is the widely used
+// default for the loudnorm filter. Callers can override any of these per request.
+const (
+	defaultTargetLoudnessLUFS   = -16.0
+	defaultTargetTruePeakDBTP   = -1.5
+	defaultTargetLoudnessRangeLU = 11.0
+)
+
+// loudnormTarget holds the desired EBU R128 output targets for a normalization run.
+type loudnormTarget struct {
+	IntegratedLUFS float64 // I: target integrated loudness in LUFS
+	TruePeakDBTP   float64 // TP: maximum true peak in dBTP
+	LoudnessRangeLU float64 // LRA: target loudness range in LU
+}
+
+// loudnormMeasurements captures the values the first (analysis) pass of the
+// loudnorm filter prints as JSON. They are kept as strings because they are fed
+// straight back into the second pass's filter string; parsing them to floats would
+// only risk reformatting drift.
+type loudnormMeasurements struct {
+	InputI       string `json:"input_i"`
+	InputTP      string `json:"input_tp"`
+	InputLRA     string `json:"input_lra"`
+	InputThresh  string `json:"input_thresh"`
+	TargetOffset string `json:"target_offset"`
+}
+
+// formatLoudnormValue renders a target parameter as a plain decimal string for the
+// ffmpeg filter (e.g. -16 -> "-16", -1.5 -> "-1.5"), avoiding scientific notation
+// and trailing zeros.
+func formatLoudnormValue(v float64) string {
+	return strconv.FormatFloat(v, 'f', -1, 64)
+}
+
+// buildLoudnormMeasureArgs builds the first-pass ffmpeg arguments. This pass does
+// not write a media file: it runs the loudnorm filter in analysis mode against the
+// requested targets and asks it to print the measured integrated loudness, true
+// peak, loudness range and threshold as JSON (to stderr). The decode is discarded
+// via the null muxer.
+func buildLoudnormMeasureArgs(input string, target loudnormTarget) []string {
+	filter := fmt.Sprintf("loudnorm=I=%s:TP=%s:LRA=%s:print_format=json",
+		formatLoudnormValue(target.IntegratedLUFS),
+		formatLoudnormValue(target.TruePeakDBTP),
+		formatLoudnormValue(target.LoudnessRangeLU),
+	)
+	return []string{"-hide_banner", "-i", input, "-af", filter, "-f", "null", "-"}
+}
+
+// buildLoudnormApplyArgs builds the second-pass ffmpeg arguments. It applies the
+// loudnorm filter using the measured values from the first pass, which lets the
+// filter perform an accurate linear correction toward the target instead of the
+// less precise single-pass dynamic mode. linear=true requests linear normalization;
+// ffmpeg automatically falls back to dynamic if a linear gain would breach the
+// true-peak ceiling.
+//
+// When the input carries a video stream the video is stream-copied so only the audio
+// is re-encoded. When a source sample rate is known it is re-applied, because the
+// loudnorm filter internally resamples to 192 kHz and would otherwise emit audio at
+// that rate.
+func buildLoudnormApplyArgs(input, output string, target loudnormTarget, m loudnormMeasurements, hasVideo bool, sampleRate string) []string {
+	filter := fmt.Sprintf(
+		"loudnorm=I=%s:TP=%s:LRA=%s:measured_I=%s:measured_TP=%s:measured_LRA=%s:measured_thresh=%s:offset=%s:linear=true:print_format=summary",
+		formatLoudnormValue(target.IntegratedLUFS),
+		formatLoudnormValue(target.TruePeakDBTP),
+		formatLoudnormValue(target.LoudnessRangeLU),
+		m.InputI, m.InputTP, m.InputLRA, m.InputThresh, m.TargetOffset,
+	)
+	args := []string{"-y", "-hide_banner", "-i", input, "-af", filter}
+	if hasVideo {
+		args = append(args, "-c:v", "copy")
+	}
+	if strings.TrimSpace(sampleRate) != "" {
+		args = append(args, "-ar", sampleRate)
+	}
+	args = append(args, output)
+	return args
+}
+
+// parseLoudnormStats extracts the loudnorm analysis JSON from ffmpeg's combined
+// output. The filter prints a single JSON object at the end of the run, so the last
+// brace-delimited block is located and decoded. All five fields the second pass
+// depends on must be present and non-empty; a missing field (or a non-finite
+// measurement such as "-inf" from pure silence) is reported as an error so the
+// caller does not attempt an invalid correction pass.
+func parseLoudnormStats(output string) (loudnormMeasurements, error) {
+	var m loudnormMeasurements
+
+	start := strings.LastIndex(output, "{")
+	end := strings.LastIndex(output, "}")
+	if start == -1 || end == -1 || end < start {
+		return m, fmt.Errorf("could not locate loudnorm JSON stats in ffmpeg output")
+	}
+
+	if err := json.Unmarshal([]byte(output[start:end+1]), &m); err != nil {
+		return m, fmt.Errorf("failed to parse loudnorm JSON stats: %w", err)
+	}
+
+	for name, value := range map[string]string{
+		"input_i":       m.InputI,
+		"input_tp":      m.InputTP,
+		"input_lra":     m.InputLRA,
+		"input_thresh":  m.InputThresh,
+		"target_offset": m.TargetOffset,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return m, fmt.Errorf("loudnorm stats missing %q value", name)
+		}
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil || math.IsInf(parsed, 0) || math.IsNaN(parsed) {
+			return m, fmt.Errorf("loudnorm stats %q is not a finite number (%q); the input may be silent or have no measurable loudness", name, value)
+		}
+	}
+
+	return m, nil
+}
+
+// executeNormalizeLoudness runs the full two-pass EBU R128 normalization: it first
+// measures the input against the requested targets, parses the reported statistics,
+// then applies the correction using those measurements. The parsed measurements are
+// returned so the caller can report the input's original loudness.
+func executeNormalizeLoudness(ctx context.Context, input, output string, target loudnormTarget, hasVideo bool, sampleRate string) (loudnormMeasurements, error) {
+	measureOutput, err := runFFmpegCommand(ctx, buildLoudnormMeasureArgs(input, target)...)
+	if err != nil {
+		return loudnormMeasurements{}, fmt.Errorf("loudness measurement pass failed: %w", err)
+	}
+
+	measurements, err := parseLoudnormStats(measureOutput)
+	if err != nil {
+		return loudnormMeasurements{}, err
+	}
+
+	if _, err := runFFmpegCommand(ctx, buildLoudnormApplyArgs(input, output, target, measurements, hasVideo, sampleRate)...); err != nil {
+		return loudnormMeasurements{}, fmt.Errorf("loudness correction pass failed: %w", err)
+	}
+
+	return measurements, nil
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatLoudnormValue ensures target parameters render as plain decimals
+// suitable for the ffmpeg filter string.
+func TestFormatLoudnormValue(t *testing.T) {
+	cases := map[float64]string{
+		-16:   "-16",
+		-1.5:  "-1.5",
+		11:    "11",
+		-23:   "-23",
+		-0.25: "-0.25",
+	}
+	for in, want := range cases {
+		if got := formatLoudnormValue(in); got != want {
+			t.Errorf("formatLoudnormValue(%v) = %q, want %q", in, want, got)
+		}
+	}
+}
+
+// TestBuildLoudnormMeasureArgs verifies the first-pass analysis command: it must
+// request JSON stats and discard the decode via the null muxer, and must not write
+// an output file.
+func TestBuildLoudnormMeasureArgs(t *testing.T) {
+	target := loudnormTarget{IntegratedLUFS: -16, TruePeakDBTP: -1.5, LoudnessRangeLU: 11}
+	got := buildLoudnormMeasureArgs("in.wav", target)
+	want := []string{"-hide_banner", "-i", "in.wav", "-af", "loudnorm=I=-16:TP=-1.5:LRA=11:print_format=json", "-f", "null", "-"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("buildLoudnormMeasureArgs = %v, want %v", got, want)
+	}
+}
+
+// TestBuildLoudnormApplyArgs verifies the second-pass command feeds the measured
+// values back into the filter, requests linear normalization, copies video only when
+// present and re-applies a known sample rate.
+func TestBuildLoudnormApplyArgs(t *testing.T) {
+	target := loudnormTarget{IntegratedLUFS: -16, TruePeakDBTP: -1.5, LoudnessRangeLU: 11}
+	m := loudnormMeasurements{
+		InputI: "-27.61", InputTP: "-10.75", InputLRA: "6.20", InputThresh: "-38.44", TargetOffset: "0.47",
+	}
+
+	t.Run("audio only preserves sample rate, no video copy", func(t *testing.T) {
+		got := buildLoudnormApplyArgs("in.wav", "out.wav", target, m, false, "44100")
+		joined := strings.Join(got, " ")
+		wantFilter := "loudnorm=I=-16:TP=-1.5:LRA=11:measured_I=-27.61:measured_TP=-10.75:measured_LRA=6.20:measured_thresh=-38.44:offset=0.47:linear=true:print_format=summary"
+		if !strings.Contains(joined, wantFilter) {
+			t.Errorf("apply args missing expected filter.\n got: %s\nwant substring: %s", joined, wantFilter)
+		}
+		if strings.Contains(joined, "-c:v copy") {
+			t.Errorf("audio-only apply args should not stream-copy video: %s", joined)
+		}
+		if !strings.Contains(joined, "-ar 44100") {
+			t.Errorf("apply args should re-apply the source sample rate: %s", joined)
+		}
+		if got[len(got)-1] != "out.wav" {
+			t.Errorf("output path should be the last argument, got %q", got[len(got)-1])
+		}
+	})
+
+	t.Run("video input copies video stream", func(t *testing.T) {
+		got := buildLoudnormApplyArgs("in.mp4", "out.mp4", target, m, true, "48000")
+		joined := strings.Join(got, " ")
+		if !strings.Contains(joined, "-c:v copy") {
+			t.Errorf("video apply args should stream-copy video: %s", joined)
+		}
+	})
+
+	t.Run("unknown sample rate omits -ar", func(t *testing.T) {
+		got := buildLoudnormApplyArgs("in.wav", "out.wav", target, m, false, "")
+		if strings.Contains(strings.Join(got, " "), "-ar") {
+			t.Errorf("apply args should omit -ar when sample rate unknown: %v", got)
+		}
+	})
+}
+
+// TestParseLoudnormStats covers extracting the JSON block from realistic ffmpeg
+// output and the error paths for missing or non-finite measurements.
+func TestParseLoudnormStats(t *testing.T) {
+	t.Run("parses trailing JSON block", func(t *testing.T) {
+		output := `[Parsed_loudnorm_0 @ 0x556]
+Input Integrated:    -27.6 LUFS
+{
+	"input_i" : "-27.61",
+	"input_tp" : "-10.75",
+	"input_lra" : "6.20",
+	"input_thresh" : "-38.44",
+	"output_i" : "-16.00",
+	"output_tp" : "-1.49",
+	"output_lra" : "5.60",
+	"output_thresh" : "-27.19",
+	"normalization_type" : "dynamic",
+	"target_offset" : "0.47"
+}
+`
+		m, err := parseLoudnormStats(output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.InputI != "-27.61" || m.InputTP != "-10.75" || m.InputLRA != "6.20" || m.InputThresh != "-38.44" || m.TargetOffset != "0.47" {
+			t.Errorf("parsed measurements incorrect: %+v", m)
+		}
+	})
+
+	t.Run("errors when no JSON present", func(t *testing.T) {
+		if _, err := parseLoudnormStats("no json here"); err == nil {
+			t.Error("expected error when no JSON block is present")
+		}
+	})
+
+	t.Run("errors on non-finite measurement", func(t *testing.T) {
+		output := `{
+	"input_i" : "-inf",
+	"input_tp" : "-120.00",
+	"input_lra" : "0.00",
+	"input_thresh" : "-inf",
+	"target_offset" : "0.00"
+}`
+		if _, err := parseLoudnormStats(output); err == nil {
+			t.Error("expected error for non-finite input_i (silent input)")
+		}
+	})
+
+	t.Run("errors on missing field", func(t *testing.T) {
+		output := `{
+	"input_i" : "-23.0",
+	"input_tp" : "-5.0",
+	"input_lra" : "7.0"
+}`
+		if _, err := parseLoudnormStats(output); err == nil {
+			t.Error("expected error when required fields are missing")
+		}
+	})
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
@@ -1197,6 +1197,169 @@ func ffmpegTrimMediaHandler(ctx context.Context, request mcp.CallToolRequest, cf
 	return mcp.NewToolResultText(strings.Join(messageParts, " ")), nil
 }
 
+// addNormalizeLoudnessTool defines and registers the 'ffmpeg_normalize_loudness' tool.
+// It performs EBU R128 loudness normalization on any audio (or audio-containing video)
+// file using the accurate two-pass loudnorm method.
+func addNormalizeLoudnessTool(s *server.MCPServer, cfg *common.Config) {
+	tool := mcp.NewTool("ffmpeg_normalize_loudness",
+		mcp.WithDescription("Normalizes the perceived loudness of an audio file (or the audio track of a video file) to a target level using EBU R128 loudness normalization. "+
+			"This uses the accurate two-pass method: a first pass measures the input's actual integrated loudness, true peak, loudness range and threshold, and a second pass applies a linear correction toward the target using those measurements. This is more accurate than a single-pass normalize and avoids over- or under-correction. "+
+			"Useful for levelling recordings or generated speech so that quiet inputs are brought up and loud inputs are brought down to a consistent playback loudness. "+
+			"Defaults target -16 LUFS integrated loudness, -1.5 dBTP true peak and 11 LU loudness range, which suit streaming and web playback; all three can be overridden. When the input is a video its video stream is copied unchanged and only the audio is normalized. Fails if the input has no audio stream."),
+		mcp.WithString("input_media_uri", mcp.Required(), mcp.Description("URI of the input audio or video file (local path or gs://). Must contain an audio stream.")),
+		mcp.WithNumber("target_loudness", mcp.DefaultNumber(defaultTargetLoudnessLUFS), mcp.Description("Optional. Target integrated loudness in LUFS (EBU R128 'I'). Defaults to -16 (common for streaming/web/podcast). Use -23 for EBU R128 broadcast delivery. Valid range: -70 to -5.")),
+		mcp.WithNumber("target_true_peak", mcp.DefaultNumber(defaultTargetTruePeakDBTP), mcp.Description("Optional. Maximum true peak in dBTP (loudnorm 'TP'). Defaults to -1.5. Valid range: -9 to 0.")),
+		mcp.WithNumber("target_loudness_range", mcp.DefaultNumber(defaultTargetLoudnessRangeLU), mcp.Description("Optional. Target loudness range in LU (loudnorm 'LRA'). Defaults to 11. Valid range: 1 to 50.")),
+		mcp.WithString("output_filename", mcp.Description("Optional. Desired name for the output file (e.g., 'normalized.wav'). The client-provided extension is honored and selects the output format. Takes precedence over the deprecated output_file_name. If omitted, a unique name is generated and the input's extension is preserved. An existing file of the same name is overwritten.")),
+		mcp.WithString("output_file_name", mcp.Description("Optional (deprecated; use output_filename). Desired name for the output file (e.g., 'normalized.wav').")),
+		mcp.WithString("output_local_dir", mcp.Description("Optional. Local directory to save the output file.")),
+		mcp.WithString("output_gcs_bucket", mcp.Description("Optional. GCS bucket to upload the output file to (uses GENMEDIA_BUCKET if set and this is empty).")),
+	)
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return ffmpegNormalizeLoudnessHandler(ctx, request, cfg)
+	})
+}
+
+// ffmpegNormalizeLoudnessHandler is the handler for the 'ffmpeg_normalize_loudness'
+// tool. It prepares the input, verifies it has an audio stream, resolves the target
+// loudness parameters (falling back to sensible defaults), runs the two-pass EBU R128
+// normalization and writes the result to the requested destination.
+func ffmpegNormalizeLoudnessHandler(ctx context.Context, request mcp.CallToolRequest, cfg *common.Config) (*mcp.CallToolResult, error) {
+	tr := otel.Tracer(serviceName)
+	ctx, span := tr.Start(ctx, "ffmpeg_normalize_loudness")
+	defer span.End()
+
+	startTime := time.Now()
+	argsMap, err := getArguments(request)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	log.Printf("Handling %s request with arguments: %v", "ffmpeg_normalize_loudness", argsMap)
+
+	inputMediaURI, _ := argsMap["input_media_uri"].(string)
+	if strings.TrimSpace(inputMediaURI) == "" {
+		return mcp.NewToolResultError("Parameter 'input_media_uri' is required."), nil
+	}
+
+	target := loudnormTarget{
+		IntegratedLUFS:  defaultTargetLoudnessLUFS,
+		TruePeakDBTP:    defaultTargetTruePeakDBTP,
+		LoudnessRangeLU: defaultTargetLoudnessRangeLU,
+	}
+	if v, ok := argsMap["target_loudness"].(float64); ok {
+		target.IntegratedLUFS = v
+	}
+	if v, ok := argsMap["target_true_peak"].(float64); ok {
+		target.TruePeakDBTP = v
+	}
+	if v, ok := argsMap["target_loudness_range"].(float64); ok {
+		target.LoudnessRangeLU = v
+	}
+
+	if target.IntegratedLUFS < -70 || target.IntegratedLUFS > -5 {
+		return mcp.NewToolResultError("Parameter 'target_loudness' must be between -70 and -5 LUFS."), nil
+	}
+	if target.TruePeakDBTP < -9 || target.TruePeakDBTP > 0 {
+		return mcp.NewToolResultError("Parameter 'target_true_peak' must be between -9 and 0 dBTP."), nil
+	}
+	if target.LoudnessRangeLU < 1 || target.LoudnessRangeLU > 50 {
+		return mcp.NewToolResultError("Parameter 'target_loudness_range' must be between 1 and 50 LU."), nil
+	}
+
+	outputFileName := resolveAVToolOutputFilename(argsMap)
+	outputLocalDir, _ := argsMap["output_local_dir"].(string)
+	outputGCSBucket, _ := argsMap["output_gcs_bucket"].(string)
+	outputGCSBucket = strings.TrimSpace(outputGCSBucket)
+
+	if outputGCSBucket == "" && cfg.GenmediaBucket != "" {
+		outputGCSBucket = cfg.GenmediaBucket
+		log.Printf("Handler ffmpeg_normalize_loudness: 'output_gcs_bucket' parameter not provided, using default from GENMEDIA_BUCKET: %s", outputGCSBucket)
+	}
+	if outputGCSBucket != "" {
+		outputGCSBucket = strings.TrimPrefix(outputGCSBucket, "gs://")
+	}
+
+	span.SetAttributes(
+		attribute.String("input_media_uri", inputMediaURI),
+		attribute.Float64("target_loudness", target.IntegratedLUFS),
+		attribute.Float64("target_true_peak", target.TruePeakDBTP),
+		attribute.Float64("target_loudness_range", target.LoudnessRangeLU),
+		attribute.String("output_file_name", outputFileName),
+		attribute.String("output_local_dir", outputLocalDir),
+		attribute.String("output_gcs_bucket", outputGCSBucket),
+	)
+
+	localInputMedia, inputCleanup, err := common.PrepareInputFile(ctx, inputMediaURI, "loudnorm_input", cfg.ProjectID)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to prepare input media: %v", err)), nil
+	}
+	defer inputCleanup()
+
+	streamInfo, err := probeMediaStreamInfo(ctx, localInputMedia)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to inspect input media: %v", err)), nil
+	}
+	if !streamInfo.HasAudio {
+		return mcp.NewToolResultError("The input has no audio stream to normalize."), nil
+	}
+
+	// Preserve the input's container by default so the output format is predictable;
+	// a client-provided output filename extension overrides it.
+	defaultOutputExt := strings.ToLower(strings.TrimPrefix(filepath.Ext(localInputMedia), "."))
+	if defaultOutputExt == "" {
+		if streamInfo.HasVideo {
+			defaultOutputExt = "mp4"
+		} else {
+			defaultOutputExt = "wav"
+		}
+	}
+	if outputFileName != "" {
+		if userExt := strings.ToLower(strings.TrimPrefix(filepath.Ext(outputFileName), ".")); userExt != "" {
+			defaultOutputExt = userExt
+		}
+	}
+
+	tempOutputFile, finalOutputFilename, outputCleanup, err := common.HandleOutputPreparation(outputFileName, defaultOutputExt)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to prepare output file: %v", err)), nil
+	}
+	defer outputCleanup()
+
+	measurements, ffmpegErr := executeNormalizeLoudness(ctx, localInputMedia, tempOutputFile, target, streamInfo.HasVideo, streamInfo.SampleRate)
+	if ffmpegErr != nil {
+		span.RecordError(ffmpegErr)
+		return mcp.NewToolResultError(fmt.Sprintf("FFMpeg loudness normalization failed: %v", ffmpegErr)), nil
+	}
+
+	finalLocalPath, finalGCSPath, processErr := common.ProcessOutputAfterFFmpeg(ctx, tempOutputFile, finalOutputFilename, outputLocalDir, outputGCSBucket, cfg.ProjectID)
+	if processErr != nil {
+		span.RecordError(processErr)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to process FFMpeg output: %v", processErr)), nil
+	}
+
+	duration := time.Since(startTime)
+	span.SetAttributes(attribute.Float64("duration_ms", float64(duration.Milliseconds())))
+
+	var messageParts []string
+	messageParts = append(messageParts, fmt.Sprintf("Loudness normalization to %s LUFS (measured input loudness %s LUFS, true peak %s dBTP) completed in %v.",
+		formatLoudnormValue(target.IntegratedLUFS), measurements.InputI, measurements.InputTP, duration))
+	if outputLocalDir != "" && finalLocalPath != "" {
+		messageParts = append(messageParts, fmt.Sprintf("Output saved locally to: %s.", finalLocalPath))
+	} else if finalLocalPath != "" && (outputGCSBucket == "" || finalGCSPath == "") {
+		messageParts = append(messageParts, fmt.Sprintf("Temporary output was at: %s (cleaned up if not moved/uploaded).", finalLocalPath))
+	}
+	if finalGCSPath != "" {
+		messageParts = append(messageParts, fmt.Sprintf("Output uploaded to GCS: %s.", finalGCSPath))
+	}
+	if len(messageParts) == 1 {
+		messageParts = append(messageParts, "No specific output location requested beyond temporary processing.")
+	}
+	return mcp.NewToolResultText(strings.Join(messageParts, " ")), nil
+}
+
 // addAdjustVolumeTool defines and registers the 'ffmpeg_adjust_volume' tool.
 // This tool allows for changing the volume of an audio file by a specified decibel (dB) level.
 func addAdjustVolumeTool(s *server.MCPServer, cfg *common.Config) {


### PR DESCRIPTION
## Summary

Adds `ffmpeg_normalize_loudness` to `mcp-avtool-go`, filling a real gap: avtool could adjust volume by a fixed dB amount and mix/layer audio, but had no way to normalize *perceived loudness* to a consistent target. This is a generic audio tool — it normalizes whatever audio file it is given, whether pure audio or the audio track of a video.

## What it does

- **Two-pass EBU R128 normalization.** Pass 1 runs ffmpeg's `loudnorm` filter in analysis mode and parses the JSON it prints (integrated loudness, true peak, loudness range, threshold, offset). Pass 2 re-applies `loudnorm` with those measured values and `linear=true`, so the correction is a single accurate linear gain toward the target rather than the less precise single-pass dynamic mode. ffmpeg automatically falls back to dynamic if a linear gain would breach the true-peak ceiling.
- **Sensible, overridable targets.** Defaults are `-16 LUFS` integrated loudness, `-1.5 dBTP` true peak, and `11 LU` loudness range. `-16 LUFS` is the common streaming/web/podcast target and matches this server's role of levelling generated speech and media for downstream playback; callers can override all three (e.g. `-23 LUFS` for broadcast delivery). Targets are range-validated.
- **Audio and video inputs.** For video, the video stream is copied unchanged (`-c:v copy`) and only the audio is normalized. The source audio sample rate is preserved (the filter internally resamples to 192 kHz otherwise).
- **Real error handling.** Inputs with no audio stream are rejected up front; non-finite measurements (e.g. from pure silence) are reported rather than fed into an invalid second pass.
- **I/O conventions.** Local paths and `gs://` URIs in and out, `output_filename`/`output_local_dir`/`output_gcs_bucket`, GENMEDIA_BUCKET default, input container preserved by default — matching the existing tools.

## Verification

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- Unit tests cover argument construction for both passes, JSON stats parsing, and the missing/non-finite-measurement error paths.
- Empirically verified against real ffmpeg by re-measuring the output loudness after normalizing:
  - Quiet audio (WAV): measured input **-46.05 LUFS → output -16.05 LUFS**; sample rate preserved (44100 Hz).
  - Video with audio track (MP4): measured input **-27.80 LUFS → output -15.97 LUFS**; video stream preserved as h264, audio still present.
  - A video with no audio stream is correctly rejected.

## Tool surface

`ffmpeg_normalize_loudness(input_media_uri, [target_loudness=-16], [target_true_peak=-1.5], [target_loudness_range=11], [output_filename], [output_local_dir], [output_gcs_bucket])`