### PR TITLE
feat(mcp-avtool-go): add resize/reframe tool for images and video

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/README.md
@@ -69,6 +69,13 @@ The `avtool` provides the following functionalities, exposed as MCP tools:
     *   When the input is a video, its video stream is copied unchanged and only the audio is normalized. The audio sample rate is preserved. Fails if the input has no audio stream.
     *   Output: The loudness-normalized media file (input container/extension preserved by default). Can be saved locally and/or to a GCS bucket.
 
+*   **`ffmpeg_resize_reframe`**:
+    *   Resizes and reframes an image or a video to a target geometry. A single image is treated as a one-frame stream, so the same tool handles both image and video inputs.
+    *   Inputs: URI of the input image or video file, plus a target specified as an explicit `width` and/or `height` (pixels) and/or an `aspect_ratio` shorthand (`16:9`, `9:16`, `1:1`). Providing both `width` and `height` sets the exact frame (any `aspect_ratio` is ignored). An `aspect_ratio` combined with a single `width` or `height` computes the other side; used alone it keeps the input's width. A single `width` or `height` alone performs a proportional resize that keeps the input's aspect ratio.
+    *   `reframe_mode` selects how an aspect-ratio mismatch is reconciled: `pad` (default) scales the whole picture to fit and fills the remainder with bars (letterbox/pillarbox), preserving all content; `crop` scales to fill the frame edge-to-edge and trims the overflow. `pad` is the default because it never discards picture content. The pad fill colour is configurable via `pad_color` (default `black`).
+    *   Target dimensions are automatically rounded to even numbers, which many video codecs (e.g. H.264/yuv420p) require. Any audio stream is copied through unchanged.
+    *   Output: The resized/reframed media file (input container/extension preserved by default). Can be saved locally and/or to a GCS bucket.
+
 ## Requirements
 
 *   **Go**: Version 1.18 or higher (as per `go.mod` if specified, otherwise latest stable).

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/avtool.go
@@ -100,6 +100,7 @@ func main() {
 	addGetMediaInfoTool(s, cfg)
 	addTrimMediaTool(s, cfg)
 	addNormalizeLoudnessTool(s, cfg)
+	addResizeReframeTool(s, cfg)
 
 	switch transport {
 	case "sse":

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1346,6 +1347,204 @@ func ffmpegNormalizeLoudnessHandler(ctx context.Context, request mcp.CallToolReq
 	var messageParts []string
 	messageParts = append(messageParts, fmt.Sprintf("Loudness normalization to %s LUFS (measured input loudness %s LUFS, true peak %s dBTP) completed in %v.",
 		formatLoudnormValue(target.IntegratedLUFS), measurements.InputI, measurements.InputTP, duration))
+	if outputLocalDir != "" && finalLocalPath != "" {
+		messageParts = append(messageParts, fmt.Sprintf("Output saved locally to: %s.", finalLocalPath))
+	} else if finalLocalPath != "" && (outputGCSBucket == "" || finalGCSPath == "") {
+		messageParts = append(messageParts, fmt.Sprintf("Temporary output was at: %s (cleaned up if not moved/uploaded).", finalLocalPath))
+	}
+	if finalGCSPath != "" {
+		messageParts = append(messageParts, fmt.Sprintf("Output uploaded to GCS: %s.", finalGCSPath))
+	}
+	if len(messageParts) == 1 {
+		messageParts = append(messageParts, "No specific output location requested beyond temporary processing.")
+	}
+	return mcp.NewToolResultText(strings.Join(messageParts, " ")), nil
+}
+
+// addResizeReframeTool defines and registers the 'ffmpeg_resize_reframe' tool. It
+// resizes an image or video to a target geometry and reconciles any aspect-ratio
+// mismatch by padding (letterbox/pillarbox, the default) or cropping.
+func addResizeReframeTool(s *server.MCPServer, cfg *common.Config) {
+	tool := mcp.NewTool("ffmpeg_resize_reframe",
+		mcp.WithDescription("Resizes and reframes an image OR a video to a target geometry. A single image is treated as a one-frame stream, so the same tool handles both. "+
+			"Specify the target either as an explicit width and/or height in pixels, or as an aspect-ratio shorthand ('16:9', '9:16', '1:1'); the aspect_ratio can be combined with a single width or height (the other side is computed), or used alone (the input's width is kept). Providing both width and height sets the exact frame and ignores aspect_ratio. "+
+			"When the source and target aspect ratios differ, the mismatch is reconciled by 'reframe_mode': 'pad' (default) scales the whole picture to fit and fills the remainder with bars (letterbox/pillarbox), preserving all content; 'crop' scales to fill the frame edge-to-edge and trims the overflow. Pad is the default because it never discards picture content. "+
+			"Target dimensions are automatically rounded to even numbers, which many video codecs require. Works on local paths and gs:// URIs and preserves any audio stream unchanged."),
+		mcp.WithString("input_media_uri", mcp.Required(), mcp.Description("URI of the input image or video file (local path or gs://). Must contain a visual (image or video) stream.")),
+		mcp.WithNumber("width", mcp.Description("Optional. Target width in pixels (must be positive). Combine with 'height' for an exact frame, with 'aspect_ratio' to compute the height, or alone for a proportional resize that keeps the input's aspect ratio.")),
+		mcp.WithNumber("height", mcp.Description("Optional. Target height in pixels (must be positive). Combine with 'width' for an exact frame, with 'aspect_ratio' to compute the width, or alone for a proportional resize that keeps the input's aspect ratio.")),
+		mcp.WithString("aspect_ratio", mcp.Description("Optional. Target aspect ratio shorthand in W:H form (e.g. '16:9', '9:16', '1:1'). Used with a single width or height to size the frame, or alone to reframe at the input's width. Ignored when both width and height are given.")),
+		mcp.WithString("reframe_mode", mcp.DefaultString(defaultReframeMode), mcp.Description("Optional. How to handle an aspect-ratio mismatch: 'pad' (default) keeps the whole frame and adds bars; 'crop' fills the frame and cuts off the excess.")),
+		mcp.WithString("pad_color", mcp.DefaultString(defaultPadColor), mcp.Description("Optional. Fill colour for the bars added in 'pad' mode (e.g. 'black', 'white', '#000000', '0xFFFFFF'). Defaults to black. Ignored in 'crop' mode.")),
+		mcp.WithString("output_filename", mcp.Description("Optional. Desired name for the output file (e.g., 'reframed.mp4' or 'thumb.png'). The client-provided extension is honored and selects the output format. Takes precedence over the deprecated output_file_name. If omitted, a unique name is generated and the input's extension is preserved. An existing file of the same name is overwritten.")),
+		mcp.WithString("output_file_name", mcp.Description("Optional (deprecated; use output_filename). Desired name for the output file.")),
+		mcp.WithString("output_local_dir", mcp.Description("Optional. Local directory to save the output file.")),
+		mcp.WithString("output_gcs_bucket", mcp.Description("Optional. GCS bucket to upload the output file to (uses GENMEDIA_BUCKET if set and this is empty).")),
+	)
+	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return ffmpegResizeReframeHandler(ctx, request, cfg)
+	})
+}
+
+// ffmpegResizeReframeHandler is the handler for the 'ffmpeg_resize_reframe' tool. It
+// validates the requested target geometry, probes the input's visual dimensions
+// (rejecting inputs with no image/video stream), resolves the final even target
+// width/height, and runs the scale+pad/crop filtergraph, writing the result to the
+// requested destination.
+func ffmpegResizeReframeHandler(ctx context.Context, request mcp.CallToolRequest, cfg *common.Config) (*mcp.CallToolResult, error) {
+	tr := otel.Tracer(serviceName)
+	ctx, span := tr.Start(ctx, "ffmpeg_resize_reframe")
+	defer span.End()
+
+	startTime := time.Now()
+	argsMap, err := getArguments(request)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	log.Printf("Handling %s request with arguments: %v", "ffmpeg_resize_reframe", argsMap)
+
+	inputMediaURI, _ := argsMap["input_media_uri"].(string)
+	if strings.TrimSpace(inputMediaURI) == "" {
+		return mcp.NewToolResultError("Parameter 'input_media_uri' is required."), nil
+	}
+
+	// Resolve the requested target components. Numbers arrive as float64 from JSON;
+	// 0 is used internally to mean "not supplied", so a supplied zero or negative
+	// dimension is an explicit error.
+	var reqWidth, reqHeight int
+	if v, ok := argsMap["width"].(float64); ok {
+		if v <= 0 {
+			return mcp.NewToolResultError("Parameter 'width' must be a positive number of pixels."), nil
+		}
+		reqWidth = int(math.Round(v))
+	}
+	if v, ok := argsMap["height"].(float64); ok {
+		if v <= 0 {
+			return mcp.NewToolResultError("Parameter 'height' must be a positive number of pixels."), nil
+		}
+		reqHeight = int(math.Round(v))
+	}
+
+	var aspect float64
+	if raw, ok := argsMap["aspect_ratio"].(string); ok && strings.TrimSpace(raw) != "" {
+		aspect, err = parseAspectRatio(raw)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Parameter 'aspect_ratio' is invalid: %v", err)), nil
+		}
+	}
+
+	if reqWidth == 0 && reqHeight == 0 && aspect == 0 {
+		return mcp.NewToolResultError("Provide at least one of 'width', 'height', or 'aspect_ratio' to define the target."), nil
+	}
+
+	reframeMode := defaultReframeMode
+	if raw, ok := argsMap["reframe_mode"].(string); ok && strings.TrimSpace(raw) != "" {
+		reframeMode = strings.ToLower(strings.TrimSpace(raw))
+	}
+	if reframeMode != reframeModePad && reframeMode != reframeModeCrop {
+		return mcp.NewToolResultError(fmt.Sprintf("Parameter 'reframe_mode' must be %q or %q.", reframeModePad, reframeModeCrop)), nil
+	}
+
+	padColor := defaultPadColor
+	if raw, ok := argsMap["pad_color"].(string); ok && strings.TrimSpace(raw) != "" {
+		padColor = strings.TrimSpace(raw)
+	}
+	if !isValidPadColor(padColor) {
+		return mcp.NewToolResultError("Parameter 'pad_color' must be a simple colour name or hex value (e.g. 'black', '#000000', '0xFFFFFF')."), nil
+	}
+
+	outputFileName := resolveAVToolOutputFilename(argsMap)
+	outputLocalDir, _ := argsMap["output_local_dir"].(string)
+	outputGCSBucket, _ := argsMap["output_gcs_bucket"].(string)
+	outputGCSBucket = strings.TrimSpace(outputGCSBucket)
+
+	if outputGCSBucket == "" && cfg.GenmediaBucket != "" {
+		outputGCSBucket = cfg.GenmediaBucket
+		log.Printf("Handler ffmpeg_resize_reframe: 'output_gcs_bucket' parameter not provided, using default from GENMEDIA_BUCKET: %s", outputGCSBucket)
+	}
+	if outputGCSBucket != "" {
+		outputGCSBucket = strings.TrimPrefix(outputGCSBucket, "gs://")
+	}
+
+	span.SetAttributes(
+		attribute.String("input_media_uri", inputMediaURI),
+		attribute.Int("requested_width", reqWidth),
+		attribute.Int("requested_height", reqHeight),
+		attribute.Float64("aspect_ratio", aspect),
+		attribute.String("reframe_mode", reframeMode),
+		attribute.String("output_file_name", outputFileName),
+		attribute.String("output_local_dir", outputLocalDir),
+		attribute.String("output_gcs_bucket", outputGCSBucket),
+	)
+
+	localInputMedia, inputCleanup, err := common.PrepareInputFile(ctx, inputMediaURI, "resize_input", cfg.ProjectID)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to prepare input media: %v", err)), nil
+	}
+	defer inputCleanup()
+
+	inWidth, inHeight, err := probeVideoDimensions(ctx, localInputMedia)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Cannot resize this input: %v", err)), nil
+	}
+
+	targetWidth, targetHeight, err := resolveTargetDimensions(reqWidth, reqHeight, aspect, inWidth, inHeight)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Could not resolve target dimensions: %v", err)), nil
+	}
+	span.SetAttributes(
+		attribute.Int("target_width", targetWidth),
+		attribute.Int("target_height", targetHeight),
+	)
+
+	// Whether the input carries an audio stream determines if we stream-copy audio
+	// through a video resize. Failure to probe this is non-fatal: assume no audio.
+	hasAudio := false
+	if streamInfo, probeErr := probeMediaStreamInfo(ctx, localInputMedia); probeErr != nil {
+		log.Printf("Handler ffmpeg_resize_reframe: could not determine audio presence, proceeding without audio copy: %v", probeErr)
+	} else {
+		hasAudio = streamInfo.HasAudio
+	}
+
+	// Preserve the input's container/extension by default; a client-provided output
+	// filename extension overrides it and selects the output format.
+	defaultOutputExt := strings.ToLower(strings.TrimPrefix(filepath.Ext(localInputMedia), "."))
+	if defaultOutputExt == "" {
+		defaultOutputExt = "mp4"
+	}
+	if outputFileName != "" {
+		if userExt := strings.ToLower(strings.TrimPrefix(filepath.Ext(outputFileName), ".")); userExt != "" {
+			defaultOutputExt = userExt
+		}
+	}
+
+	tempOutputFile, finalOutputFilename, outputCleanup, err := common.HandleOutputPreparation(outputFileName, defaultOutputExt)
+	if err != nil {
+		span.RecordError(err)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to prepare output file: %v", err)), nil
+	}
+	defer outputCleanup()
+
+	target := reframeTarget{Width: targetWidth, Height: targetHeight, Mode: reframeMode, PadColor: padColor}
+	if ffmpegErr := executeResizeReframe(ctx, localInputMedia, tempOutputFile, target, hasAudio); ffmpegErr != nil {
+		span.RecordError(ffmpegErr)
+		return mcp.NewToolResultError(fmt.Sprintf("FFMpeg resize/reframe failed: %v", ffmpegErr)), nil
+	}
+
+	finalLocalPath, finalGCSPath, processErr := common.ProcessOutputAfterFFmpeg(ctx, tempOutputFile, finalOutputFilename, outputLocalDir, outputGCSBucket, cfg.ProjectID)
+	if processErr != nil {
+		span.RecordError(processErr)
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to process FFMpeg output: %v", processErr)), nil
+	}
+
+	duration := time.Since(startTime)
+	span.SetAttributes(attribute.Float64("duration_ms", float64(duration.Milliseconds())))
+
+	var messageParts []string
+	messageParts = append(messageParts, fmt.Sprintf("Resized from %dx%d to %dx%d (%s mode) in %v.",
+		inWidth, inHeight, targetWidth, targetHeight, reframeMode, duration))
 	if outputLocalDir != "" && finalLocalPath != "" {
 		messageParts = append(messageParts, fmt.Sprintf("Output saved locally to: %s.", finalLocalPath))
 	} else if finalLocalPath != "" && (outputGCSBucket == "" || finalGCSPath == "") {

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/resize_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/resize_commands.go
@@ -1,0 +1,223 @@
+// Package main implements an MCP server for audio and video processing.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Reframe modes decide how an aspect-ratio mismatch between the source and the
+// requested target frame is reconciled.
+//
+// "pad" is the default: the whole source is scaled to fit inside the target frame
+// and the leftover space is filled with bars (letterbox/pillarbox). It is chosen as
+// the default because it never discards picture content — every pixel of the input
+// is preserved in the output, which is the safe, non-destructive behaviour a caller
+// expects unless they explicitly ask to fill the frame.
+//
+// "crop" scales the source to cover the target frame and trims the overflow, which
+// fills the frame edge-to-edge at the cost of cutting off the parts of the picture
+// that fall outside the target aspect ratio.
+const (
+	reframeModePad  = "pad"
+	reframeModeCrop = "crop"
+
+	defaultReframeMode = reframeModePad
+	defaultPadColor    = "black"
+)
+
+// reframeTarget captures the fully-resolved output geometry for a resize/reframe
+// run: the exact (even) target dimensions, how to reconcile an aspect mismatch, and
+// the fill colour used when padding.
+type reframeTarget struct {
+	Width    int
+	Height   int
+	Mode     string
+	PadColor string
+}
+
+// parseAspectRatio parses an aspect-ratio shorthand of the form "W:H" (e.g. "16:9",
+// "9:16", "1:1") into a numeric width/height ratio. Both components must be positive
+// numbers; anything else is reported as an error so a malformed target is rejected
+// before it reaches ffmpeg.
+func parseAspectRatio(s string) (float64, error) {
+	parts := strings.Split(strings.TrimSpace(s), ":")
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("aspect ratio %q must be in W:H form (e.g. 16:9)", s)
+	}
+	w, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil || w <= 0 {
+		return 0, fmt.Errorf("aspect ratio %q has an invalid width component", s)
+	}
+	h, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err != nil || h <= 0 {
+		return 0, fmt.Errorf("aspect ratio %q has an invalid height component", s)
+	}
+	return w / h, nil
+}
+
+// roundToEvenDim rounds a computed pixel dimension to the nearest positive even
+// integer (with a floor of 2). Even dimensions are required by common 4:2:0 video
+// codecs (e.g. H.264 with yuv420p), so rounding here rather than letting ffmpeg fail
+// on an odd width/height keeps the output encodable. An odd value is rounded up to
+// the next even number.
+func roundToEvenDim(v float64) int {
+	n := int(math.Round(v))
+	if n < 2 {
+		return 2
+	}
+	if n%2 != 0 {
+		n++
+	}
+	return n
+}
+
+// resolveTargetDimensions derives the final, even target width and height from the
+// caller's request and the input's own dimensions. The precedence is:
+//
+//  1. width AND height both given -> use them verbatim (any aspect_ratio is ignored;
+//     the caller has stated the exact frame).
+//  2. aspect_ratio given -> size the frame to that ratio, using an explicit width or
+//     height as the anchor when one is supplied, otherwise anchoring on the input's
+//     width.
+//  3. only width (or only height) given -> a plain proportional resize that keeps the
+//     input's aspect ratio.
+//
+// reqWidth/reqHeight of 0 mean "not supplied"; aspect of 0 means "not supplied".
+// inWidth/inHeight are the input's pixel dimensions and are only consulted when the
+// request cannot be satisfied from explicit values alone.
+func resolveTargetDimensions(reqWidth, reqHeight int, aspect float64, inWidth, inHeight int) (int, int, error) {
+	switch {
+	case reqWidth > 0 && reqHeight > 0:
+		return roundToEvenDim(float64(reqWidth)), roundToEvenDim(float64(reqHeight)), nil
+
+	case aspect > 0:
+		switch {
+		case reqWidth > 0:
+			return roundToEvenDim(float64(reqWidth)), roundToEvenDim(float64(reqWidth) / aspect), nil
+		case reqHeight > 0:
+			return roundToEvenDim(float64(reqHeight) * aspect), roundToEvenDim(float64(reqHeight)), nil
+		default:
+			if inWidth <= 0 || inHeight <= 0 {
+				return 0, 0, fmt.Errorf("cannot derive target dimensions from aspect ratio alone: the input's dimensions are unknown; provide a width or height")
+			}
+			return roundToEvenDim(float64(inWidth)), roundToEvenDim(float64(inWidth) / aspect), nil
+		}
+
+	case reqWidth > 0:
+		if inWidth <= 0 || inHeight <= 0 {
+			return 0, 0, fmt.Errorf("cannot compute a proportional height: the input's dimensions are unknown; provide both width and height")
+		}
+		return roundToEvenDim(float64(reqWidth)), roundToEvenDim(float64(reqWidth) * float64(inHeight) / float64(inWidth)), nil
+
+	case reqHeight > 0:
+		if inWidth <= 0 || inHeight <= 0 {
+			return 0, 0, fmt.Errorf("cannot compute a proportional width: the input's dimensions are unknown; provide both width and height")
+		}
+		return roundToEvenDim(float64(reqHeight) * float64(inWidth) / float64(inHeight)), roundToEvenDim(float64(reqHeight)), nil
+
+	default:
+		return 0, 0, fmt.Errorf("no target specified: provide width, height, and/or aspect_ratio")
+	}
+}
+
+// buildReframeFilter constructs the ffmpeg -vf filtergraph for the requested target.
+//
+// Both modes first scale the source and then reconcile any aspect mismatch:
+//   - pad:  scale to fit *inside* the target (force_original_aspect_ratio=decrease),
+//     then pad the remainder with the fill colour, centring the picture.
+//   - crop: scale to *cover* the target (force_original_aspect_ratio=increase), then
+//     crop the overflow, centring the picture.
+//
+// force_divisible_by=2 keeps the intermediate scaled dimensions even so the codec
+// never sees an odd size, and setsar=1 normalises the sample aspect ratio so the
+// stored pixel dimensions display as intended (guards against anamorphic inputs).
+// When the source and target already share an aspect ratio, both graphs reduce to a
+// plain scale with no bars added or pixels cut.
+func buildReframeFilter(t reframeTarget) string {
+	switch t.Mode {
+	case reframeModeCrop:
+		return fmt.Sprintf(
+			"scale=%d:%d:force_original_aspect_ratio=increase:force_divisible_by=2,crop=%d:%d,setsar=1",
+			t.Width, t.Height, t.Width, t.Height,
+		)
+	default: // reframeModePad
+		return fmt.Sprintf(
+			"scale=%d:%d:force_original_aspect_ratio=decrease:force_divisible_by=2,pad=%d:%d:(ow-iw)/2:(oh-ih)/2:color=%s,setsar=1",
+			t.Width, t.Height, t.Width, t.Height, t.PadColor,
+		)
+	}
+}
+
+// buildResizeArgs assembles the full ffmpeg argument list. The video (or single
+// image frame) is filtered to the target geometry; when the input also carries an
+// audio stream it is stream-copied so a video resize does not needlessly re-encode
+// or drop the audio.
+func buildResizeArgs(input, output string, t reframeTarget, hasAudio bool) []string {
+	args := []string{"-y", "-hide_banner", "-i", input, "-vf", buildReframeFilter(t)}
+	if hasAudio {
+		args = append(args, "-c:a", "copy")
+	}
+	args = append(args, output)
+	return args
+}
+
+// executeResizeReframe runs the resize/reframe operation for the resolved target.
+func executeResizeReframe(ctx context.Context, input, output string, t reframeTarget, hasAudio bool) error {
+	_, err := runFFmpegCommand(ctx, buildResizeArgs(input, output, t, hasAudio)...)
+	return err
+}
+
+// probeVideoDimensions returns the pixel width and height of the first video (or
+// image) stream in a media file. An image is treated as a single-frame video stream,
+// so this works for both. A non-nil error indicates the file has no dimensioned
+// visual stream (e.g. audio-only input), which resize cannot operate on.
+func probeVideoDimensions(ctx context.Context, localInputMedia string) (int, int, error) {
+	infoJSON, err := executeGetMediaInfo(ctx, localInputMedia)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to probe media info: %w", err)
+	}
+	var info struct {
+		Streams []struct {
+			CodecType string `json:"codec_type"`
+			Width     int    `json:"width"`
+			Height    int    `json:"height"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal([]byte(infoJSON), &info); err != nil {
+		return 0, 0, fmt.Errorf("failed to parse media info: %w", err)
+	}
+	for _, stream := range info.Streams {
+		if stream.CodecType == "video" && stream.Width > 0 && stream.Height > 0 {
+			return stream.Width, stream.Height, nil
+		}
+	}
+	return 0, 0, fmt.Errorf("input has no video or image stream with usable dimensions")
+}
+
+// isValidPadColor restricts the caller-supplied pad colour to characters that appear
+// in ffmpeg colour specifications (named colours like "black", hex forms like
+// "0xRRGGBB" or "#RRGGBB", and an optional "@alpha" suffix). Rejecting anything else
+// prevents a crafted value from injecting extra filtergraph tokens (commas, colons,
+// quotes) into the -vf string.
+func isValidPadColor(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '#' || r == '@' || r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/resize_commands_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/resize_commands_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseAspectRatio covers the valid W:H forms and the malformed inputs that must
+// be rejected before reaching ffmpeg.
+func TestParseAspectRatio(t *testing.T) {
+	t.Run("valid ratios", func(t *testing.T) {
+		cases := map[string]float64{
+			"16:9": 16.0 / 9.0,
+			"9:16": 9.0 / 16.0,
+			"1:1":  1.0,
+			"4:3":  4.0 / 3.0,
+			" 21 : 9 ": 21.0 / 9.0,
+		}
+		for in, want := range cases {
+			got, err := parseAspectRatio(in)
+			if err != nil {
+				t.Errorf("parseAspectRatio(%q) unexpected error: %v", in, err)
+				continue
+			}
+			if got != want {
+				t.Errorf("parseAspectRatio(%q) = %v, want %v", in, got, want)
+			}
+		}
+	})
+
+	t.Run("malformed ratios error", func(t *testing.T) {
+		bad := []string{"", "16", "16:9:1", "16:", ":9", "a:b", "0:9", "16:0", "-16:9", "16x9"}
+		for _, in := range bad {
+			if _, err := parseAspectRatio(in); err == nil {
+				t.Errorf("parseAspectRatio(%q) expected error, got nil", in)
+			}
+		}
+	})
+}
+
+// TestRoundToEvenDim ensures computed dimensions are rounded to positive even
+// integers, which codecs like H.264/yuv420p require.
+func TestRoundToEvenDim(t *testing.T) {
+	cases := map[float64]int{
+		1080:   1080,
+		1081:   1082, // odd rounds up to even
+		1919.4: 1920, // rounds to nearest int (1919), then up to even
+		1920.6: 1922, // rounds to 1921, then up to even
+		0:      2,    // floor of 2
+		1:      2,
+		-5:     2,
+		607:    608,
+	}
+	for in, want := range cases {
+		if got := roundToEvenDim(in); got != want {
+			t.Errorf("roundToEvenDim(%v) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// TestResolveTargetDimensions exercises the precedence rules for turning the
+// requested width/height/aspect plus the input dimensions into an even target frame.
+func TestResolveTargetDimensions(t *testing.T) {
+	type args struct {
+		reqW, reqH   int
+		aspect       float64
+		inW, inH     int
+	}
+	cases := []struct {
+		name       string
+		in         args
+		wantW      int
+		wantH      int
+		wantErr    bool
+	}{
+		{"explicit width and height", args{reqW: 1280, reqH: 720, inW: 1920, inH: 1080}, 1280, 720, false},
+		{"explicit dims ignore aspect", args{reqW: 1000, reqH: 1000, aspect: 16.0 / 9.0, inW: 1920, inH: 1080}, 1000, 1000, false},
+		{"aspect with width anchor (9:16)", args{reqW: 1080, aspect: 9.0 / 16.0, inW: 1920, inH: 1080}, 1080, 1920, false},
+		{"aspect with height anchor (16:9)", args{reqH: 1080, aspect: 16.0 / 9.0, inW: 640, inH: 480}, 1920, 1080, false},
+		{"aspect alone keeps input width (1:1)", args{aspect: 1.0, inW: 1920, inH: 1080}, 1920, 1920, false},
+		{"width alone keeps input aspect", args{reqW: 960, inW: 1920, inH: 1080}, 960, 540, false},
+		{"height alone keeps input aspect", args{reqH: 540, inW: 1920, inH: 1080}, 960, 540, false},
+		{"odd computed dim rounds even", args{reqW: 641, aspect: 1.0, inW: 100, inH: 100}, 642, 642, false},
+		{"aspect alone without input dims errors", args{aspect: 1.0}, 0, 0, true},
+		{"width alone without input dims errors", args{reqW: 640}, 0, 0, true},
+		{"nothing specified errors", args{inW: 1920, inH: 1080}, 0, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotW, gotH, err := resolveTargetDimensions(tc.in.reqW, tc.in.reqH, tc.in.aspect, tc.in.inW, tc.in.inH)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %dx%d", gotW, gotH)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotW != tc.wantW || gotH != tc.wantH {
+				t.Errorf("resolveTargetDimensions = %dx%d, want %dx%d", gotW, gotH, tc.wantW, tc.wantH)
+			}
+			if gotW%2 != 0 || gotH%2 != 0 {
+				t.Errorf("resolveTargetDimensions produced odd dimensions %dx%d", gotW, gotH)
+			}
+		})
+	}
+}
+
+// TestBuildReframeFilter verifies the pad and crop filtergraphs are constructed with
+// the correct scale strategy, even-dimension enforcement and SAR normalisation.
+func TestBuildReframeFilter(t *testing.T) {
+	t.Run("pad mode fits and letterboxes", func(t *testing.T) {
+		got := buildReframeFilter(reframeTarget{Width: 1080, Height: 1920, Mode: reframeModePad, PadColor: "black"})
+		want := "scale=1080:1920:force_original_aspect_ratio=decrease:force_divisible_by=2,pad=1080:1920:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1"
+		if got != want {
+			t.Errorf("pad filter = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("crop mode covers and trims", func(t *testing.T) {
+		got := buildReframeFilter(reframeTarget{Width: 1080, Height: 1080, Mode: reframeModeCrop})
+		want := "scale=1080:1080:force_original_aspect_ratio=increase:force_divisible_by=2,crop=1080:1080,setsar=1"
+		if got != want {
+			t.Errorf("crop filter = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unknown mode defaults to pad", func(t *testing.T) {
+		got := buildReframeFilter(reframeTarget{Width: 640, Height: 480, Mode: "bogus", PadColor: "white"})
+		if !strings.Contains(got, "pad=640:480") || !strings.Contains(got, "color=white") {
+			t.Errorf("unexpected default filter: %q", got)
+		}
+	})
+}
+
+// TestBuildResizeArgs verifies the ffmpeg argument list, including audio stream-copy
+// only when audio is present and output as the final argument.
+func TestBuildResizeArgs(t *testing.T) {
+	target := reframeTarget{Width: 1280, Height: 720, Mode: reframeModePad, PadColor: "black"}
+
+	t.Run("video with audio copies audio", func(t *testing.T) {
+		got := buildResizeArgs("in.mp4", "out.mp4", target, true)
+		joined := strings.Join(got, " ")
+		if !strings.Contains(joined, "-c:a copy") {
+			t.Errorf("expected audio stream copy: %s", joined)
+		}
+		if got[len(got)-1] != "out.mp4" {
+			t.Errorf("output must be last arg, got %q", got[len(got)-1])
+		}
+		if !strings.Contains(joined, "-vf scale=1280:720") {
+			t.Errorf("expected scale filter for target: %s", joined)
+		}
+	})
+
+	t.Run("image without audio omits audio copy", func(t *testing.T) {
+		got := buildResizeArgs("in.png", "out.png", target, false)
+		if strings.Contains(strings.Join(got, " "), "-c:a copy") {
+			t.Errorf("image resize should not stream-copy audio: %v", got)
+		}
+	})
+}
+
+// TestIsValidPadColor guards the -vf injection defense on the pad colour parameter.
+func TestIsValidPadColor(t *testing.T) {
+	valid := []string{"black", "white", "#000000", "0xFFFFFF", "red@0.5", "Gray"}
+	for _, c := range valid {
+		if !isValidPadColor(c) {
+			t.Errorf("isValidPadColor(%q) = false, want true", c)
+		}
+	}
+	invalid := []string{"", "black,crop=1:1", "black:0", "red green", "co'lor", "a\"b", "x;y"}
+	for _, c := range invalid {
+		if isValidPadColor(c) {
+			t.Errorf("isValidPadColor(%q) = true, want false", c)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `ffmpeg_resize_reframe` tool to `mcp-avtool-go`, closing a real gap: the server previously had no way to resize or reframe media. A single image is treated by ffmpeg as a one-frame stream, so the same tool handles **both image and video** inputs.

## What it does

- **Target geometry** can be given as:
  - an explicit `width` and `height` (exact frame),
  - an `aspect_ratio` shorthand (`16:9`, `9:16`, `1:1`) combined with a single `width` or `height` (the other side is computed), or used alone (the input's width is kept),
  - a single `width` or `height` alone → proportional resize that keeps the input's aspect ratio.
- **Aspect-ratio mismatch** is reconciled by `reframe_mode`:
  - `pad` (**default**) — scales the whole picture to fit and fills the remainder with bars (letterbox/pillarbox), configurable via `pad_color` (default `black`). Chosen as the default because it never discards picture content.
  - `crop` — scales to fill the frame edge-to-edge and trims the overflow.
- **Even-dimension correctness**: target width/height are rounded to even numbers (required by common 4:2:0 codecs such as H.264/yuv420p), and the intermediate scale uses `force_divisible_by=2`, so ffmpeg never fails on an odd dimension. `setsar=1` normalizes the sample aspect ratio.
- **Audio preserved**: when the input carries an audio stream it is stream-copied through unchanged.
- Follows avtool's existing I/O conventions: local paths and `gs://` URIs in/out, `output_filename` (with the deprecated `output_file_name` alias), `output_local_dir`, `output_gcs_bucket`/`GENMEDIA_BUCKET`.
- **Error handling** for zero/negative dimensions, malformed aspect strings, inputs with no visual stream, and a filtergraph-injection guard on `pad_color`.

## Verification

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- New unit tests cover aspect parsing, target-dimension resolution/precedence, even rounding, filtergraph construction, argument assembly and pad-color validation.
- Server starts and registers `ffmpeg_resize_reframe` (verified via MCP `tools/list`).
- **Empirically verified with real ffmpeg** on a real image (1920x1080) and a real video (1280x720, with audio); output dimensions confirmed with `ffprobe`:
  | case | input | target | mode | measured output |
  |---|---|---|---|---|
  | image exact-fit | 1920x1080 | 1280x720 | pad | **1280x720** |
  | image mismatch | 1920x1080 (16:9) | 1080x1920 (9:16) | pad | **1080x1920** (black bars confirmed) |
  | image mismatch | 1920x1080 (16:9) | 1080x1920 (9:16) | crop | **1080x1920** (frame filled) |
  | video exact-fit | 1280x720 | 640x360 | pad | **640x360** (audio preserved) |
  | video mismatch | 1280x720 (16:9) | 720x720 (1:1) | pad | **720x720** (audio preserved) |
  | video mismatch | 1280x720 (16:9) | 720x720 (1:1) | crop | **720x720** (audio preserved) |
  | odd target rounding | 1920x1080 | 1081x721 → | pad | **1082x722** |

  Pad vs. crop confirmed distinct: for the 16:9→9:16 image, the pad output's top strip is black (`0,0,0`, the letterbox bar) while the crop output's top strip contains picture content.

## Notes

- Scope is intentionally limited to resize + aspect-ratio pad/crop. Rotate/flip/fps are natural future increments and are not included here.