### PR TITLE
refactor(mcp-avtool-go): fold non-blocking review cleanup for trim/loudnorm/resize

### DIFF
--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffmpeg_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffmpeg_commands.go
@@ -77,10 +77,7 @@ func executeTrimMedia(ctx context.Context, localInput, tempOutput string, startS
 		log.Printf("Stream-copy trim failed (%v); retrying with a re-encode fallback.", err)
 	}
 	_, err := runFFmpegCommand(ctx, buildTrimArgs(localInput, tempOutput, startSeconds, durationSeconds, false)...)
-	if err != nil {
-		return true, err
-	}
-	return true, nil
+	return true, err
 }
 
 // Note: Specific ffmpeg command functions (like convertAudioToMP3, createGIF etc.) will be added here later.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/ffprobe_commands.go
@@ -51,17 +51,21 @@ func executeGetMediaInfo(ctx context.Context, localInputMedia string) (string, e
 }
 
 // mediaStreamInfo summarizes the stream layout of a media file: whether it carries
-// audio and/or video, plus the first audio stream's sample rate (empty when unknown).
+// audio and/or video, the first audio stream's sample rate (empty when unknown), and
+// the first video (or image) stream's pixel dimensions (zero when there is none).
 type mediaStreamInfo struct {
 	HasAudio   bool
 	HasVideo   bool
 	SampleRate string
+	Width      int
+	Height     int
 }
 
 // probeMediaStreamInfo inspects a media file with ffprobe and reports which stream
-// types it contains and the audio sample rate. Callers use it to reject inputs that
-// have no audio stream and to preserve the source sample rate through filters that
-// would otherwise resample.
+// types it contains, the audio sample rate, and the first visual stream's pixel
+// dimensions. Callers use it to reject inputs that have no audio stream, to preserve
+// the source sample rate through filters that would otherwise resample, and to size a
+// resize/reframe against the input's own dimensions — all from a single ffprobe call.
 func probeMediaStreamInfo(ctx context.Context, localInputMedia string) (mediaStreamInfo, error) {
 	var result mediaStreamInfo
 
@@ -74,6 +78,8 @@ func probeMediaStreamInfo(ctx context.Context, localInputMedia string) (mediaStr
 		Streams []struct {
 			CodecType  string `json:"codec_type"`
 			SampleRate string `json:"sample_rate"`
+			Width      int    `json:"width"`
+			Height     int    `json:"height"`
 		} `json:"streams"`
 	}
 	if err := json.Unmarshal([]byte(infoJSON), &info); err != nil {
@@ -89,6 +95,10 @@ func probeMediaStreamInfo(ctx context.Context, localInputMedia string) (mediaStr
 			}
 		case "video":
 			result.HasVideo = true
+			if result.Width == 0 && stream.Width > 0 && stream.Height > 0 {
+				result.Width = stream.Width
+				result.Height = stream.Height
+			}
 		}
 	}
 

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands.go
@@ -53,14 +53,15 @@ func formatLoudnormValue(v float64) string {
 // not write a media file: it runs the loudnorm filter in analysis mode against the
 // requested targets and asks it to print the measured integrated loudness, true
 // peak, loudness range and threshold as JSON (to stderr). The decode is discarded
-// via the null muxer.
+// via the null muxer. Only audio is analyzed, so -vn disables the video stream to
+// avoid decoding it — a meaningful saving on large video inputs.
 func buildLoudnormMeasureArgs(input string, target loudnormTarget) []string {
 	filter := fmt.Sprintf("loudnorm=I=%s:TP=%s:LRA=%s:print_format=json",
 		formatLoudnormValue(target.IntegratedLUFS),
 		formatLoudnormValue(target.TruePeakDBTP),
 		formatLoudnormValue(target.LoudnessRangeLU),
 	)
-	return []string{"-hide_banner", "-i", input, "-af", filter, "-f", "null", "-"}
+	return []string{"-hide_banner", "-i", input, "-af", filter, "-vn", "-f", "null", "-"}
 }
 
 // buildLoudnormApplyArgs builds the second-pass ffmpeg arguments. It applies the

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands_test.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/loudnorm_commands_test.go
@@ -28,7 +28,7 @@ func TestFormatLoudnormValue(t *testing.T) {
 func TestBuildLoudnormMeasureArgs(t *testing.T) {
 	target := loudnormTarget{IntegratedLUFS: -16, TruePeakDBTP: -1.5, LoudnessRangeLU: 11}
 	got := buildLoudnormMeasureArgs("in.wav", target)
-	want := []string{"-hide_banner", "-i", "in.wav", "-af", "loudnorm=I=-16:TP=-1.5:LRA=11:print_format=json", "-f", "null", "-"}
+	want := []string{"-hide_banner", "-i", "in.wav", "-af", "loudnorm=I=-16:TP=-1.5:LRA=11:print_format=json", "-vn", "-f", "null", "-"}
 	if strings.Join(got, " ") != strings.Join(want, " ") {
 		t.Errorf("buildLoudnormMeasureArgs = %v, want %v", got, want)
 	}

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/mcp_handlers.go
@@ -1485,10 +1485,17 @@ func ffmpegResizeReframeHandler(ctx context.Context, request mcp.CallToolRequest
 	}
 	defer inputCleanup()
 
-	inWidth, inHeight, err := probeVideoDimensions(ctx, localInputMedia)
+	// A single ffprobe call yields both the input's dimensions and whether it carries
+	// an audio stream (used to decide if audio is stream-copied through the resize).
+	streamInfo, err := probeMediaStreamInfo(ctx, localInputMedia)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Cannot resize this input: %v", err)), nil
 	}
+	if streamInfo.Width <= 0 || streamInfo.Height <= 0 {
+		return mcp.NewToolResultError("Cannot resize this input: it has no video or image stream with usable dimensions"), nil
+	}
+	inWidth, inHeight := streamInfo.Width, streamInfo.Height
+	hasAudio := streamInfo.HasAudio
 
 	targetWidth, targetHeight, err := resolveTargetDimensions(reqWidth, reqHeight, aspect, inWidth, inHeight)
 	if err != nil {
@@ -1498,15 +1505,6 @@ func ffmpegResizeReframeHandler(ctx context.Context, request mcp.CallToolRequest
 		attribute.Int("target_width", targetWidth),
 		attribute.Int("target_height", targetHeight),
 	)
-
-	// Whether the input carries an audio stream determines if we stream-copy audio
-	// through a video resize. Failure to probe this is non-fatal: assume no audio.
-	hasAudio := false
-	if streamInfo, probeErr := probeMediaStreamInfo(ctx, localInputMedia); probeErr != nil {
-		log.Printf("Handler ffmpeg_resize_reframe: could not determine audio presence, proceeding without audio copy: %v", probeErr)
-	} else {
-		hasAudio = streamInfo.HasAudio
-	}
 
 	// Preserve the input's container/extension by default; a client-provided output
 	// filename extension overrides it and selects the output format.

--- a/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/resize_commands.go
+++ b/experiments/mcp-genmedia/mcp-genmedia-go/mcp-avtool-go/resize_commands.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -171,33 +170,6 @@ func buildResizeArgs(input, output string, t reframeTarget, hasAudio bool) []str
 func executeResizeReframe(ctx context.Context, input, output string, t reframeTarget, hasAudio bool) error {
 	_, err := runFFmpegCommand(ctx, buildResizeArgs(input, output, t, hasAudio)...)
 	return err
-}
-
-// probeVideoDimensions returns the pixel width and height of the first video (or
-// image) stream in a media file. An image is treated as a single-frame video stream,
-// so this works for both. A non-nil error indicates the file has no dimensioned
-// visual stream (e.g. audio-only input), which resize cannot operate on.
-func probeVideoDimensions(ctx context.Context, localInputMedia string) (int, int, error) {
-	infoJSON, err := executeGetMediaInfo(ctx, localInputMedia)
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to probe media info: %w", err)
-	}
-	var info struct {
-		Streams []struct {
-			CodecType string `json:"codec_type"`
-			Width     int    `json:"width"`
-			Height    int    `json:"height"`
-		} `json:"streams"`
-	}
-	if err := json.Unmarshal([]byte(infoJSON), &info); err != nil {
-		return 0, 0, fmt.Errorf("failed to parse media info: %w", err)
-	}
-	for _, stream := range info.Streams {
-		if stream.CodecType == "video" && stream.Width > 0 && stream.Height > 0 {
-			return stream.Width, stream.Height, nil
-		}
-	}
-	return 0, 0, fmt.Errorf("input has no video or image stream with usable dimensions")
 }
 
 // isValidPadColor restricts the caller-supplied pad colour to characters that appear


### PR DESCRIPTION
## Summary
Folds the three genuine non-blocking **Optional** cleanup items surfaced by the independent reviews of the recently-merged avtool tools (PRs #1836, #1838, #1839). No behavior change; the already-declined FYIs are intentionally left untouched.

### Changes
1. **`ffmpeg_trim_media`** (from #1836 review) — collapse `executeTrimMedia`'s re-encode-tail `(true, err)` / `(true, nil)` into a single `return true, err`. Cosmetic; command args unchanged.
2. **`ffmpeg_normalize_loudness`** (from #1838 review) — add `-vn` to `buildLoudnormMeasureArgs` so the analysis (pass 1) skips video decode on large video inputs. **Perf only** — measured loudness values are unchanged.
3. **`ffmpeg_resize_reframe`** (from #1839 review) — extend `mediaStreamInfo` with `Width`/`Height` (first video stream) and have the handler read dimensions + audio presence from a single `probeMediaStreamInfo` call, removing the duplicate `probeVideoDimensions` helper (one fewer ffprobe subprocess per request). Also removes the effectively-dead silent-audio-drop branch, resolving that review's FYI.

### Verification
- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — all pure-logic tests pass (incl. updated `TestBuildLoudnormMeasureArgs`); the two pre-existing `TestRunFFmpegCommand` / `TestExecuteGetMediaInfo` require the ffmpeg/ffprobe binaries (environmental, unrelated to this diff).
- **Empirical (ffmpeg installed):**
  - Loudnorm measure JSON is **byte-identical** with vs. without `-vn` (`input_i/tp/lra/thresh`, `target_offset` all match).
  - Trim still produces a clip; args are identical (change is a return-value collapse).
  - Resize: single probe reports the same 640×360 dims + audio present; output is correct 640×640 with audio copied.

Purely additive/cleanup — no wire-format or existing-tool signature changes.
