### PR TITLE
fix(omni): unwrap WebEvent payload in gcs_uploader handlers (#1831)

### DIFF
--- a/pages/omni.py
+++ b/pages/omni.py
@@ -698,7 +698,7 @@ def on_request_signed_url_video(e: me.WebEvent) -> Generator[None]:
     """Generate GCS Signed URL for video upload."""
     state = me.state(PageState)
     try:
-        data = json.loads(e.value)
+        data = json.loads(e.value["value"])
         filename = data["filename"]
         content_type = data["contentType"]
 
@@ -725,8 +725,9 @@ def on_request_signed_url_video(e: me.WebEvent) -> Generator[None]:
 def on_upload_complete_video(e: me.WebEvent) -> Generator[None]:
     """Handle successful direct upload of base video."""
     state = me.state(PageState)
-    state.reference_video_gcs = e.value
-    state.reference_video_uri = create_display_url(e.value)
+    gcs_uri = e.value["value"]
+    state.reference_video_gcs = gcs_uri
+    state.reference_video_uri = create_display_url(gcs_uri)
     state.reference_video_mime_type = "video/mp4"
 
     state.video_upload_signed_url = ""
@@ -738,14 +739,14 @@ def on_upload_complete_video(e: me.WebEvent) -> Generator[None]:
 def on_upload_progress_video(e: me.WebEvent) -> Generator[None]:
     """Handle direct upload progress updates."""
     state = me.state(PageState)
-    state.video_upload_progress = int(e.value)
+    state.video_upload_progress = int(e.value["value"])
     yield
 
 
 def on_upload_error_video(e: me.WebEvent) -> Generator[None]:
     """Handle direct upload errors."""
     state = me.state(PageState)
-    state.error_message = f"Video upload failed: {e.value}"
+    state.error_message = f"Video upload failed: {e.value['value']}"
     state.show_error_dialog = True
 
     state.video_upload_signed_url = ""

--- a/test/test_omni.py
+++ b/test/test_omni.py
@@ -284,9 +284,13 @@ def test_on_request_signed_url_video(
     mock_sign.return_value = "https://gcs-signed-url.com/upload"
 
     event = MagicMock()
-    event.value = (
-        '{"filename": "test_video.mp4", "contentType": "video/mp4", "fileSize": 1024}'
-    )
+    # Mesop's WebEvent mapper json.loads()s the whole dispatched object, so the
+    # handler receives the wrapper dict the JS component sent, not the inner value.
+    event.value = {
+        "value": (
+            '{"filename": "test_video.mp4", "contentType": "video/mp4", "fileSize": 1024}'
+        ),
+    }
 
     gen = on_request_signed_url_video(event)
     list(gen)
@@ -308,7 +312,7 @@ def test_on_upload_complete_video(mock_state: MagicMock) -> None:
     mock_state.return_value = mock_page_state
 
     event = MagicMock()
-    event.value = "gs://bucket/uploads/uuid_test_video.mp4"
+    event.value = {"value": "gs://bucket/uploads/uuid_test_video.mp4"}
 
     gen = on_upload_complete_video(event)
     list(gen)
@@ -329,7 +333,7 @@ def test_on_upload_progress_video(mock_state: MagicMock) -> None:
     mock_state.return_value = mock_page_state
 
     event = MagicMock()
-    event.value = "45"
+    event.value = {"value": "45"}
 
     gen = on_upload_progress_video(event)
     list(gen)
@@ -346,7 +350,7 @@ def test_on_upload_error_video(mock_state: MagicMock) -> None:
     mock_state.return_value = mock_page_state
 
     event = MagicMock()
-    event.value = "Network timeout"
+    event.value = {"value": "Network timeout"}
 
     gen = on_upload_error_video(event)
     list(gen)


### PR DESCRIPTION
## Summary

On `/gemini-omni`, **Upload Base Video to Edit** fails the instant a file is picked with *"Failed to prepare video upload: the JSON object must be str, bytes or bytearray, not dict"*. Nothing reaches GCS, so `edit` mode only works via **Choose from Library**.

### Root cause

Mesop registers its `WebEvent` mapper as `WebEvent(key=..., value=json.loads(userEvent.string_value))` (`mesop/component_helpers/helper.py`). `string_value` is the *entire* object dispatched by the JS component, so for every `new MesopEvent(name, { value: ... })` in `components/gcs_uploader/gcs_uploader.js` (lines 118, 147, 159, 164/176), the handler receives the wrapper dict `{"value": <payload>}` — not the raw inner value.

The four handlers in `pages/omni.py` read `e.value` directly:

- `on_request_signed_url_video` — `json.loads(e.value)` on a dict raises the dialog's exact error (only reachable handler today).
- `on_upload_complete_video` — assigns the dict as the GCS URI.
- `on_upload_progress_video` — `int(dict)` → `TypeError`.
- `on_upload_error_video` — interpolates the dict into the error message.

Only the first is reachable today (it fails immediately), masking the identical latent bug in the other three.

### Fix

Unwrap `e.value["value"]` in all four handlers, matching the established `WebEvent`-unwrap pattern already used throughout this repo:
`pages/selfie.py`, `pages/portraits.py` (`on_selfie_capture`), `components/page_scaffold.py`, `workflows/retro_games/page.py`, `components/library/video_chooser_button.py`.

### Tests

`test/test_omni.py`'s four handler fixtures previously set `event.value` to the *unwrapped inner value* — a shape the real Mesop runtime never produces — which is why they stayed green despite the bug. They are now wrapped as `{"value": <inner>}` to match the actual runtime payload.

Verified empirically: with the fixtures fixed but the code left unfixed, all four tests fail — each for the exact mechanism predicted (`AssertionError`, `AttributeError`, `TypeError`, dict-in-message). With the fix applied, the full `test/test_omni.py` (21 tests) passes.

```
21 passed in 1.87s
```

### Verification performed

- Independently re-verified the root cause against current `main`: the Mesop `WebEvent` mapper, the `gcs_uploader.js` dispatch calls, and all four `pages/omni.py` handlers (current lines 701, 728, 742, 748).
- Cross-referenced the repo's other `WebEvent` readers to confirm `e.value["value"]` is the established correct pattern.
- Ran the test suite (prove-it: fail-without-fix, pass-with-fix). `ruff` error count on the touched files is unchanged from `main`.

### Credit

Root-cause analysis, reproduction, and the exact failure-mode breakdown by external contributor **@xpkgabors** in #1831 — excellent, thorough investigation.

Fixes #1831
