### PR TITLE
Genkit Go genmedia series — Tier 2: multi-server producer flow (STABLE capstone)

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
@@ -234,6 +234,13 @@ asserts every required tool is present before the flow runs.
 > structure itself and fails fast with a clear message if a path is present.
 > `avtool` also needs **`ffmpeg`/`ffprobe`** on your `PATH`.
 
+> **Teaching caveat — prompt-injection surface.** As in Tiers 0-1, the positional
+> CLI argument is fed as free text into the model prompt, which then calls tools —
+> a (benign here, local-dev) prompt-injection surface, called out in
+> `tier2-producer/main.go`. A production caller should treat any untrusted input as
+> adversarial: constrain it and/or validate the tool arguments the model chooses,
+> rather than trusting free text.
+
 ## The `resource_link` rule
 
 The genmedia GCS-writing tools (nanobanana/gemini image, veo, lyria, omni)

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
@@ -6,18 +6,22 @@ independently reviewable PR. The through-line of the whole series is the
 **Genkit Developer UI and per-turn tracing** — every tier is meant to be *run*,
 then *read* at `http://localhost:4000`.
 
-> **You are here: Tier 1.** A two-step `genkit.DefineFlow` that chains
-> `nanobanana` → `veo_i2v` (image → video). It builds directly on **Tier 0**, the
-> minimal "one tool, one generate" program (also the Go counterpart to the
-> JavaScript [Nano Banana sample](../genkit/); see [Related samples](#related-samples)).
+> **You are here: Tier 2.** A multi-server **producer** flow: one
+> `genkit.DefineFlow` that composes **four** genmedia MCP servers —
+> `nanobanana` → `veo_i2v` → `lyria` → `avtool` — into a single traced production
+> line (still → clip → score → **muxed scored video**), with every artifact proven
+> by verify-by-listing. It builds on **Tier 1** (the two-server chain) and
+> **Tier 0** (the minimal "one tool, one generate" program, also the Go
+> counterpart to the JavaScript [Nano Banana sample](../genkit/); see
+> [Related samples](#related-samples)).
 
 ## The series
 
 | Tier | What it adds | Servers/tools | Status |
 |------|--------------|---------------|--------|
 | 0 · `tier0-image/` | single tool, single `generate` | `nanobanana` | STABLE |
-| **1 · `tier1-video/`** | `DefineFlow`, linear chain | `nanobanana` → `veo_i2v` | **STABLE** *(this tier)* |
-| 2 · `tier2-producer/` | multi-server producer flow | nb → veo → lyria → avtool | STABLE *(future PR)* |
+| 1 · `tier1-video/` | `DefineFlow`, linear chain | `nanobanana` → `veo_i2v` | STABLE |
+| **2 · `tier2-producer/`** | multi-server producer flow + in-prompt crosswalk | nb → veo → lyria → avtool | **STABLE** *(this tier)* |
 | 3 · `tier3-preview/` | agents middleware + interrupt | all, partitioned | PREVIEW *(future PR)* |
 
 Tiers land one per PR. They share the foundation Tier 0 established and later
@@ -33,9 +37,10 @@ genkit-go/
       launch.go          StdioFor("<server>") -> mcp.StdioConfig at bin/genmedia-launch
       quirks.go          QuirksPrompt: the genmedia footguns the LLM cannot see
     verify/
-      verify.go          Verify(ctx, dest): confirm output by LISTING, not by trusting the tool result
+      verify.go          Verify / VerifyRecursive(ctx, dest): confirm output by LISTING, not by trusting the tool result
   tier0-image/main.go    Tier 0 — single tool, single generate
   tier1-video/main.go    Tier 1 — DefineFlow: nanobanana -> veo_i2v
+  tier2-producer/main.go Tier 2 — DefineFlow: nanobanana -> veo_i2v -> lyria -> avtool (one shared toolset)
 ```
 
 ## Why lead with the Dev UI
@@ -159,6 +164,76 @@ you read in the trace is the order the Go code fixed, every run.
 > `gs://` URI — a local directory works for Tier 0 but cannot carry the still into
 > the video step here. Tier 1 fails fast with a clear message if it is not `gs://`.
 
+## Run Tier 2, then read the producer trace
+
+Tier 2 is the **capstone**: one **`genkit.DefineFlow`** named `produce-scored-clip`
+that composes **four** genmedia servers into a production line. As in Tier 1 the
+order is fixed in Go (deterministic, not LLM-sequenced), but now **all four
+servers' tools are offered to every step at once** — the model, not the code,
+picks which tool to call from a single shared toolset:
+
+```
+generate-image  ->  nanobanana writes a still to GCS
+verify-image    ->  LIST: confirm the still, carry its gs:// URI forward
+generate-video  ->  veo_i2v turns that still into a clip (explicit Veo-3 model)
+verify-video    ->  LIST recursively: carry the clip's .mp4 leaf forward
+generate-music  ->  lyria composes a score to GCS
+verify-music    ->  LIST recursively: carry the score's audio leaf forward
+generate-final  ->  avtool muxes the clip + score into one scored video
+verify-final    ->  LIST: confirm the finished artifact
+```
+
+```bash
+cd experiments/mcp-genmedia/sample-agents/genkit-go
+
+export GOOGLE_CLOUD_PROJECT=your-project
+export GENMEDIA_BUCKET=gs://your-bare-bucket   # BARE bucket, no path (see below)
+export GOOGLE_CLOUD_LOCATION=us-central1
+
+# Launch the flow under the Dev UI:
+genkit start -- go run ./tier2-producer
+```
+
+Pass a custom subject as arguments to change what gets drawn, animated, and scored:
+`genkit start -- go run ./tier2-producer "a paper boat on a rain-soaked street"`.
+
+Then open **`http://localhost:4000`**. Tier 2's one new thing is the **multi-server
+producer trace**: a single `produce-scored-clip` flow span wrapping **eight** named
+step spans, with **four** `generate` spans — and each one shows *which tool the
+model chose out of all sixteen* offered from the four servers. That is the tier's
+whole lesson made visible.
+
+### The in-prompt crosswalk (Tier 2's one new idea)
+
+Four servers put sixteen tools into one toolset, several with lookalike names
+(`veo` alone contributes six variants). Tier 2 does **not** rename or prefix them.
+Instead the **system prompt** — `QuirksPrompt` plus a `producerCrosswalk` fragment
+in `tier2-producer/main.go` — tells the model which namespaced tool does which job:
+
+```
+IMAGE (text -> still): nanobanana_nanobanana_image_generation
+VIDEO (still -> clip): veo_veo_i2v         (not veo_veo_t2v, veo_veo_extend_video, …)
+MUSIC (text -> score): lyria_lyria_generate_music
+MUX  (clip+score -> scored video): avtool_ffmpeg_combine_audio_and_video
+```
+
+The MCP client's `<server>_<tool>` namespacing keeps the names *unique*; the prompt
+tells the model which name to *pick*. This is the deliberate contrast with the ADK
+genmedia sibling, which resolves the same collision **structurally** with
+`tool_name_prefix` on each toolset. Same problem, two philosophies: **ADK renames
+the tools; Tier 2 instructs the model.** The producer also guards startup —
+`mcp.NewMCPHost` logs-and-continues when a server fails to connect, so Tier 2
+asserts every required tool is present before the flow runs.
+
+> **A BARE bucket is required for Tier 2.** `nanobanana` and `veo` accept a
+> bucket **and** a path prefix (Tier 2 writes them under `…/<runID>/image` and
+> `…/<runID>/video`), but `lyria` and `avtool` take a bucket **name only** — they
+> strip `gs://` and upload the object at the bucket root using just the filename, so
+> a prefixed value becomes an invalid bucket name and the upload fails. Set
+> `GENMEDIA_BUCKET` to a bare `gs://bucket` (no path); the producer adds all per-run
+> structure itself and fails fast with a clear message if a path is present.
+> `avtool` also needs **`ffmpeg`/`ffprobe`** on your `PATH`.
+
 ## The `resource_link` rule
 
 The genmedia GCS-writing tools (nanobanana/gemini image, veo, lyria, omni)
@@ -205,8 +280,9 @@ download bridge — `StdioConfig.Command` resolves it directly.
 | Genkit Go | `github.com/firebase/genkit/go v1.13.1` | `go.mod` |
 | Go | `go 1.25` | `go.mod` |
 | genmedia release | `v3.18.0` | `internal/genmedia` `DefaultReleaseTag` + `bin/genmedia-launch` `PINNED_TAG` |
-| Orchestrating model | `vertexai/gemini-2.5-flash` | `tier{0,1}-*/main.go` `modelName` |
-| Veo model (Tier 1) | `veo-3.1-fast-generate-001` | `tier1-video/main.go` `veoModel` |
+| Orchestrating model | `vertexai/gemini-2.5-flash` | `tier{0,1,2}-*/main.go` `modelName` |
+| Veo model (Tiers 1-2) | `veo-3.1-fast-generate-001` | `tier{1,2}-*/main.go` `veoModel` |
+| Lyria model (Tier 2) | `lyria-3-clip-preview` | `tier2-producer/main.go` `lyriaModel` |
 
 ## Related samples
 

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/internal/genmedia/client.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/internal/genmedia/client.go
@@ -49,6 +49,46 @@ func NewClient(ctx context.Context, g *genkit.Genkit, server string) (*mcp.Genki
 	})
 }
 
+// NewHost connects to SEVERAL genmedia MCP servers at once, by their friendly
+// nicknames, and returns an *mcp.MCPHost that aggregates their tools. It is the
+// multi-server fan-out path Tier 2 uses: one host, many servers, exposed to the
+// model through host.GetActiveTools so a single genkit.Generate turn can pick any
+// tool across all of them (disambiguated in the system prompt, not by a rename
+// layer — see tier2-producer for the in-prompt crosswalk).
+//
+// Each server is launched over stdio through bin/genmedia-launch via the shared
+// StdioFor wiring, so the multi-server path reuses exactly the launch story the
+// single-client path established. The MCP client namespaces every tool as
+// "<nickname>_<toolName>" (e.g. "veo_veo_i2v"), which is what keeps four servers'
+// tools distinct in one toolset.
+//
+// mcp.NewMCPHost logs and continues when an individual server fails to connect,
+// so a healthy host can still be returned with some servers missing. Callers
+// MUST confirm the tools they need are actually present (e.g. by checking
+// host.GetActiveTools for the expected tool names) rather than assuming every
+// requested server connected. The caller owns Disconnect for each server.
+func NewHost(ctx context.Context, g *genkit.Genkit, servers ...string) (*mcp.MCPHost, error) {
+	configs := make([]mcp.MCPServerConfig, 0, len(servers))
+	for _, server := range servers {
+		stdio, err := StdioFor(server)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, mcp.MCPServerConfig{
+			Name: server,
+			Config: mcp.MCPClientOptions{
+				Name:  server,
+				Stdio: stdio,
+			},
+		})
+	}
+
+	return mcp.NewMCPHost(g, mcp.MCPHostOptions{
+		Name:       "genmedia-producer",
+		MCPServers: configs,
+	})
+}
+
 // ToolRefs adapts the []ai.Tool returned by GetActiveTools into the []ai.ToolRef
 // that genkit.Generate's ai.WithTools expects. Shared so every tier converts
 // identically.

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify.go
@@ -79,6 +79,31 @@ func Verify(ctx context.Context, dest string) (Result, error) {
 	return verifyLocal(dest)
 }
 
+// VerifyRecursive confirms artifacts at or under dest by listing RECURSIVELY,
+// returning only the leaf object URIs / file paths — never intermediate
+// subfolder prefixes. Use it (instead of Verify) when a genmedia tool writes
+// into a server-assigned subfolder and a later step needs the EXACT leaf file:
+//
+//   - veo writes gs://<prefix>/<jobid>/sample_0.mp4 — a plain `gcloud storage ls
+//     <prefix>` reports the <jobid>/ subfolder, not the mp4. avtool muxing needs
+//     the mp4 leaf, so Tier 2 lists it recursively.
+//   - lyria writes gs://<bucket>/<runID>-score.<ext>, where the extension is
+//     finalized from the audio bytes (.mp3/.wav) and is not known ahead of time.
+//     VerifyRecursive matches it by prefix, so the caller need not guess.
+//
+// For gs:// destinations it runs `gcloud storage ls <dest>**` (the `**` wildcard
+// matches every object whose path begins with dest, at any depth, and returns
+// leaf object URIs without the folder-header lines a plain `-r` listing prints).
+// For local paths it walks the tree and returns the files found. Semantics
+// otherwise match Verify: a non-nil error means the check could not be performed;
+// Result.Exists == false with a nil error means nothing was found.
+func VerifyRecursive(ctx context.Context, dest string) (Result, error) {
+	if IsGCS(dest) {
+		return verifyGCSRecursive(ctx, dest)
+	}
+	return verifyLocalRecursive(dest)
+}
+
 // VerifyAll runs Verify for each destination and returns the results in order.
 // It does not short-circuit: every destination is checked so a tier can report
 // each GCS-writing step. The returned error is the first check that could not be
@@ -143,6 +168,71 @@ func parseGCSListing(stdout []byte) []string {
 		}
 	}
 	return entries
+}
+
+// verifyGCSRecursive lists every object under a gs:// prefix with the `**`
+// recursive wildcard, returning the leaf object URIs (never subfolder prefixes).
+func verifyGCSRecursive(ctx context.Context, uri string) (Result, error) {
+	res := Result{Destination: uri}
+
+	if _, err := exec.LookPath("gcloud"); err != nil {
+		return res, fmt.Errorf("verify: gcloud not found on PATH (needed to list %s): %w", uri, err)
+	}
+
+	// Append the `**` recursive wildcard to the (slash-trimmed) prefix so gcloud
+	// returns matching leaf objects at any depth, without folder-header lines.
+	pattern := strings.TrimRight(uri, "/") + "**"
+	cmd := exec.CommandContext(ctx, "gcloud", "storage", "ls", pattern)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && isGCSNotFound(stderr.Bytes()) {
+			return res, nil
+		}
+		return res, fmt.Errorf("verify: gcloud storage ls %s failed: %w: %s",
+			pattern, err, strings.TrimSpace(stderr.String()))
+	}
+
+	res.Entries = parseGCSListing(stdout.Bytes())
+	res.Exists = len(res.Entries) > 0
+	return res, nil
+}
+
+// verifyLocalRecursive walks a local path and returns the files found (never
+// directories). A missing path is reported as Exists == false with a nil error,
+// matching verifyLocal.
+func verifyLocalRecursive(path string) (Result, error) {
+	res := Result{Destination: path}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return res, nil
+		}
+		return res, fmt.Errorf("verify: stat %s failed: %w", path, err)
+	}
+	if !info.IsDir() {
+		res.Entries = []string{path}
+		res.Exists = true
+		return res, nil
+	}
+
+	walkErr := filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			res.Entries = append(res.Entries, p)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return res, fmt.Errorf("verify: walk %s failed: %w", path, walkErr)
+	}
+	res.Exists = len(res.Entries) > 0
+	return res, nil
 }
 
 // isGCSNotFound reports whether gcloud's diagnostic output is its

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify.go
@@ -91,9 +91,13 @@ func Verify(ctx context.Context, dest string) (Result, error) {
 //     finalized from the audio bytes (.mp3/.wav) and is not known ahead of time.
 //     VerifyRecursive matches it by prefix, so the caller need not guess.
 //
-// For gs:// destinations it runs `gcloud storage ls <dest>**` (the `**` wildcard
-// matches every object whose path begins with dest, at any depth, and returns
-// leaf object URIs without the folder-header lines a plain `-r` listing prints).
+// For gs:// destinations it runs `gcloud storage ls <dest>**`. Note `**` is a
+// PREFIX glob, not a strict directory-contents match: it matches every object
+// whose path BEGINS WITH dest, at any depth (so a dest of ".../image" would also
+// match a sibling object ".../imageXYZ"), returning leaf object URIs without the
+// folder-header lines a plain `-r` listing prints. Tier 2's runID-stamped, unique
+// prefixes make this exact in practice; a caller relying on it must likewise use a
+// prefix that cannot collide with a sibling object's name.
 // For local paths it walks the tree and returns the files found. Semantics
 // otherwise match Verify: a non-nil error means the check could not be performed;
 // Result.Exists == false with a nil error means nothing was found.
@@ -170,6 +174,17 @@ func parseGCSListing(stdout []byte) []string {
 	return entries
 }
 
+// gcsRecursivePattern turns a gs:// prefix into the `gcloud storage ls` argument
+// that matches every object at or under it: the prefix with any trailing slash
+// trimmed, then `**` appended. `**` is a PREFIX glob (see VerifyRecursive) — it
+// matches by string prefix at any depth, not strict directory contents. Factored
+// out as a pure function so the pattern construction is unit-testable without
+// shelling to gcloud (the shell-out itself follows the same no-direct-test
+// convention as verifyGCS).
+func gcsRecursivePattern(uri string) string {
+	return strings.TrimRight(uri, "/") + "**"
+}
+
 // verifyGCSRecursive lists every object under a gs:// prefix with the `**`
 // recursive wildcard, returning the leaf object URIs (never subfolder prefixes).
 func verifyGCSRecursive(ctx context.Context, uri string) (Result, error) {
@@ -181,7 +196,7 @@ func verifyGCSRecursive(ctx context.Context, uri string) (Result, error) {
 
 	// Append the `**` recursive wildcard to the (slash-trimmed) prefix so gcloud
 	// returns matching leaf objects at any depth, without folder-header lines.
-	pattern := strings.TrimRight(uri, "/") + "**"
+	pattern := gcsRecursivePattern(uri)
 	cmd := exec.CommandContext(ctx, "gcloud", "storage", "ls", pattern)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify_test.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify_test.go
@@ -15,7 +15,11 @@
 package verify
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -139,4 +143,66 @@ func TestParseGCSListing(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestVerifyRecursiveLocal pins the recursive local walk that Tier 2 relies on:
+// it returns every file at any depth (never directories), reports a missing path
+// as not-found with a nil error, and a single file as itself.
+func TestVerifyRecursiveLocal(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nested files are returned as leaves", func(t *testing.T) {
+		root := t.TempDir()
+		want := []string{
+			filepath.Join(root, "a.mp3"),
+			filepath.Join(root, "sub", "b.mp4"),
+			filepath.Join(root, "sub", "deep", "c.wav"),
+		}
+		for _, f := range want {
+			if err := os.MkdirAll(filepath.Dir(f), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		res, err := VerifyRecursive(ctx, root)
+		if err != nil {
+			t.Fatalf("VerifyRecursive(%q) error: %v", root, err)
+		}
+		if !res.Exists {
+			t.Fatalf("VerifyRecursive(%q).Exists = false, want true", root)
+		}
+		got := append([]string(nil), res.Entries...)
+		sort.Strings(got)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("VerifyRecursive(%q).Entries = %#v, want %#v", root, got, want)
+		}
+	})
+
+	t.Run("missing path is not-found with nil error", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+		res, err := VerifyRecursive(ctx, missing)
+		if err != nil {
+			t.Fatalf("VerifyRecursive(%q) error: %v", missing, err)
+		}
+		if res.Exists || len(res.Entries) != 0 {
+			t.Errorf("VerifyRecursive(%q) = %+v, want empty not-found", missing, res)
+		}
+	})
+
+	t.Run("single file returns itself", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "only.mp4")
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res, err := VerifyRecursive(ctx, f)
+		if err != nil {
+			t.Fatalf("VerifyRecursive(%q) error: %v", f, err)
+		}
+		if !res.Exists || !reflect.DeepEqual(res.Entries, []string{f}) {
+			t.Errorf("VerifyRecursive(%q) = %+v, want single entry %q", f, res, f)
+		}
+	})
 }

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify_test.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify/verify_test.go
@@ -145,6 +145,31 @@ func TestParseGCSListing(t *testing.T) {
 	}
 }
 
+// TestGCSRecursivePattern pins the one new pure bit of the gs:// recursive path:
+// the prefix is slash-normalized and the `**` recursive wildcard appended. `**` is
+// a PREFIX glob (matches by string prefix, not strict directory contents) — the
+// "prefix, not a subfolder boundary" case documents that on purpose.
+func TestGCSRecursivePattern(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"no trailing slash", "gs://b/p/image", "gs://b/p/image**"},
+		{"one trailing slash trimmed", "gs://b/p/video/", "gs://b/p/video**"},
+		{"multiple trailing slashes trimmed", "gs://b/p///", "gs://b/p**"},
+		{"bare bucket", "gs://b", "gs://b**"},
+		{"prefix, not a subfolder boundary", "gs://b/img", "gs://b/img**"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gcsRecursivePattern(tc.uri); got != tc.want {
+				t.Errorf("gcsRecursivePattern(%q) = %q, want %q", tc.uri, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestVerifyRecursiveLocal pins the recursive local walk that Tier 2 relies on:
 // it returns every file at any depth (never directories), reports a missing path
 // as not-found with a nil error, and a single file as itself.

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/tier2-producer/main.go
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/tier2-producer/main.go
@@ -1,0 +1,488 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command tier2-producer is Tier 2 of the Genkit Go genmedia series: the
+// multi-server "producer" capstone. Where Tier 1 chained TWO servers with each
+// step handed only that one server's tools, Tier 2 connects FOUR genmedia MCP
+// servers into a SINGLE Genkit tool host and exposes ALL of their tools to every
+// Gemini-orchestrated generate step at once. One toolset, many servers.
+//
+// The flow "produce-scored-clip" runs an end-to-end production line:
+//
+//	generate-image  -> nanobanana writes a still to GCS
+//	verify-image    -> LIST the destination; carry the confirmed still URI forward
+//	generate-video  -> veo_i2v turns that still into a clip (explicit Veo-3 model)
+//	verify-video    -> LIST recursively; carry the confirmed .mp4 leaf forward
+//	generate-music  -> lyria composes a score to GCS
+//	verify-music    -> LIST recursively; carry the confirmed audio leaf forward
+//	generate-final  -> avtool muxes the clip + the score into one scored video
+//	verify-final    -> LIST the destination to confirm the finished artifact
+//
+// THE IN-PROMPT CROSSWALK (the deliberate design contrast of this tier):
+// four servers put overlapping, similarly named tools into one toolset
+// (veo alone contributes six). Tier 2 does NOT rename or prefix them behind a
+// disambiguation layer. Instead it tells the MODEL — in the system prompt
+// (producerCrosswalk) — which namespaced tool does which job. The MCP client's
+// "<server>_<tool>" namespacing keeps the names unique; the prompt tells the
+// model which name to pick. Contrast the ADK genmedia sibling, which resolves the
+// same collision structurally with `tool_name_prefix` on each toolset. Same
+// problem, two philosophies: ADK renames the tools, Tier 2 instructs the model.
+//
+// Run it with the Dev UI to read the trace:
+//
+//	export GOOGLE_CLOUD_PROJECT=your-project
+//	export GENMEDIA_BUCKET=gs://your-bare-bucket   # bare bucket, NO path — see below
+//	export GOOGLE_CLOUD_LOCATION=us-central1
+//	genkit start -- go run ./tier2-producer
+//
+// then open http://localhost:4000 and read the "produce-scored-clip" flow span:
+// eight nested steps, four generate spans each showing which tool the model chose
+// from the shared toolset, and the GCS writes verified by listing between them.
+// See README.md for the full walkthrough.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+
+	"github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/sample-agents/genkit-go/internal/genmedia"
+	"github.com/GoogleCloudPlatform/vertex-ai-creative-studio/experiments/mcp-genmedia/sample-agents/genkit-go/internal/verify"
+)
+
+// modelName is the Vertex Gemini model that orchestrates the tool calls. Verified
+// against the googlegenai plugin registry (provider "vertexai"). Single-sourced
+// here; matches Tiers 0-1.
+const modelName = "vertexai/gemini-2.5-flash"
+
+// Model ids passed explicitly to the genmedia tools. These are load-bearing and
+// single-sourced here (the quirks prompt tells the model WHY; naming the ids in
+// code keeps them greppable and bump-in-one-place):
+//
+//   - veoModel: with no model veo falls back to "veo-2.0-generate-001", which
+//     REJECTS generate_audio=true (the default) and the call fails.
+//   - lyriaModel: the clip-preview model routes through the global Interactions
+//     API (region-independent), which is what lets lyria run alongside the
+//     us-central1 image/video steps without a per-server location dance.
+const (
+	veoModel   = "veo-3.1-fast-generate-001"
+	lyriaModel = "lyria-3-clip-preview"
+)
+
+// producerServers are the four genmedia servers this tier composes, by their
+// friendly nicknames (resolved to binaries by the shared genmedia package).
+var producerServers = []string{"nanobanana", "veo", "lyria", "avtool"}
+
+// requiredTools are the exact namespaced tool names the flow depends on — one per
+// server. mcp.NewMCPHost logs-and-continues when a server fails to connect, so
+// the flow must PROVE every server it needs is actually present rather than
+// discovering a missing tool mid-run. These names are "<server>_<tool>"; note
+// veo and lyria carry a doubled segment because the server's own name is already
+// part of the tool name (e.g. tool "veo_i2v" on server "veo" -> "veo_veo_i2v").
+var requiredTools = []string{
+	"nanobanana_nanobanana_image_generation",
+	"veo_veo_i2v",
+	"lyria_lyria_generate_music",
+	"avtool_ffmpeg_combine_audio_and_video",
+}
+
+// producerCrosswalk is the IN-PROMPT disambiguation layer — the heart of Tier 2.
+// It is appended to the shared QuirksPrompt so the model sees, in one system
+// prompt, both the genmedia footguns AND which of the four servers' tools to use
+// for each job. This is the deliberate contrast with the ADK genmedia sibling,
+// which disambiguates the same colliding tool names STRUCTURALLY via
+// `tool_name_prefix`. Here there is no rename layer: the tools keep their native
+// "<server>_<tool>" names and the model is TOLD which to pick.
+const producerCrosswalk = `
+
+MULTI-SERVER TOOLSET (Tier 2 producer):
+You have the tools of FOUR genmedia servers in ONE toolset at the same time
+(image, video, music, and audio/video muxing). Several names look alike and veo
+alone offers six variants. Use EXACTLY the tool named below for each job, and no
+other — do not substitute a similarly named tool:
+
+- IMAGE (text -> still): nanobanana_nanobanana_image_generation
+- VIDEO (still -> clip): veo_veo_i2v
+  Do NOT use veo_veo_t2v, veo_veo_extend_video, veo_veo_first_last_to_video,
+  veo_veo_ingredients_to_video, or veo_veo_reference_to_video for this job.
+- MUSIC (text -> score): lyria_lyria_generate_music
+- MUX (clip + score -> scored video): avtool_ffmpeg_combine_audio_and_video
+
+Call one tool per turn, the one the instruction names. The parameter names differ
+per server — follow the 3-WAY NAMING CROSSWALK above for each tool you call.`
+
+// ProduceRequest is the flow input: what to draw, how to animate it, and the mood
+// of the score.
+type ProduceRequest struct {
+	ImageSubject string `json:"imageSubject"`
+	VideoPrompt  string `json:"videoPrompt"`
+	MusicPrompt  string `json:"musicPrompt"`
+}
+
+// ProduceResult is the flow output: every confirmed (verified-by-listing)
+// artifact along the production line, ending in the scored video.
+type ProduceResult struct {
+	ImageURI string `json:"imageUri"` // confirmed still (nanobanana)
+	VideoURI string `json:"videoUri"` // confirmed clip leaf (veo_i2v)
+	MusicURI string `json:"musicUri"` // confirmed score leaf (lyria)
+	FinalURI string `json:"finalUri"` // confirmed scored video (avtool mux)
+}
+
+// Default prompts. Positional args, if any, override only the image subject; the
+// video and music prompts stay subject-agnostic (camera/motion, mood/instrument).
+const (
+	defaultImageSubject = "a photorealistic red panda sitting on a moss-covered rock in a misty forest at dawn"
+	defaultVideoPrompt  = "Animate this scene with a slow, gentle camera push-in; drifting mist and subtle movement."
+	defaultMusicPrompt  = "A calm, warm ambient piece: soft piano and airy strings, unhurried, gently hopeful."
+)
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatalf("tier2-producer: %v", err)
+	}
+}
+
+func run(ctx context.Context) error {
+	project := firstEnv("GOOGLE_CLOUD_PROJECT", "PROJECT_ID")
+	if project == "" {
+		return fmt.Errorf("set GOOGLE_CLOUD_PROJECT (or PROJECT_ID) to your Google Cloud project")
+	}
+	location := firstEnv("GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION")
+	if location == "" {
+		location = "us-central1"
+	}
+
+	// Tier 2 needs a BARE GCS bucket (gs://bucket with NO path). This is a genmedia
+	// footgun worth teaching: nanobanana and veo accept a bucket+prefix and write
+	// under it, but lyria and avtool take a bucket NAME only (they strip gs:// and
+	// upload the object at the bucket root using just the filename) — a prefixed
+	// value would become an invalid bucket name and the upload would fail. So the
+	// producer standardizes on a bare bucket and adds per-run structure itself:
+	// nanobanana/veo get "<bucket>/<runID>/..." prefixes, while lyria/avtool write
+	// at the root with runID-stamped filenames.
+	base := os.Getenv("GENMEDIA_BUCKET")
+	if base == "" {
+		return fmt.Errorf("set GENMEDIA_BUCKET to a gs:// bucket for the generated artifacts")
+	}
+	bucket, err := bareBucket(base)
+	if err != nil {
+		return err
+	}
+
+	// Initialize Genkit with the Vertex AI (Gemini) plugin. genkit.Init also wires
+	// the Dev UI / tracing exporter when launched via `genkit start`. Use
+	// googlegenai.VertexAI (NOT a vertexai.* type): this is the plugin the whole
+	// series orchestrates through.
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{
+		ProjectID: project,
+		Location:  location,
+	}))
+
+	// Connect to ALL FOUR genmedia servers at once through the shared multi-server
+	// host. This is Tier 2's fan-out: one host aggregating four servers' tools,
+	// launched over stdio through bin/genmedia-launch by the same interface Tier 0
+	// established. The caller owns Disconnect for each server.
+	host, err := genmedia.NewHost(ctx, g, producerServers...)
+	if err != nil {
+		return fmt.Errorf("creating multi-server genmedia host: %w", err)
+	}
+	for _, s := range producerServers {
+		defer host.Disconnect(ctx, s)
+	}
+
+	// One shared toolset drawn from every connected server. Because NewMCPHost
+	// logs-and-continues on a failed connection, an empty-ish toolset here would
+	// otherwise surface only as a confusing "no tool found" mid-flight — so we
+	// confirm each required tool is actually present before defining the flow.
+	tools, err := host.GetActiveTools(ctx, g)
+	if err != nil {
+		return fmt.Errorf("listing multi-server tools: %w", err)
+	}
+	if err := requireTools(tools, requiredTools); err != nil {
+		return err
+	}
+	allTools := genmedia.ToolRefs(tools)
+	log.Printf("connected: %d server(s), %d tool(s) total in one shared toolset", len(producerServers), len(tools))
+
+	// systemPrompt is the shared quirks fragment PLUS the in-prompt crosswalk that
+	// tells the model which of the four servers' tools to use for each job. Every
+	// generate step gets this same system prompt and the SAME full toolset — the
+	// prompt, not a rename layer, is what disambiguates.
+	systemPrompt := genmedia.QuirksPrompt + producerCrosswalk
+
+	// generate is the shared per-step call: same model, same system prompt, same
+	// full multi-server toolset every time. Only the user instruction changes per
+	// step, naming the one tool + parameters that step must use. Wrapping it keeps
+	// each flow step to its essence (what to ask) and proves the point of the tier:
+	// the model, not the code, selects the tool from a single shared toolset.
+	generate := func(ctx context.Context, instruction string) (string, error) {
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModelName(modelName),
+			ai.WithSystem(systemPrompt),
+			ai.WithPrompt(instruction),
+			ai.WithTools(allTools...),
+			ai.WithToolChoice(ai.ToolChoiceAuto),
+		)
+		if err != nil {
+			return "", err
+		}
+		return resp.Text(), nil
+	}
+
+	// The flow is the reproducible, traced unit: eight ordered steps in a fixed Go
+	// order (deterministic sequencing — the MODEL picks each step's tool, the CODE
+	// picks the order), each artifact carried forward only after verify-by-listing.
+	flow := genkit.DefineFlow(g, "produce-scored-clip",
+		func(ctx context.Context, req ProduceRequest) (ProduceResult, error) {
+			// One run id threads through every destination so verify-by-listing
+			// confirms THIS run's artifacts, not leftovers from a prior run.
+			id := runID()
+			imageDest := gcsJoin(base, id, "image")           // nanobanana: bucket+prefix OK
+			videoDest := gcsJoin(base, id, "video")           // veo: bucket+prefix OK
+			musicName := id + "-score"                        // lyria: root filename only
+			musicPrefix := "gs://" + bucket + "/" + musicName // where lyria writes (ext forced)
+			finalName := id + "-final.mp4"                    // avtool: root filename only
+			finalURI := "gs://" + bucket + "/" + finalName    // where avtool writes
+			log.Printf("run %s: image=%s video=%s music=%s final=%s", id, imageDest, videoDest, musicPrefix, finalURI)
+
+			// Step 1: still. nanobanana writes to GCS via gcs_bucket_uri.
+			if _, err := genkit.RunWithContext(ctx, "generate-image", func(ctx context.Context) (string, error) {
+				return generate(ctx, fmt.Sprintf(
+					"Generate an image of %s. Use the tool nanobanana_nanobanana_image_generation and "+
+						"write it to Google Cloud Storage with gcs_bucket_uri set to %q.",
+					req.ImageSubject, imageDest))
+			}); err != nil {
+				return ProduceResult{}, fmt.Errorf("generate-image: %w", err)
+			}
+
+			// Step 2: verify the still and carry its confirmed leaf URI (NOT the
+			// resource_link) into veo_i2v.
+			imageURI, err := verifyLeaf(ctx, "verify-image", imageDest, "")
+			if err != nil {
+				return ProduceResult{}, err
+			}
+
+			// Step 3: still -> clip with veo_i2v (explicit Veo-3 model; bucket+prefix).
+			if _, err := genkit.RunWithContext(ctx, "generate-video", func(ctx context.Context) (string, error) {
+				return generate(ctx, fmt.Sprintf(
+					"Using the tool veo_veo_i2v, generate a short video from the input image. "+
+						"Set image_uri to %q. %s Use the Veo-3 model %q and write the output to "+
+						"Google Cloud Storage with bucket set to %q.",
+					imageURI, req.VideoPrompt, veoModel, videoDest))
+			}); err != nil {
+				return ProduceResult{}, fmt.Errorf("generate-video: %w", err)
+			}
+
+			// Step 4: verify the clip RECURSIVELY (veo writes into a server-assigned
+			// <jobid>/ subfolder) and carry the .mp4 leaf into the mux.
+			videoURI, err := verifyLeaf(ctx, "verify-video", videoDest, ".mp4")
+			if err != nil {
+				return ProduceResult{}, err
+			}
+
+			// Step 5: score with lyria. output_gcs_bucket is a BARE bucket; the
+			// output_filename base is runID-stamped and predictable (lyria forces the
+			// extension to the true audio type, so we do not guess .mp3 vs .wav).
+			if _, err := genkit.RunWithContext(ctx, "generate-music", func(ctx context.Context) (string, error) {
+				return generate(ctx, fmt.Sprintf(
+					"Compose music: %s Use the tool lyria_lyria_generate_music with model_id %q, "+
+						"set output_gcs_bucket to %q, and set output_filename to %q.",
+					req.MusicPrompt, lyriaModel, bucket, musicName))
+			}); err != nil {
+				return ProduceResult{}, fmt.Errorf("generate-music: %w", err)
+			}
+
+			// Step 6: verify the score RECURSIVELY by its known filename prefix (the
+			// extension was decided by lyria from the audio bytes).
+			musicURI, err := verifyLeaf(ctx, "verify-music", musicPrefix, "")
+			if err != nil {
+				return ProduceResult{}, err
+			}
+
+			// Step 7: mux the confirmed clip + score into one scored video. avtool
+			// reads both gs:// inputs, muxes with ffmpeg, and uploads to the bare
+			// bucket at the runID-stamped output filename.
+			if _, err := genkit.RunWithContext(ctx, "generate-final", func(ctx context.Context) (string, error) {
+				return generate(ctx, fmt.Sprintf(
+					"Combine a video and an audio track into one scored video using the tool "+
+						"avtool_ffmpeg_combine_audio_and_video. Set input_video_uri to %q, set "+
+						"input_audio_uri to %q, set output_gcs_bucket to %q, and set output_filename to %q.",
+					videoURI, musicURI, bucket, finalName))
+			}); err != nil {
+				return ProduceResult{}, fmt.Errorf("generate-final: %w", err)
+			}
+
+			// Step 8: verify the finished scored video.
+			finalConfirmed, err := verifyLeaf(ctx, "verify-final", finalURI, "")
+			if err != nil {
+				return ProduceResult{}, err
+			}
+
+			return ProduceResult{
+				ImageURI: imageURI,
+				VideoURI: videoURI,
+				MusicURI: musicURI,
+				FinalURI: finalConfirmed,
+			}, nil
+		})
+
+	// Invoke the flow once so `go run ./tier2-producer` executes end to end. Under
+	// `genkit start` the same flow is also invocable from the Dev UI.
+	//
+	// Teaching-material caveat: the positional arg is fed as free text into the
+	// model prompt, which then calls tools — a (benign here, local dev)
+	// prompt-injection surface. A production caller should treat untrusted input as
+	// adversarial: constrain it and/or validate the tool arguments the model picks.
+	req := ProduceRequest{
+		ImageSubject: defaultImageSubject,
+		VideoPrompt:  defaultVideoPrompt,
+		MusicPrompt:  defaultMusicPrompt,
+	}
+	if len(os.Args) > 1 {
+		req.ImageSubject = strings.Join(os.Args[1:], " ")
+	}
+
+	res, err := flow.Run(ctx, req)
+	if err != nil {
+		return err
+	}
+	log.Printf("DONE: image=%s video=%s music=%s final=%s",
+		res.ImageURI, res.VideoURI, res.MusicURI, res.FinalURI)
+	return nil
+}
+
+// verifyLeaf is the shared verify-by-listing step: it LISTS dest (never trusts a
+// tool result), logs what it found, and returns the leaf URI to carry forward.
+//
+// wantSuffix selects which leaf to hand on when a step writes into a subfolder
+// that may contain several objects: veo writes gs://.../<jobid>/ with the sample
+// mp4 plus siblings, so the mux needs the ".mp4" specifically. An empty
+// wantSuffix means "the destination is a single artifact (or a prefix that
+// resolves to one); return the first leaf." A recursive listing is used whenever
+// a suffix is requested or the destination is a known-prefix (not a full object
+// path), so a server-assigned subfolder or an unknown extension is matched.
+func verifyLeaf(ctx context.Context, step, dest, wantSuffix string) (string, error) {
+	uri, err := genkit.RunWithContext(ctx, step, func(ctx context.Context) (string, error) {
+		result, err := verify.VerifyRecursive(ctx, dest)
+		if err != nil {
+			return "", fmt.Errorf("verifying %s: %w", dest, err)
+		}
+		log.Printf("verify: %s", result)
+		for _, e := range result.Entries {
+			log.Printf("  - %s", e)
+		}
+		if !result.Exists || len(result.Entries) == 0 {
+			return "", fmt.Errorf("no artifact found at %s — the step did not produce output there", dest)
+		}
+		if wantSuffix != "" {
+			for _, e := range result.Entries {
+				if strings.HasSuffix(e, wantSuffix) {
+					return e, nil
+				}
+			}
+			return "", fmt.Errorf("no %s artifact found under %s (found %d other entr%s)",
+				wantSuffix, dest, len(result.Entries), plural(len(result.Entries)))
+		}
+		return result.Entries[0], nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", step, err)
+	}
+	log.Printf("%s -> %s", step, uri)
+	return uri, nil
+}
+
+// requireTools confirms every required namespaced tool name is present in the
+// aggregated toolset. NewMCPHost swallows per-server connect failures, so this is
+// the guard that turns a silently-missing server into an explicit, actionable
+// error before the flow runs.
+func requireTools(tools []ai.Tool, required []string) error {
+	present := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		present[t.Name()] = true
+	}
+	var missing []string
+	for _, name := range required {
+		if !present[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("required genmedia tool(s) not available (a server failed to connect?): %s",
+			strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// bareBucket validates that base is a gs:// URI naming a bucket with NO path, and
+// returns the bare bucket name (no gs://, no trailing slash). lyria and avtool
+// require a bucket name only; a prefixed value is a footgun that fails at upload.
+func bareBucket(base string) (string, error) {
+	if !verify.IsGCS(base) {
+		return "", fmt.Errorf("GENMEDIA_BUCKET must be a gs:// URI (got %q)", base)
+	}
+	name := strings.Trim(strings.TrimPrefix(base, "gs://"), "/")
+	if name == "" {
+		return "", fmt.Errorf("GENMEDIA_BUCKET must name a bucket (got %q)", base)
+	}
+	if strings.Contains(name, "/") {
+		return "", fmt.Errorf("GENMEDIA_BUCKET must be a BARE bucket with no path for Tier 2: "+
+			"lyria and avtool take a bucket name only and write at the root (got %q)", base)
+	}
+	return name, nil
+}
+
+// gcsJoin appends per-run segments to a gs:// base, normalizing the trailing
+// slash. Tier 2 is GCS-throughout, so unlike Tier 1's join this is gs://-only.
+func gcsJoin(base string, segments ...string) string {
+	return strings.TrimRight(base, "/") + "/" + strings.Join(segments, "/")
+}
+
+// runID returns a per-run segment: a UTC timestamp plus a short random suffix so
+// two runs in the same second do not collide.
+func runID() string {
+	ts := time.Now().UTC().Format("20060102-150405")
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ts // timestamp alone is good enough if randomness is unavailable
+	}
+	return ts + "-" + hex.EncodeToString(b[:])
+}
+
+// firstEnv returns the value of the first set (non-empty) environment variable.
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// plural renders the entry-count suffix for log/error messages.
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}


### PR DESCRIPTION
## Tier 2 — multi-server "producer" flow (STABLE capstone)

The Genkit Go genmedia series' STABLE capstone: one `genkit.DefineFlow` ("produce-scored-clip")
composes **four** genmedia MCP servers — nanobanana (image) then veo_i2v (image-to-video) then lyria
(music) then avtool (mux) — via `mcp.NewMCPHost`, exposing all 16 tools in one shared toolset and
letting Gemini orchestrate across them.

### What it demonstrates
- **In-prompt crosswalk** (not a rename/prefix layer): tool-name collisions across servers are
  disambiguated in the system prompt (`producerCrosswalk`), explicitly contrasted with ADK's
  `tool_name_prefix` in code, notes, and README.
- **Verify-by-listing on every artifact** — image, video, music, and the final mux are each proven by
  listing the produced object (via `verify.Verify` / the new `verify.VerifyRecursive`), never by
  trusting the raw tool result / resource_link. `VerifyRecursive` handles veo's `<jobid>/` subfolder
  and lyria's forced audio extension.
- **Additive shared helpers** — `genmedia.NewHost()` multi-server fan-out and `verify.VerifyRecursive()`
  (with unit tests); Tiers 0 and 1 are unaffected.
- Teaching footguns documented: the veo-3.1-fast audio requirement and the bare-bucket write behavior
  of lyria/avtool.

### Validation
- Live-run end to end (nanobanana -> veo_i2v -> lyria -> avtool): all four artifacts produced and
  verified by listing; final mux confirmed by ffprobe (h264 video + aac audio). Independently
  re-run live by a fresh reviewer.
- Gates green: gofmt / build / vet / test / `go mod tidy` (no-diff) / `go mod verify`.
- Pins unchanged: genkit/go v1.13.1, mcp-go v0.33.0. No `replace` directives, no dependency patches.

Reviewed and APPROVED (0 blockers); non-blocking findings closed out.
