### PR TITLE
docs: add Gemini 3.5 Transcribe (gemini_transcribe tool + standalone server)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -91,7 +91,7 @@ export default defineConfig({
 										{ label: 'mcp-chirp3-go', slug: 'experiments/mcp-genmedia/mcp-chirp3-go' },
 										{ label: 'mcp-nanobanana-go', slug: 'experiments/mcp-genmedia/mcp-nanobanana-go' },
 										{ label: 'mcp-gemini-go', slug: 'experiments/mcp-genmedia/mcp-gemini-go' },
-											{ label: 'mcp-gemini-transcribe-go', slug: 'experiments/mcp-genmedia/mcp-gemini-transcribe-go' },
+										{ label: 'mcp-gemini-transcribe-go', slug: 'experiments/mcp-genmedia/mcp-gemini-transcribe-go' },
 										{ label: 'mcp-omni-go', slug: 'experiments/mcp-genmedia/mcp-omni-go' },
 										{ label: 'mcp-avtool-go', slug: 'experiments/mcp-genmedia/mcp-avtool-go' },
 									]

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -91,6 +91,7 @@ export default defineConfig({
 										{ label: 'mcp-chirp3-go', slug: 'experiments/mcp-genmedia/mcp-chirp3-go' },
 										{ label: 'mcp-nanobanana-go', slug: 'experiments/mcp-genmedia/mcp-nanobanana-go' },
 										{ label: 'mcp-gemini-go', slug: 'experiments/mcp-genmedia/mcp-gemini-go' },
+											{ label: 'mcp-gemini-transcribe-go', slug: 'experiments/mcp-genmedia/mcp-gemini-transcribe-go' },
 										{ label: 'mcp-omni-go', slug: 'experiments/mcp-genmedia/mcp-omni-go' },
 										{ label: 'mcp-avtool-go', slug: 'experiments/mcp-genmedia/mcp-avtool-go' },
 									]

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/index.md
@@ -11,6 +11,7 @@ Each server can be enabled and run separately, allowing flexibility for environm
 *   **Nano Banana: [Gemini 3.1 Flash Image](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-flash-image) & [Gemini 3 Pro Image](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image) & [Gemini 2.5 Flash Image](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash#image)** - for image generation and editing
 *   **[Veo 3 & 3.1](https://cloud.google.com/vertex-ai/generative-ai/docs/video/generate-videos)** - for video creation
 *   **[Gemini TTS](https://docs.cloud.google.com/text-to-speech/docs/gemini-tts)** & **[Chirp 3 HD](https://cloud.google.com/text-to-speech/docs/chirp3-hd)** - for speech synthesis
+*   **[Gemini 3.5 Transcribe](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-5-transcribe)** - for speech-to-text transcription
 *   **[Lyria](https://cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music)** - for music generation
 *   **[Imagen 3 & 4](https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview)** - for image generation and editing
 
@@ -67,6 +68,7 @@ The servers are configured primarily through environment variables. Key variable
 
 *   **Gemini Image** Generate and edit images from text prompts.
 *   **Gemini TTS** Synthesize high-quality audio from text.
+*   **Gemini Transcribe:** Transcribe pre-recorded audio to text (synchronous Gemini 3.5 Transcribe). Available both as the `gemini_transcribe` tool on the Gemini server and as the standalone `mcp-gemini-transcribe-go` server.
 *   **Veo:** Create videos from text or images.
 *   **Gemini Omni:** Generate video (with optional embedded audio) from a text prompt, optionally conditioned on input images and/or videos, via the Vertex Interactions API.
 *   **Lyria:** Generate music from text prompts.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
@@ -41,7 +41,7 @@ Synthesizes speech from text using Gemini models, allowing for granular control 
 
 Transcribes a pre-recorded audio file to text using Google's **Gemini 3.5 Transcribe** model in **synchronous** mode (the `generate_content` path on `gemini-3.5-transcribe-preview`, **not** the live/streaming API). Intended for pre-recorded files up to ~15 minutes. Supports language hints, custom vocabulary biasing, speaker diarization, word-level timestamps, and smart formatting.
 
-> **Note:** Gemini 3.5 Transcribe is served only in the `global` location. This server forces `global` automatically when `LOCATION`/`GOOGLE_CLOUD_LOCATION` are unset.
+> **Note:** Gemini 3.5 Transcribe is served only in the `global` location. `mcp-gemini-go` already defaults to `global`; leave `LOCATION`/`GOOGLE_CLOUD_LOCATION` unset (or set to `global`) for transcription to work.
 
 **Parameters:**
 

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
@@ -37,6 +37,30 @@ Synthesizes speech from text using Gemini models, allowing for granular control 
 - `output_filename` (string, optional): Full base name for the output WAV file, e.g. `greeting.wav`. The extension is forced to `.wav`. Takes precedence over `output_filename_prefix` (which only supplies a prefix). See [Naming Outputs](../index.md#naming-outputs-output_filename).
 - `output_filename_prefix` (string, optional): **Deprecated — prefer `output_filename`.** A prefix for the output WAV filename. Still accepted for backward compatibility.
 
+### `gemini_transcribe`
+
+Transcribes a pre-recorded audio file to text using Google's **Gemini 3.5 Transcribe** model in **synchronous** mode (the `generate_content` path on `gemini-3.5-transcribe-preview`, **not** the live/streaming API). Intended for pre-recorded files up to ~15 minutes. Supports language hints, custom vocabulary biasing, speaker diarization, word-level timestamps, and smart formatting.
+
+> **Note:** Gemini 3.5 Transcribe is served only in the `global` location. This server forces `global` automatically when `LOCATION`/`GOOGLE_CLOUD_LOCATION` are unset.
+
+**Parameters:**
+
+- `input_audio` (string, required): The audio to transcribe — either a local file path or a `gs://` URI. Supported formats include WAV, MP3, OGG/Opus, FLAC, M4A/AAC, AIFF, AMR, WEBM, and PCM.
+- `mime_type` (string, optional): The MIME type of the audio (e.g. `audio/wav`, `audio/mpeg`, `audio/ogg`). Inferred from the file extension when omitted (`.m4a`/`.mp4`/`.aac` infer `audio/mp4`).
+- `model` (string, optional): The transcription model. Defaults to `gemini-3.5-transcribe-preview`.
+- `language_codes` (string array, optional): BCP-47 language hints (e.g. `["en-US", "es-ES"]`). Omit for automatic language detection.
+- `custom_vocabulary` (string array, optional): Up to 1000 phrases (brand names, proper nouns, domain terms) that bias recognition. Most reliable when `language_codes` is also set.
+- `enable_diarization` (boolean, optional): Label individual speakers (up to 8). Incompatible with `smart_formatting`.
+- `enable_word_timestamps` (boolean, optional): Return word-level start/end offsets. Incompatible with `smart_formatting`.
+- `smart_formatting` (boolean, optional): Use SMART mode — filler-word removal, light grammatical cleanup, and automatic formatting. Incompatible with `enable_diarization` and `enable_word_timestamps`.
+- `output_directory` (string, optional): Local directory to save the transcription result (JSON) to.
+- `gcs_bucket_uri` (string, optional): GCS URI prefix to store the transcription result (JSON).
+- `output_filename` (string, optional): Base name for the saved transcript. The extension is forced to `.json`. See [Naming Outputs](../index.md#naming-outputs-output_filename).
+
+The plain transcript is always returned as the first text content item. When speaker diarization or word-level timestamps are requested, a second text content item carries the full structured result as JSON (transcript, per-segment speaker labels, and word timings).
+
+This tool is also available as a single-purpose, standalone server: [`mcp-gemini-transcribe-go`](../mcp-gemini-transcribe-go/). Both share the same implementation via `mcp-common`, so their behavior never drifts.
+
 ### `list_gemini_voices`
 
 Lists the available single-speaker voices for use with the Gemini-TTS models.

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-transcribe-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-transcribe-go/index.md
@@ -1,0 +1,63 @@
+---
+title: "`mcp-gemini-transcribe-go` MCP Server"
+---
+
+This server provides synchronous speech-to-text transcription using Google's **Gemini 3.5 Transcribe** model (`gemini-3.5-transcribe-preview`) via the Vertex `genai` client.
+
+It is the single-purpose, standalone sibling of the `gemini_transcribe` tool that is also bundled into the all-in-one [`mcp-gemini-go`](../mcp-gemini-go/) server. Both share the exact same implementation via `mcp-common`, so their behavior can never drift — use this standalone server when you only need transcription and want a minimal surface.
+
+This server uses the **synchronous** transcription API (the `generate_content` path on `gemini-3.5-transcribe-preview`), **not** the live/streaming API. It is intended for pre-recorded files up to ~15 minutes, not for real-time streaming.
+
+> **Note:** Gemini 3.5 Transcribe is served only in the `global` location. This server defaults `LOCATION` to `global`; leave `LOCATION`/`GOOGLE_CLOUD_LOCATION` unset (or set to `global`) for transcription to work.
+
+## Tools
+
+### `gemini_transcribe`
+
+Transcribes a pre-recorded audio file to text using Google's Gemini 3.5 Transcribe model (synchronous mode). Supports language hints, custom vocabulary biasing, speaker diarization, word-level timestamps, and smart formatting.
+
+**Parameters:**
+
+- `input_audio` (string, required): The audio to transcribe — either a local file path or a `gs://` URI. Supported formats include WAV, MP3, OGG/Opus, FLAC, M4A/AAC, AIFF, AMR, WEBM, and PCM.
+- `mime_type` (string, optional): The MIME type of the audio (e.g. `audio/wav`, `audio/mpeg`, `audio/ogg`). Inferred from the file extension when omitted (`.m4a`/`.mp4`/`.aac` infer `audio/mp4`).
+- `model` (string, optional): The transcription model. Defaults to `gemini-3.5-transcribe-preview`.
+- `language_codes` (string array, optional): BCP-47 language hints (e.g. `["en-US", "es-ES"]`). Omit for automatic language detection.
+- `custom_vocabulary` (string array, optional): Up to 1000 phrases (brand names, proper nouns, domain terms) that bias recognition. Most reliable when `language_codes` is also set.
+- `enable_diarization` (boolean, optional): Label individual speakers (up to 8). Incompatible with `smart_formatting`.
+- `enable_word_timestamps` (boolean, optional): Return word-level start/end offsets. Incompatible with `smart_formatting`.
+- `smart_formatting` (boolean, optional): Use SMART mode — filler-word removal, light grammatical cleanup, and automatic formatting. Incompatible with `enable_diarization` and `enable_word_timestamps`.
+- `output_directory` (string, optional): Local directory to save the transcription result (JSON) to.
+- `gcs_bucket_uri` (string, optional): GCS URI prefix to store the transcription result (JSON).
+- `output_filename` (string, optional): Base name for the saved transcript. The extension is forced to `.json`. See [Naming Outputs](../index.md#naming-outputs-output_filename).
+
+The plain transcript is always returned as the first text content item. When speaker diarization or word-level timestamps are requested, a second text content item carries the full structured result as JSON (transcript, per-segment speaker labels, and word timings).
+
+## Environment Variable Configuration
+
+The tool utilizes the following environment variables:
+
+*   `GOOGLE_CLOUD_PROJECT` (string): **Required**. Your Google Cloud Project ID. Note: `PROJECT_ID` is also supported as a fallback.
+*   `GOOGLE_CLOUD_LOCATION` (string): The preferred Google Cloud location. For Gemini 3.5 Transcribe this defaults to `global` (the only location where the model is served).
+    *   **Fallback**: `LOCATION` is also supported as a fallback for `GOOGLE_CLOUD_LOCATION`.
+*   `GENMEDIA_BUCKET` (string): An optional default Google Cloud Storage bucket to use for GCS outputs if the `gcs_bucket_uri` parameter is not specified in the tool request.
+*   `PORT` (string, for HTTP transport): The port for the HTTP server to listen on. Default: `8080`.
+
+## Example Usage
+
+### Transcribe a GCS audio file
+
+```bash
+export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project)
+
+mcptools call gemini_transcribe \
+  --params '{"input_audio": "gs://your-gcs-bucket/audio/meeting.wav", "language_codes": ["en-US"], "output_directory": "./transcripts"}' \
+  mcp-gemini-transcribe-go
+```
+
+### Transcribe with diarization and word timestamps
+
+```bash
+mcptools call gemini_transcribe \
+  --params '{"input_audio": "./samples/interview.mp3", "enable_diarization": true, "enable_word_timestamps": true, "output_directory": "./transcripts"}' \
+  mcp-gemini-transcribe-go
+```

--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-transcribe-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-transcribe-go/index.md
@@ -42,6 +42,36 @@ The tool utilizes the following environment variables:
 *   `GENMEDIA_BUCKET` (string): An optional default Google Cloud Storage bucket to use for GCS outputs if the `gcs_bucket_uri` parameter is not specified in the tool request.
 *   `PORT` (string, for HTTP transport): The port for the HTTP server to listen on. Default: `8080`.
 
+## Transports Supported
+
+*   `stdio` (default)
+*   `sse` (Server-Sent Events)
+*   `http` (Streamable HTTP)
+
+CORS is enabled for the HTTP transport, allowing all origins by default.
+
+## Run
+
+Build the tool using `go build` or `go install`.
+
+*   **STDIO (Default)**:
+    ```bash
+    ./mcp-gemini-transcribe-go
+    # or
+    ./mcp-gemini-transcribe-go -transport stdio
+    ```
+*   **HTTP**:
+    ```bash
+    ./mcp-gemini-transcribe-go -transport http
+    # Optionally set PORT, e.g. PORT=8084 ./mcp-gemini-transcribe-go -transport http
+    ```
+    The MCP server will be available at `http://localhost:<PORT>/mcp`.
+*   **SSE (Server-Sent Events)**:
+    ```bash
+    ./mcp-gemini-transcribe-go -transport sse
+    ```
+    The MCP server will be available at `http://localhost:8081`.
+
 ## Example Usage
 
 ### Transcribe a GCS audio file


### PR DESCRIPTION
## Summary

Documents the new **Gemini 3.5 Transcribe** speech-to-text capability shipped in `mcp-v3.20.0` (via [#1849](https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/pull/1849) and [#1850](https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/pull/1850)).

### Changes
- **`mcp-gemini-go` page**: adds a `gemini_transcribe` tool section (synchronous mode, full parameter reference, diarization/word-timestamp output note, and a cross-link to the standalone server).
- **New `mcp-gemini-transcribe-go` page**: docs for the standalone single-purpose transcription server (tool reference, env-var config, `global`-location note, example usage).
- **Genmedia overview (`index.md`)**: lists Gemini 3.5 Transcribe under both "Generative Media & Compositing Capabilities" and "Available MCP Servers and Capabilities".

Docs-only; no code changes. This is the follow-up docs PR to the two merged feature PRs.
