### PR TITLE
docs: add gemini_transcribe Example Usage to mcp-gemini-go page

### DIFF
--- a/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
+++ b/docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md
@@ -122,3 +122,23 @@ mcp-gemini-go | \
 jq -r '.result.content[] | select(.type == "audio") | .data' | \
 base64 --decode > test_direct_jsonrpc.wav
 ```
+
+### Transcribing Audio
+
+First, ensure the `GOOGLE_CLOUD_PROJECT` environment variable is set. Then call the `gemini_transcribe` tool with either a local file path or a `gs://` URI. The following example transcribes an audio file stored in GCS with an English language hint and saves the JSON result to a local directory named `transcripts`.
+
+```bash
+export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project)
+
+mcptools call gemini_transcribe \
+  --params '{"input_audio": "gs://your-gcs-bucket/audio/meeting.wav", "language_codes": ["en-US"], "output_directory": "./transcripts"}' \
+  mcp-gemini-go
+```
+
+To label individual speakers and return word-level timestamps, enable diarization and word timestamps:
+
+```bash
+mcptools call gemini_transcribe \
+  --params '{"input_audio": "./samples/interview.mp3", "enable_diarization": true, "enable_word_timestamps": true, "output_directory": "./transcripts"}' \
+  mcp-gemini-go
+```


### PR DESCRIPTION
## What

Adds a **Transcribing Audio** example to the *Example Usage* section of the `mcp-gemini-go` Astro Starlight docs page (`docs-site/src/content/docs/experiments/mcp-genmedia/mcp-gemini-go/index.md`).

## Why

Follow-up to the Gemini 3.5 Transcribe workstream (#1849, #1850, #1851). PR #1851 added the `gemini_transcribe` tool section to the `mcp-gemini-go` page and shipped an "Example Usage" block on the standalone `mcp-gemini-transcribe-go` page — but the `mcp-gemini-go` page's own *Example Usage* section still lacked a `gemini_transcribe` example, unlike its `gemini_image_generation` and `gemini_audio_tts` tools which each have one. Reported by the owner.

## What changed

- Reused/adapted the two transcribe examples from the standalone `mcp-gemini-transcribe-go` docs page, rewritten to invoke the `mcp-gemini-go` server (server name in the `mcptools call ... mcp-gemini-go` invocation), so the examples read naturally as `mcp-gemini-go` tool calls.
- Follows the existing "Example Usage" convention on the page (short intro prose + `bash` code block ending with the server name), consistent with the image and TTS examples.

## Verification

- Docs-only markdown change. `npm ci` succeeds; `astro build` could not be run in my environment (Node.js 20.20.2 present, Astro 7 requires Node >= 22.12.0). Change is a pure additive markdown section matching the surrounding, already-building content.