### PR TITLE
fix(imagen): route virtual-model helper to Nano Banana (Phase 1)

### DIFF
--- a/models/image_models.py
+++ b/models/image_models.py
@@ -31,6 +31,7 @@ from tenacity import (
     wait_exponential,
 )
 
+import models.gemini as gemini
 from common.analytics import get_logger, track_model_call
 from config.default import Default
 
@@ -199,6 +200,10 @@ def generate_images_from_prompt(
 def generate_virtual_models(prompt: str, num_images: int) -> list[str]:
     """Generates multiple virtual model images and saves them to GCS.
 
+    Text-to-image virtual model generation via Nano Banana (Gemini image). The
+    Imagen model family returns HTTP 404 on Vertex AI, so this helper routes
+    through the Gemini image adapter, which is text-only when ``images=[]``.
+
     Args:
         prompt: The prompt to generate the images.
         num_images: The number of images to generate.
@@ -207,18 +212,18 @@ def generate_virtual_models(prompt: str, num_images: int) -> list[str]:
         A list of GCS URIs for the generated images.
 
     """
-    response = generate_images(
-        model=Default().MODEL_IMAGEN4_FAST,
-        prompt=prompt,
-        number_of_images=num_images,
-        aspect_ratio="1:1",
-        negative_prompt="",  # Assuming no negative prompt for this case
-    )
-    generated_uris = [
-        img.image.gcs_uri
-        for img in response.generated_images
-        if hasattr(img, "image") and hasattr(img.image, "gcs_uri")
-    ]
+    cfg = Default()
+    generated_uris: list[str] = []
+    for _ in range(num_images):
+        gcs_uris, *_ = gemini.generate_image_from_prompt_and_images(
+            prompt=prompt,
+            images=[],  # text-only
+            aspect_ratio="1:1",
+            gcs_folder=cfg.IMAGEN_GENERATED_SUBFOLDER,
+            file_prefix="virtual_model",
+            model_name=cfg.GEMINI_IMAGE_GEN_MODEL,
+        )
+        generated_uris.extend(gcs_uris)
     return generated_uris
 
 

--- a/pages/test_vto_prompt_generator.py
+++ b/pages/test_vto_prompt_generator.py
@@ -22,6 +22,7 @@ import mesop.labs as mel
 
 from common.metadata import add_media_item
 from common.utils import create_display_url
+from config.default import Default
 from components.dialog import dialog
 from components.header import header
 from components.page_scaffold import on_theme_load
@@ -358,7 +359,7 @@ def on_click_generate_matrix(e: me.ClickEvent):
         if state.save_to_library:
             add_media_item(
                 user_email=me.state(AppState).user_email,
-                model="imagen-4.0-generate-preview-06-06",
+                model=Default().GEMINI_IMAGE_GEN_MODEL,
                 mime_type="image/png",
                 gcs_uris=image_urls,
                 prompt=prompt,

--- a/test/test_virtual_models_gemini.py
+++ b/test/test_virtual_models_gemini.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests proving generate_virtual_models routes through the Nano Banana
-(Gemini image) adapter instead of the retired Imagen generation path."""
+"""Unit tests for the Nano Banana routing of generate_virtual_models.
+
+They prove generate_virtual_models routes through the Nano Banana (Gemini
+image) adapter instead of the retired Imagen generation path.
+"""
 
 import sys
 from pathlib import Path
@@ -25,7 +28,9 @@ from config.default import Default
 from models.image_models import generate_virtual_models
 
 
-def _fake_adapter_return(uri: str):
+def _fake_adapter_return(
+    uri: str,
+) -> tuple[list[str], float, list[str], None, list[str]]:
     """Mirror the 5-tuple contract of generate_image_from_prompt_and_images."""
     return ([uri], 0.0, [], None, [])
 

--- a/test/test_virtual_models_gemini.py
+++ b/test/test_virtual_models_gemini.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests proving generate_virtual_models routes through the Nano Banana
+(Gemini image) adapter instead of the retired Imagen generation path."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from config.default import Default
+from models.image_models import generate_virtual_models
+
+
+def _fake_adapter_return(uri: str):
+    """Mirror the 5-tuple contract of generate_image_from_prompt_and_images."""
+    return ([uri], 0.0, [], None, [])
+
+
+def test_generate_virtual_models_routes_through_gemini_adapter() -> None:
+    """A single-image request calls the Gemini adapter with text-only inputs."""
+    with patch(
+        "models.image_models.gemini.generate_image_from_prompt_and_images",
+        return_value=_fake_adapter_return("gs://fake-bucket/virtual_model_0.png"),
+    ) as mock_adapter:
+        uris = generate_virtual_models(prompt="a model in a studio", num_images=1)
+
+    mock_adapter.assert_called_once()
+    _, kwargs = mock_adapter.call_args
+    assert kwargs["prompt"] == "a model in a studio"
+    assert kwargs["images"] == []  # text-only
+    assert kwargs["aspect_ratio"] == "1:1"
+    assert kwargs["gcs_folder"] == Default().IMAGEN_GENERATED_SUBFOLDER
+    assert kwargs["file_prefix"] == "virtual_model"
+    assert kwargs["model_name"] == Default().GEMINI_IMAGE_GEN_MODEL
+    assert uris == ["gs://fake-bucket/virtual_model_0.png"]
+
+
+def test_generate_virtual_models_produces_n_uris_for_n_images() -> None:
+    """num_images=N yields N adapter calls and N accumulated GCS URIs."""
+    returns = [
+        _fake_adapter_return(f"gs://fake-bucket/virtual_model_{i}.png")
+        for i in range(3)
+    ]
+    with patch(
+        "models.image_models.gemini.generate_image_from_prompt_and_images",
+        side_effect=returns,
+    ) as mock_adapter:
+        uris = generate_virtual_models(prompt="a model", num_images=3)
+
+    assert mock_adapter.call_count == 3
+    assert uris == [
+        "gs://fake-bucket/virtual_model_0.png",
+        "gs://fake-bucket/virtual_model_1.png",
+        "gs://fake-bucket/virtual_model_2.png",
+    ]


### PR DESCRIPTION
## Summary

The entire Imagen model family returns live **HTTP 404** on Vertex AI. Two dead user-facing surfaces both funnel through a single function, `generate_virtual_models`, so one change fixes both:

- VTO "generate a model" helper (`pages/vto.py`)
- Starter Pack "generate a virtual model" button (`models/starter_pack.py`)

This is **Phase 1** of the Imagen purge/migration — the smallest, highest-value, lowest-risk slice. It strictly *adds* working behavior (the helper starts producing images again) and depends on no product decision.

## Changes

1. **Re-point `generate_virtual_models(prompt, num_images) -> list[str]`** (`models/image_models.py`) to call the existing Nano Banana adapter `models.gemini.generate_image_from_prompt_and_images(...)` instead of the dead Imagen `generate_images` path.
   - Public signature unchanged — all three callers (`models/starter_pack.py`, `pages/vto.py`, `pages/test_vto_prompt_generator.py`) are untouched.
   - Text-only inputs (`images=[]`), `aspect_ratio="1:1"`, `gcs_folder=cfg.IMAGEN_GENERATED_SUBFOLDER`, `file_prefix="virtual_model"`, `model_name=cfg.GEMINI_IMAGE_GEN_MODEL` (defaults to `gemini-3.1-flash-image`).
   - The adapter returns one image per call and a 5-tuple whose first element is the URI list; the code loops `num_images` times, unpacks `gcs_uris, *_ = ...`, and accumulates URIs.
2. **Fix a stray metadata label** (`pages/test_vto_prompt_generator.py`) that hard-coded `imagen-4.0-generate-preview-06-06` in the `add_media_item` library-log record. It now reports the actual model (`GEMINI_IMAGE_GEN_MODEL`), so Nano Banana output is labeled correctly. This is library logging, not a generation call.

**Out of scope (deferred to later phases):** the Imagen generation page, Imagen Upscale, config/model-constant cleanup, and removal of now-orphaned `generate_image_for_vto` / `generate_images*` / `ImagenModelSetup`.

## Testing

- Added `test/test_virtual_models_gemini.py`: proves `generate_virtual_models` routes through the Gemini adapter with the expected kwargs (`images=[]`, aspect ratio, gcs folder, file prefix, model name), and that `num_images=N` produces N adapter calls and N GCS URIs. **Both pass.**
- Adjacent suites checked: `test/test_gemini_image_models.py` passes. `test/test_imagen_generation_flow.py` has a pre-existing failure (`AppState.__init__() got an unexpected keyword argument 'user_email'`) confirmed present on clean `main` — unrelated to this change.
- **Live end-to-end validation (generate a model on `/vto` and `/starter-pack`) was NOT performed** — no live GCP-backed environment is available in this container. Full `requirements.txt` install is also blocked here (pins `librosa==1.0.0`, which requires Python ≥3.12). Staging validation is requested before merge.

## Design rationale

See design doc "The one redirect that matters" and "Acceptance Criteria → Phase 1". Nano Banana (Gemini image) is the sanctioned Imagen replacement and is already used elsewhere in the app.