### PR TITLE
docs(sample-agents): README review pass for the Genkit Go series + JS peer

### DIFF
--- a/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
@@ -48,7 +48,7 @@ tiers consume without changes:
 
 ```
 genkit-go/
-  go.mod                 module .../sample-agents/genkit-go ; go 1.25 ; genkit/go v1.13.1
+  go.mod                 module .../sample-agents/genkit-go ; go 1.25.0 ; genkit/go v1.13.1
   bin/genmedia-launch    pinned, SHA-256-verifying download-on-launch script (copy of agent_tools')
   internal/
     genmedia/            the shared fan-out interface
@@ -389,7 +389,7 @@ download bridge — `StdioConfig.Command` resolves it directly.
 | Thing | Pin | Where |
 |-------|-----|-------|
 | Genkit Go | `github.com/firebase/genkit/go v1.13.1` | `go.mod` |
-| Go | `go 1.25` | `go.mod` |
+| Go | `go 1.25.0` | `go.mod` |
 | genmedia release | `v3.18.0` | `internal/genmedia` `DefaultReleaseTag` + `bin/genmedia-launch` `PINNED_TAG` |
 | Orchestrating model | `vertexai/gemini-2.5-flash` | `tier{0,1,2}-*/main.go` `modelName`; `tier3-preview/main.go` `defaultModel` |
 | Veo model (Tiers 1-3) | `veo-3.1-fast-generate-001` | `tier{1,2}-*/main.go` + `tier3-preview/main.go` `veoModel` |

--- a/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
+++ b/experiments/mcp-genmedia/sample-agents/genkit-go/README.md
@@ -6,14 +6,33 @@ independently reviewable PR. The through-line of the whole series is the
 **Genkit Developer UI and per-turn tracing** — every tier is meant to be *run*,
 then *read* at `http://localhost:4000`.
 
-> **You are here: Tier 2.** A multi-server **producer** flow: one
-> `genkit.DefineFlow` that composes **four** genmedia MCP servers —
-> `nanobanana` → `veo_i2v` → `lyria` → `avtool` — into a single traced production
-> line (still → clip → score → **muxed scored video**), with every artifact proven
-> by verify-by-listing. It builds on **Tier 1** (the two-server chain) and
-> **Tier 0** (the minimal "one tool, one generate" program, also the Go
-> counterpart to the JavaScript [Nano Banana sample](../genkit/); see
-> [Related samples](#related-samples)).
+> **The whole series is here.** All four tiers (0-3) are merged and independently
+> runnable from this directory: Tiers 0-2 on stable Genkit Go API, and **Tier 3**
+> as a **PREVIEW** capstone on experimental `.../exp` APIs. Start at
+> [Tier 0](#run-tier-0-then-read-the-trace) — the minimal "one tool, one generate"
+> program (also the Go counterpart to the JavaScript
+> [Nano Banana sample](../genkit/); see [Related samples](#related-samples)) — then
+> climb: [Tier 1](#run-tier-1-then-read-the-flow-trace) adds a `DefineFlow` chain,
+> [Tier 2](#run-tier-2-then-read-the-producer-trace) composes **four** genmedia MCP
+> servers (`nanobanana` → `veo_i2v` → `lyria` → `avtool`) into one traced producer
+> flow, and [Tier 3 (PREVIEW)](#run-tier-3-preview--agentic-producer-with-delegation--a-human-approval-interrupt)
+> hands sequencing to a delegating orchestrator with a human-approval interrupt.
+> Every tier proves each artifact by verify-by-listing.
+
+## Contents
+
+- [The series](#the-series)
+- [Why lead with the Dev UI](#why-lead-with-the-dev-ui)
+- [Prerequisites](#prerequisites)
+- [Run Tier 0, then read the trace](#run-tier-0-then-read-the-trace)
+- [Run Tier 1, then read the flow trace](#run-tier-1-then-read-the-flow-trace)
+- [Run Tier 2, then read the producer trace](#run-tier-2-then-read-the-producer-trace)
+- [Run Tier 3 (PREVIEW)](#run-tier-3-preview--agentic-producer-with-delegation--a-human-approval-interrupt)
+- [The `resource_link` rule](#the-resource_link-rule)
+- [Where the genmedia binary comes from](#where-the-genmedia-binary-comes-from)
+- [Version pins](#version-pins)
+- [Contributing](#contributing)
+- [Related samples](#related-samples)
 
 ## The series
 
@@ -21,7 +40,7 @@ then *read* at `http://localhost:4000`.
 |------|--------------|---------------|--------|
 | 0 · `tier0-image/` | single tool, single `generate` | `nanobanana` | STABLE |
 | 1 · `tier1-video/` | `DefineFlow`, linear chain | `nanobanana` → `veo_i2v` | STABLE |
-| **2 · `tier2-producer/`** | multi-server producer flow + in-prompt crosswalk | nb → veo → lyria → avtool | **STABLE** *(this tier)* |
+| 2 · `tier2-producer/` | multi-server producer flow + in-prompt crosswalk | nb → veo → lyria → avtool | STABLE |
 | 3 · `tier3-preview/` | **agents middleware** (delegation) + **tool interrupt** (human approval) | all, partitioned across sub-agents | **PREVIEW** — see [Tier 3](#run-tier-3-preview--agentic-producer-with-delegation--a-human-approval-interrupt) |
 
 Tiers land one per PR. They share the foundation Tier 0 established and later
@@ -376,6 +395,14 @@ download bridge — `StdioConfig.Command` resolves it directly.
 | Veo model (Tiers 1-3) | `veo-3.1-fast-generate-001` | `tier{1,2}-*/main.go` + `tier3-preview/main.go` `veoModel` |
 | Lyria model (Tiers 2-3) | `lyria-3-clip-preview` | `tier2-producer/main.go` + `tier3-preview/main.go` `lyriaModel` |
 | **Tier 3 (PREVIEW) experimental APIs** | `genkit/exp`, `ai/exp`, `ai/exp/localstore`, `ai/exp/tool`, `plugins/middleware/exp` behind `WithExperimental()` — **pinned to `genkit/go v1.13.1`, may break on upgrade** | `tier3-preview/main.go` |
+
+## Contributing
+
+This sample lives in the `vertex-ai-creative-studio` monorepo. Contributions are welcome; please
+read the repository's [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md) first — it requires a signed
+Google [Contributor License Agreement](https://cla.developers.google.com/) and routes all changes
+through GitHub pull-request review. Keep a change scoped to one tier's `main.go` (or the shared
+`internal/` packages) and update the matching section of this README in the same PR.
 
 ## Related samples
 

--- a/experiments/mcp-genmedia/sample-agents/genkit/README.md
+++ b/experiments/mcp-genmedia/sample-agents/genkit/README.md
@@ -11,8 +11,8 @@ the retired `imagen` server), **Veo** (`mcp-veo-go`), and **Chirp 3**
 
 * NodeJs (You can use the [nvm](https://github.com/nvm-sh/nvm) node manager to install this)
 * The genmedia MCP server binaries (`mcp-nanobanana-go`, `mcp-veo-go`,
-  `mcp-chirp3-go`) built and available on your `PATH`. See
-  `experiments/mcp-genmedia` for build/install instructions.
+  `mcp-chirp3-go`) built and available on your `PATH`. See the
+  [`mcp-genmedia`](../../README.md) README for build/install instructions.
 * A Google Cloud project with the required APIs enabled. Export it before
   running:
 
@@ -20,23 +20,27 @@ the retired `imagen` server), **Veo** (`mcp-veo-go`), and **Chirp 3**
   export GOOGLE_CLOUD_PROJECT="$(gcloud config get project)"
   ```
 
-Install Genkit client
+## Install and run
 
-```bash
-npm install -D genkit-cli
-```
-
-## Run Genkit MCP client
-
-Genkit js genmedia MCP client
+The app lives in `genkit-agent-js`. Installing its dependencies also pulls in
+`genkit-cli` (a devDependency), which `npm run start` uses to launch the Dev UI:
 
 ```bash
 cd genkit-agent-js
 npm i
-npm run start
+npm run start        # runs: genkit start -- node --watch src/index.js
 ```
 
-Open Genkit dev tools at localhost:4000
+`src/index.js` registers the three MCP clients and a Gemini model on Vertex AI; it
+does not call `generate` itself. Open the Genkit Dev UI at
+[localhost:4000](http://localhost:4000) and exercise the genmedia tools (and the
+model) from there — each call renders as a trace.
 
+![genkit devtools screenshot](./assets/genkit-devtools.png)
 
-![genkt devtools screenshot](./assets/genkit-devtools.png)
+## Contributing
+
+Contributions are welcome; see the monorepo's
+[`CONTRIBUTING.md`](../../../../CONTRIBUTING.md) — a signed Google
+[Contributor License Agreement](https://cla.developers.google.com/) and PR review
+are required.


### PR DESCRIPTION
# docs(sample-agents): README review pass for the Genkit Go series + JS peer

## What this is

A documentation-only review of the two sample-agent READMEs the Genkit Go genmedia
series produced/touched, scored against the **make-readme** skill
([github.com/ghchinoy/agent-skills](https://github.com/ghchinoy/agent-skills), Mark
Allen weighted rubric, 8 dimensions x 0-5 = /40) and improved where warranted. No
code or logic changes.

Both READMEs were verified line-by-line against the merged code on `main`
(`7658bb2` at review time). Nothing added is unverifiable; the one existing
inaccuracy found (a stale "current tier" banner) is corrected.

## Scores (make-readme rubric)

| README | Score | Band |
|--------|-------|------|
| `experiments/mcp-genmedia/sample-agents/genkit-go/README.md` | 34/40 | Excellent |
| `experiments/mcp-genmedia/sample-agents/genkit/README.md` | 26/40 | Good |

## Changes

### `genkit-go/README.md` (the series README)

- **Fix a stale banner (accuracy).** The intro still read **"You are here: Tier 2"**
  with a Tier-2-only description, even though the whole series (Tiers 0-3) is merged
  and documented in this one file. The Tier 3 PR (#1848) added the Tier 3 content but
  left the "current tier" pointer on Tier 2. Replaced with a series-status intro that
  links each tier's run section.
- Dropped the `(this tier)` marker (and the row bolding) from the Tier 2 row of the
  series table — no single tier is "current" on the merged series README.
- Added a **Table of Contents** (the doc has 11 top-level sections / ~390 lines).
- Added a **Contributing** section pointing to the repo-root `CONTRIBUTING.md`
  (CLA + PR review).

### `genkit/README.md` (JavaScript Nano Banana peer)

- **Set correct expectations (accuracy).** `src/index.js` registers the three MCP
  clients (`mcp-nanobanana-go`, `mcp-veo-go`, `mcp-chirp3-go`) and a Gemini model on
  Vertex AI but makes **no** `generate` call, so `npm run start` opens the Dev UI with
  nothing auto-running. Added one line saying so and directing the reader to exercise
  the tools from the Dev UI.
- Streamlined install/run: dropped the redundant root `npm install -D genkit-cli`
  (the app's own `npm i` already installs `genkit-cli`, which `npm run start`'s
  `genkit start` needs).
- Turned the bare `experiments/mcp-genmedia` prereq into a relative link to that
  README's build/install instructions.
- Promoted two pseudo-heading body lines to real `##` headings.
- Fixed the screenshot alt text typo (`genkt` -> `genkit`).
- Added a **Contributing** pointer.

## Verified accurate, left unchanged

`DefaultReleaseTag`/`PINNED_TAG` = `v3.18.0`; models `vertexai/gemini-2.5-flash`,
`veo-3.1-fast-generate-001`, `lyria-3-clip-preview`; `go 1.25.0`; `mcp.NewMCPHost` /
`mcp.NewGenkitMCPClient`; the env-var table; the Tier 3 PREVIEW / experimental-API
framing; every internal anchor; the three JS server names and the "replaces the
retired imagen server" note; the `genkit-agent-js` `start` script; the
`assets/genkit-devtools.png` screenshot.

## Testing

Documentation only. Verified: all changed relative links resolve on `main`
(`../../../../CONTRIBUTING.md`, `../../README.md`, `../genkit/`), all Table-of-Contents
anchors match their headings, and every retained claim matches the merged source.

## Scope

Two READMEs. No per-tier README files exist (tier dirs contain only `main.go`), and
`genkit/` has no separate Go "fix" README, so these two are the complete in-scope set.
